### PR TITLE
IMPROVE: Docs coverage (hooks, REST, models, helpers, architecture) plus dark mode theme

### DIFF
--- a/src/.vuepress/components/ThemeToggle.vue
+++ b/src/.vuepress/components/ThemeToggle.vue
@@ -1,0 +1,105 @@
+<template>
+  <button
+    class="ff-theme-toggle"
+    type="button"
+    :aria-label="ariaLabel"
+    :title="ariaLabel"
+    @click="toggle"
+  >
+    <svg v-if="!isDark" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <circle cx="12" cy="12" r="4"/>
+      <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/>
+    </svg>
+    <svg v-else xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+    </svg>
+  </button>
+</template>
+
+<script>
+export default {
+  name: 'ThemeToggle',
+  data() {
+    return { isDark: false };
+  },
+  computed: {
+    ariaLabel() {
+      return this.isDark ? 'Switch to light theme' : 'Switch to dark theme';
+    }
+  },
+  mounted() {
+    let stored = null;
+    try { stored = localStorage.getItem('ff-docs-theme'); } catch (e) {}
+    if (stored === 'dark' || stored === 'light') {
+      this.isDark = stored === 'dark';
+    } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      this.isDark = true;
+    }
+    this.apply();
+  },
+  methods: {
+    toggle() {
+      this.isDark = !this.isDark;
+      this.apply();
+      try { localStorage.setItem('ff-docs-theme', this.isDark ? 'dark' : 'light'); } catch (e) {}
+    },
+    apply() {
+      const root = document.documentElement;
+      if (this.isDark) {
+        root.classList.add('ff-dark');
+      } else {
+        root.classList.remove('ff-dark');
+      }
+    }
+  }
+};
+</script>
+
+<style>
+.ff-theme-toggle {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  width: 44px;
+  height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  border: 1px solid #e4e7eb;
+  background: #ffffff;
+  color: #1f2937;
+  cursor: pointer;
+  z-index: 200;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+.ff-theme-toggle:hover {
+  background: #f3f4f6;
+  transform: scale(1.05);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.12);
+}
+.ff-theme-toggle:focus-visible {
+  outline: 2px solid #10b981;
+  outline-offset: 2px;
+}
+.ff-dark .ff-theme-toggle {
+  background: #1f2937;
+  border-color: #374151;
+  color: #f3f4f6;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+.ff-dark .ff-theme-toggle:hover {
+  background: #374151;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.5);
+}
+@media (max-width: 719px) {
+  .ff-theme-toggle {
+    bottom: 16px;
+    right: 16px;
+    width: 40px;
+    height: 40px;
+  }
+}
+</style>

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -161,6 +161,10 @@ module.exports = {
                 ],
             },
             {
+                text: 'Changelog',
+                link: '/changelog/',
+            },
+            {
                 text: 'Blog',
                 link: 'https://fluentforms.com/blog/',
             },

--- a/src/.vuepress/enhanceApp.js
+++ b/src/.vuepress/enhanceApp.js
@@ -10,5 +10,31 @@ export default ({
   router, // the router instance for the app
   siteData // site metadata
 }) => {
-  // ...apply enhancements for the site.
-}
+  if (typeof window === 'undefined') return;
+
+  // Apply theme as early as possible to avoid a flash of light theme.
+  try {
+    const stored = localStorage.getItem('ff-docs-theme');
+    const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    if (stored === 'dark' || (!stored && prefersDark)) {
+      document.documentElement.classList.add('ff-dark');
+    }
+  } catch (e) {}
+
+  // Mount the floating ThemeToggle once the router is ready.
+  router.onReady(() => {
+    if (document.getElementById('ff-theme-toggle-mount')) return;
+    const mount = document.createElement('div');
+    mount.id = 'ff-theme-toggle-mount';
+    document.body.appendChild(mount);
+
+    // ThemeToggle is auto-registered by @vuepress/plugin-register-components
+    // because it lives at src/.vuepress/components/ThemeToggle.vue.
+    new Vue({
+      el: mount,
+      render(h) {
+        return h('theme-toggle');
+      }
+    });
+  });
+};

--- a/src/.vuepress/sidebars/apiSidebar.js
+++ b/src/.vuepress/sidebars/apiSidebar.js
@@ -4,7 +4,29 @@ module.exports = [
         collapsable: false,
         sidebarDepth: -1,
         children: [
-            ['/api/extending-rest-api/', 'Extend Rest API']
+            ['/api/extending-rest-api/', 'Extend Rest API'],
+            ['/api/endpoints/', 'Endpoint Reference']
+        ]
+    },
+    {
+        title: 'Endpoint Reference',
+        collapsable: true,
+        sidebarDepth: 0,
+        children: [
+            ['/api/endpoints/forms', 'Forms'],
+            ['/api/endpoints/settings', 'Form Settings'],
+            ['/api/endpoints/submissions', 'Submissions'],
+            ['/api/endpoints/integrations', 'Integrations'],
+            ['/api/endpoints/global-settings', 'Global Settings'],
+            ['/api/endpoints/managers', 'Managers'],
+            ['/api/endpoints/roles', 'Roles'],
+            ['/api/endpoints/analytics', 'Analytics'],
+            ['/api/endpoints/report', 'Reports'],
+            ['/api/endpoints/logs', 'Logs'],
+            ['/api/endpoints/form-submit', 'Form Submit'],
+            ['/api/endpoints/global-search', 'Global Search'],
+            ['/api/endpoints/suggested-plugins', 'Suggested Plugins'],
+            ['/api/endpoints/notice', 'Notice']
         ]
     },
     {

--- a/src/.vuepress/sidebars/db-schema.js
+++ b/src/.vuepress/sidebars/db-schema.js
@@ -19,6 +19,27 @@ module.exports = [
         ]
     },
     {
+        title: 'Model Reference',
+        collapsable: true,
+        sidebarDepth: 0,
+        children: [
+            ['/database/models/form', 'Form'],
+            ['/database/models/formmeta', 'FormMeta'],
+            ['/database/models/formanalytics', 'FormAnalytics'],
+            ['/database/models/submission', 'Submission'],
+            ['/database/models/submissionmeta', 'SubmissionMeta'],
+            ['/database/models/entry', 'Entry'],
+            ['/database/models/entrydetails', 'EntryDetails'],
+            ['/database/models/entrymeta', 'EntryMeta'],
+            ['/database/models/transaction', 'Transaction'],
+            ['/database/models/subscription', 'Subscription'],
+            ['/database/models/orderitem', 'OrderItem'],
+            ['/database/models/log', 'Log'],
+            ['/database/models/scheduler', 'Scheduler'],
+            ['/database/models/user', 'User']
+        ]
+    },
+    {
         title: 'Fluent ORM',
         collapsable: true,
         sidebarDepth: -1,

--- a/src/.vuepress/sidebars/helpers.js
+++ b/src/.vuepress/sidebars/helpers.js
@@ -6,6 +6,7 @@ module.exports = [
         children: [
             ['/helpers/', 'Helper'],
             ['/helpers/protector', 'Protector Helper'],
+            ['/helpers/integration-manager-helper', 'Integration Manager Helper'],
         ]
     },
     {

--- a/src/.vuepress/sidebars/hooks.js
+++ b/src/.vuepress/sidebars/hooks.js
@@ -14,8 +14,10 @@ module.exports = [
       ['/hooks/actions/settings', 'Settings'],
       ['/hooks/actions/payment', 'Payment'],
       ['/hooks/actions/integration', 'Integration'],
+      ['/hooks/actions/post-creation', 'Post Creation'],
       ['/hooks/actions/addon', 'Addon'],
       ['/hooks/actions/conversational', 'Conversational'],
+      ['/hooks/actions/miscellaneous', 'Miscellaneous'],
     ]
   },
   {
@@ -26,15 +28,23 @@ module.exports = [
       ['/hooks/filters/', 'Overview'],
       ['/hooks/filters/submission', 'Submission'],
       ['/hooks/filters/form', 'Form'],
+      ['/hooks/filters/conversational', 'Conversational'],
       ['/hooks/filters/settings', 'Settings'],
+      ['/hooks/filters/messages', 'Messages'],
       ['/hooks/filters/integration', 'Integration'],
-      ['/hooks/filters/miscellaneous', 'Miscellaneous'],
+      ['/hooks/filters/spam-protection', 'Spam Protection'],
+      ['/hooks/filters/payment', 'Payment'],
+      ['/hooks/filters/reports', 'Reports'],
+      ['/hooks/filters/entries-export', 'Entries & Export'],
       ['/hooks/filters/email', 'Email'],
       ['/hooks/filters/file-uploader', 'File Uploader'],
+      ['/hooks/filters/post-creation', 'Post Creation'],
+      ['/hooks/filters/dynamic-fields', 'Dynamic Fields'],
       ['/hooks/filters/quiz', 'Quiz'],
       ['/hooks/filters/user-registration', 'User Registration'],
       ['/hooks/filters/webhook', 'Webhook'],
-      ['/hooks/filters/payment', 'Payment'],
+      ['/hooks/filters/pdf', 'PDF (Add-on)'],
+      ['/hooks/filters/miscellaneous', 'Miscellaneous'],
     ]
   }
 ];

--- a/src/.vuepress/styles/index.styl
+++ b/src/.vuepress/styles/index.styl
@@ -260,9 +260,27 @@ table.nowrap
       background #0976ff
       color white
 
-.warning
-  padding 10px 15px
-  background #ffff66
+p.warning, div.warning
+  padding 12px 16px
+  background #fffbeb
+  border-left 4px solid #f59e0b
+  color #78350f
+  border-radius 4px
+  margin 1rem 0
+  code
+    background #fef3c7
+    color #78350f
+
+p.info, div.info
+  padding 12px 16px
+  background #ecfdf5
+  border-left 4px solid #10b981
+  color #064e3b
+  border-radius 4px
+  margin 1rem 0
+  code
+    background #d1fae5
+    color #064e3b
 
 .listed_internals ul li
   margin-bottom 10px
@@ -335,3 +353,376 @@ details.custom-block.details
     transition: background-color .1s ease;
     box-sizing: border-box;
     border-bottom: 1px solid #389d70;
+
+// ==========================================================================
+// Dark mode — toggled by the floating ThemeToggle component
+// (adds the `ff-dark` class to <html>). Flat fully-qualified selectors only
+// to avoid Stylus nesting quirks. Light theme styles above stay untouched.
+// ==========================================================================
+.ff-dark
+  background-color #0f172a
+
+.ff-dark body
+  background-color #0f172a
+  color #e5e7eb
+
+.ff-dark #app .navbar
+  background-color #111827
+  border-bottom-color #1f2937
+
+.ff-dark #app .navbar .site-name,
+.ff-dark #app .navbar .repo-link
+  color #f3f4f6
+
+.ff-dark #app .navbar .links,
+.ff-dark #app .navbar .links .nav-links
+  background-color transparent
+
+.ff-dark #app .navbar .links a
+  color #f3f4f6
+
+.ff-dark #app .navbar .links .nav-item > a
+  color #d1d5db
+
+.ff-dark #app .navbar .links .nav-item > a:hover,
+.ff-dark #app .navbar .links .nav-item > a.router-link-active
+  color #ffffff
+
+.ff-dark #app .dropdown-wrapper .dropdown-title,
+.ff-dark #app .dropdown-wrapper .mobile-dropdown-title
+  color #f3f4f6
+
+.ff-dark #app .dropdown-wrapper .dropdown-title:hover
+  color #ffffff
+
+.ff-dark #app .nav-dropdown
+  background-color #1f2937
+  border-color #374151
+
+.ff-dark #app .nav-dropdown .dropdown-item h4
+  color #f3f4f6
+  border-color #374151
+
+.ff-dark #app .nav-dropdown .dropdown-item a
+  color #d1d5db
+
+.ff-dark #app .nav-dropdown .dropdown-item a:hover,
+.ff-dark #app .nav-dropdown .dropdown-item a:focus
+  color #ffffff
+  background-color #374151
+
+.ff-dark #app .nav-dropdown .dropdown-item a.router-link-active
+  color #60a5fa
+
+.ff-dark #app .navbar .links .search-box input
+  background-color #1f2937
+  color #f3f4f6
+  border-color #374151
+
+.ff-dark #app .navbar .links .search-box input::placeholder
+  color #9ca3af
+
+// ---- Sidebar (LEFT MENU) ----
+.ff-dark .sidebar
+  background-color #111827
+  border-right-color #1f2937
+
+.ff-dark .sidebar .sidebar-heading,
+.ff-dark .sidebar .sidebar-link
+  color #d1d5db
+
+.ff-dark .sidebar a.sidebar-link:hover,
+.ff-dark .sidebar a.sidebar-link.active
+  background-color #1f2937
+  color #ffffff
+
+.ff-dark .sidebar .sidebar-heading.open,
+.ff-dark .sidebar .sidebar-heading.active
+  color #f9fafb
+
+// ---- Main content ----
+.ff-dark .theme-default-content
+  color #e5e7eb
+
+.ff-dark .theme-default-content h1,
+.ff-dark .theme-default-content h2,
+.ff-dark .theme-default-content h3,
+.ff-dark .theme-default-content h4,
+.ff-dark .theme-default-content h5,
+.ff-dark .theme-default-content h6
+  color #f9fafb
+  border-bottom-color #1f2937
+
+.ff-dark .theme-default-content a
+  color #60a5fa
+
+.ff-dark .theme-default-content a:hover
+  color #93c5fd
+
+.ff-dark .theme-default-content code
+  background-color #1f2937
+  color #f3f4f6
+
+.ff-dark .theme-default-content blockquote
+  border-left-color #374151
+  color #9ca3af
+
+.ff-dark .theme-default-content table tr:nth-child(2n)
+  background-color #111827
+
+.ff-dark .theme-default-content table th,
+.ff-dark .theme-default-content table td
+  border-color #1f2937
+
+.ff-dark .theme-default-content hr
+  border-color #1f2937
+
+.ff-dark div[class*="language-"],
+.ff-dark pre
+  background-color #0b1220 !important
+
+.ff-dark div[class*="language-"]::before
+  color #6b7280
+
+// ---- Custom blocks ----
+.ff-dark .custom-block.tip
+  background-color #064e3b
+  border-color #10b981
+  color #d1fae5
+
+.ff-dark .custom-block.warning
+  background-color #78350f
+  border-color #f59e0b
+  color #fef3c7
+
+.ff-dark .custom-block.danger
+  background-color #7f1d1d
+  border-color #ef4444
+  color #fee2e2
+
+.ff-dark p.info,
+.ff-dark div.info
+  background #064e3b
+  border-left-color #10b981
+  color #d1fae5
+
+.ff-dark p.info code,
+.ff-dark div.info code
+  background #10b981
+  color #064e3b
+
+.ff-dark p.warning,
+.ff-dark div.warning
+  background #78350f
+  border-left-color #f59e0b
+  color #fef3c7
+
+.ff-dark p.warning code,
+.ff-dark div.warning code
+  background #f59e0b
+  color #78350f
+
+// ---- Schema / hook explain tables ----
+.ff-dark table.nowrap
+  background-color #111827
+  color #e5e7eb
+
+.ff-dark table.nowrap thead
+  background-color #1e40af
+
+.ff-dark table.nowrap tbody tr.odd
+  background-color #0b1220
+
+.ff-dark table.nowrap th,
+.ff-dark table.nowrap td
+  border-color #1f2937
+
+.ff-dark .hook_explain
+  background-color #111827
+  border-color #1f2937
+
+.ff-dark .hook_explain .explain_header
+  background-color #1f2937
+  color #f3f4f6
+
+.ff-dark .hook_explain .hook_body
+  background-color #0b1220
+  border-color #1f2937
+
+// Higher specificity overrides for ExplainBlock importance variants
+.ff-dark .hook_explain.is-important
+  border-left-color #60a5fa
+
+.ff-dark .hook_explain.is-important .explain_header
+  background-color #0b2545
+  color #dbeafe
+
+.ff-dark .hook_explain.is-common
+  border-left-color #34d399
+
+.ff-dark .hook_explain.is-common .explain_header
+  background-color #064e3b
+  color #d1fae5
+
+.ff-dark details.custom-block.details
+  background-color #111827
+  border-color #1f2937
+
+.ff-dark details.custom-block.details summary
+  background-color #1f2937
+  color #f3f4f6
+
+// ---- Home page ----
+.ff-dark div.docs-home #home-hero
+  background-color #0b1220
+  color #f9fafb
+
+.ff-dark div.docs-home .home-content
+  background-color #0f172a
+  color #e5e7eb
+
+// ---- Badges ----
+.ff-dark .badge.tip
+  background-color #047857
+
+.ff-dark .badge.warning
+  background-color #b45309
+
+.ff-dark .badge.error
+  background-color #b91c1c
+
+.ff-dark .listed_internals ul li code
+  background-color #4c1d95
+  color #f3f4f6
+
+// ---- Page nav / edit footer ----
+.ff-dark .page-edit,
+.ff-dark .page-nav,
+.ff-dark .last-updated
+  color #9ca3af
+  border-color #1f2937
+
+.ff-dark .page-edit a,
+.ff-dark .page-nav a,
+.ff-dark .last-updated a
+  color #60a5fa
+
+
+// ==========================================================================
+// Algolia DocSearch (legacy v2) — VuePress' default theme has rules with
+// 3-4 class specificity AND uses !important in places. Match its selector
+// chains exactly and use !important where needed to override.
+// Doc structure refs:
+//   .algolia-search-wrapper > .algolia-autocomplete > .ds-dropdown-menu
+//     > [class^="ds-dataset-"]                       (inner panel bg)
+//       > .algolia-docsearch-suggestion              (row)
+//         > .algolia-docsearch-suggestion--category-header
+//         > .algolia-docsearch-suggestion--subcategory-column
+//         > .algolia-docsearch-suggestion--content
+//           > .algolia-docsearch-suggestion--title
+//           > .algolia-docsearch-suggestion--text
+// ==========================================================================
+
+// Outer dropdown panel — softer, raised shadow, smoother radius
+.ff-dark .algolia-search-wrapper .algolia-autocomplete .ds-dropdown-menu
+  background-color #1e293b !important
+  border 1px solid #334155 !important
+  border-radius 8px !important
+  box-shadow 0 10px 28px -4px rgba(0, 0, 0, 0.55), 0 4px 12px -2px rgba(0, 0, 0, 0.35) !important
+
+.ff-dark .algolia-search-wrapper .algolia-autocomplete .ds-dropdown-menu:before
+  background-color #1e293b !important
+  border-color #334155 !important
+
+// Inner dataset wrapper
+.ff-dark .algolia-search-wrapper .algolia-autocomplete .ds-dropdown-menu [class^="ds-dataset-"]
+  background #1e293b !important
+  border none !important
+  border-radius 6px !important
+  padding 4px !important
+
+// Listbox (detached portal fallback)
+.ff-dark [id^="algolia-autocomplete-listbox-"]
+  background-color #1e293b !important
+  color #e2e8f0 !important
+
+// Each suggestion row — subtle separator
+.ff-dark .algolia-search-wrapper .algolia-autocomplete .algolia-docsearch-suggestion
+  background-color transparent !important
+  color #e2e8f0 !important
+  border-bottom 1px solid rgba(51, 65, 85, 0.6) !important
+  transition background-color 0.12s ease !important
+
+// Category header — emerald left-accent strip + slate raise
+.ff-dark .algolia-search-wrapper .algolia-autocomplete .algolia-docsearch-suggestion .algolia-docsearch-suggestion--category-header
+  background #0f172a !important
+  color #f1f5f9 !important
+  border-bottom 1px solid #334155 !important
+  border-left 3px solid #10b981 !important
+  padding-top 7px !important
+  padding-bottom 7px !important
+  font-weight 600 !important
+  letter-spacing 0.01em !important
+
+// Subcategory column (left meta column)
+.ff-dark .algolia-search-wrapper .algolia-autocomplete .algolia-docsearch-suggestion .algolia-docsearch-suggestion--subcategory-column
+  background #0f172a !important
+  color #94a3b8 !important
+  border-right 1px solid #334155 !important
+  border-color #334155 !important
+  font-size 0.85em !important
+
+.ff-dark .algolia-search-wrapper .algolia-docsearch-suggestion--subcategory-column
+  background #0f172a !important
+
+// Suggestion content
+.ff-dark .algolia-search-wrapper .algolia-autocomplete .algolia-docsearch-suggestion--content
+  background-color transparent !important
+  color #e2e8f0 !important
+
+// Titles + text
+.ff-dark .algolia-search-wrapper .algolia-autocomplete .algolia-docsearch-suggestion--title
+  color #f8fafc !important
+  font-weight 600 !important
+
+.ff-dark .algolia-search-wrapper .algolia-autocomplete .algolia-docsearch-suggestion--text
+  color #cbd5e1 !important
+
+// Match highlights — cleaner emerald (drop underline shadow for less noise)
+.ff-dark .algolia-search-wrapper .algolia-autocomplete .algolia-docsearch-suggestion--highlight
+  background rgba(16, 185, 129, 0.16) !important
+  color #6ee7b7 !important
+  box-shadow none !important
+  padding 0 2px !important
+  border-radius 2px !important
+
+.ff-dark .algolia-search-wrapper .algolia-autocomplete .algolia-docsearch-suggestion--category-header .algolia-docsearch-suggestion--highlight
+  background rgba(110, 231, 183, 0.28) !important
+  color #ffffff !important
+
+// Cursor / hover row — emerald glow on the left
+.ff-dark .algolia-search-wrapper .algolia-autocomplete .ds-cursor .algolia-docsearch-suggestion--content
+  background-color #334155 !important
+  color #ffffff !important
+  box-shadow inset 2px 0 0 0 #10b981 !important
+
+.ff-dark .algolia-search-wrapper .algolia-autocomplete .ds-dropdown-menu .ds-suggestion.ds-cursor .algolia-docsearch-suggestion.suggestion-layout-simple,
+.ff-dark .algolia-search-wrapper .algolia-autocomplete .ds-dropdown-menu .ds-suggestion.ds-cursor .algolia-docsearch-suggestion:not(.suggestion-layout-simple) .algolia-docsearch-suggestion--content
+  background-color #334155 !important
+
+// "Search by Algolia" footer — quiet
+.ff-dark .algolia-search-wrapper .algolia-autocomplete .algolia-docsearch-footer
+  background-color #0f172a !important
+  color #64748b !important
+  border-top 1px solid #334155 !important
+  padding 6px 10px !important
+
+.ff-dark .algolia-search-wrapper .algolia-autocomplete .algolia-docsearch-footer--logo
+  filter brightness(1.6) saturate(0.4) opacity(0.7)
+
+// No-results
+.ff-dark .algolia-search-wrapper .algolia-autocomplete .algolia-docsearch-suggestion--no-results
+  background #1e293b !important
+  color #cbd5e1 !important
+  padding 18px !important
+  text-align center !important

--- a/src/.vuepress/styles/index.styl
+++ b/src/.vuepress/styles/index.styl
@@ -385,8 +385,28 @@ details.custom-block.details
   color #d1d5db
 
 .ff-dark #app .navbar .links .nav-item > a:hover,
-.ff-dark #app .navbar .links .nav-item > a.router-link-active
-  color #ffffff
+.ff-dark #app .navbar .links .nav-item > a.router-link-active,
+.ff-dark #app .navbar .links .nav-link.router-link-active,
+.ff-dark #app .navbar .links .nav-link.router-link-exact-active,
+.ff-dark #app .nav-links a.router-link-active,
+.ff-dark #app .nav-links a:hover
+  color #ffffff !important
+
+// Home page CTA "Get Started" action button — keep its blue bg, force
+// white text in dark mode (generic content-link rule was painting it blue
+// and blending into the background).
+.ff-dark .action-button,
+.ff-dark a.action-button,
+.ff-dark a.nav-link.action-button,
+.ff-dark .theme-default-content a.action-button,
+.ff-dark .theme-default-content a.nav-link.action-button
+  color #ffffff !important
+
+.ff-dark .action-button:hover,
+.ff-dark a.action-button:hover,
+.ff-dark a.nav-link.action-button:hover,
+.ff-dark .theme-default-content a.action-button:hover
+  color #ffffff !important
 
 .ff-dark #app .dropdown-wrapper .dropdown-title,
 .ff-dark #app .dropdown-wrapper .mobile-dropdown-title

--- a/src/api/classes/base-field-manager/index.md
+++ b/src/api/classes/base-field-manager/index.md
@@ -16,6 +16,91 @@ Please check out the GitHub file to get more information.
 - [`getGeneralEditorElements()`](/api/classes/base-field-manager/#getgeneraleditorelements)
 - [`getAdvancedEditorElements()`](/api/classes/base-field-manager/#getadvancededitorelements)
 
+### `advancedEditorElement()`
+
+**Source:** `fluentform/app/Services/FormBuilder/BaseFieldManager.php` (line 89)
+
+---
+
+### Element Settings UI components for EditorElements
+There has 69 UI components for making any type of settings ui for your element. You can even implement your own by implementing `generalEditorElement` and `advancedEditorElement` method. Please check the source code or phone field element in pro version.
+
+**Where to find the built-in UI components:** Please check in the [GitHub source file here](https://github.com/fluentform/fluentform/blob/5f400dbcdc/app/Services/FormBuilder/ElementCustomization.php)
+
+## Implementing this class
+Create a php class and then extend this class. Here is the example where we can use they must use methods
+
+```php
+class MyAwesomeFFElement extends \FluentForm\App\Services\FormBuilder\BaseFieldManager
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'key',
+            'Element title',
+            ['tag1', 'tag2', 'tag3'],
+            'general' // where to push general/advanced
+        );
+    }
+
+    function getComponent()
+    {
+        return []; // return your element structure
+    }
+
+    public function getGeneralEditorElements()
+    {
+        return []; // return your general settings keys
+    }
+
+    public function getAdvancedEditorElements()
+    {
+        return []; // return your advanced settings keys
+    }
+
+    public function render($data, $form)
+    {
+        // print your valid html for this element
+    }
+}
+
+/*
+ * Finally initialize the class
+ */
+add_action('fluentform/loaded', function () {
+    new MyAwesomeFFElement();
+});
+```
+## Further read
+
+### `generalEditorElement()`
+
+**Source:** `fluentform/app/Services/FormBuilder/BaseFieldManager.php` (line 84)
+
+---
+
+### getAdvancedEditorElements()
+This is an important method to that you have to implement when implementing your own element class. This method will return what settings will show in the advanced settings of your form element. By default, it returns the following
+
+**For example:**
+
+```php
+    public function getAdvancedEditorElements()
+    {
+        return [
+            'name',
+            'help_message',
+            'container_class',
+            'class',
+            'conditional_logics',
+        ];
+    }
+```
+
+You should implement this method if you want to add or remove any settings.
+
+Please note that, These keys need to be matched with either your component’s settings or attributes keys.
+
 ### getComponent()
 ```php
     /*
@@ -72,7 +157,6 @@ function getComponent()
 
 The code is already self-explanatory. But you have to keep the structure as same as the example. The array need to have the following keys:
 
-
 - index
 - element
 - attributes (will be used for rendering in editor and frontend)
@@ -94,26 +178,15 @@ The code is already self-explanatory. But you have to keep the structure as same
   - icon_class
   - template ([View Available Templates](https://github.com/fluentform/fluentform/tree/master/resources/assets/admin/components/templates))
 
-
 Please check our other element implementations in `fluentformpro/src/Components` folder to get an idea about the available attributes.
 
 To check all the existing get component data structure please [check this file](https://github.com/fluentform/fluentform/blob/5f400dbcdc/app/Services/FormBuilder/DefaultElements.php). That file contains all free and some pro version data attributes implementation.
 
-### render($data, $form)
-```php
-    /*
-     * Implement render html for your form element. You have to print your element html
-     * @param: $element array - Contain the total element with attributes, settings etc
-     * @param: $form object - Form Object of the current form rendering in that time.
-     * @return void
-     */
-    abstract function render($element, $form);
-```
-You have to implement this method and print the final html for your custom element. Please check other implementations in pro versions `fluentformpro/src/Components` folder. The DOM need to be symmetric, and you must have to use the parent class function to generate the DOM's to make the conditional logic/error messages work.
+### `getEditorCustomizationSettings()`
 
-Please check the all element `render(compile())` method in these files.
+**Source:** `fluentform/app/Services/FormBuilder/BaseFieldManager.php` (line 116)
 
-[https://github.com/fluentform/fluentform/tree/master/app/Services/FormBuilder/Components](https://github.com/fluentform/fluentform/tree/master/app/Services/FormBuilder/Components)
+---
 
 ### getGeneralEditorElements()
 This is an important method that you have to implement when implementing your own element class. This method will return what settings will show in the general settings of your form element.
@@ -135,98 +208,57 @@ This is an important method that you have to implement when implementing your ow
 ```
 Please note that, These keys need to be matched with either your component’s settings or attributes keys.
 
-### getAdvancedEditorElements()
-This is an important method to that you have to implement when implementing your own element class. This method will return what settings will show in the advanced settings of your form element. By default, it returns the following
+### `pushComponent($components)`
 
-**For example:**
+**Source:** `fluentform/app/Services/FormBuilder/BaseFieldManager.php` (line 61)
 
+---
+
+### `pushConditionalSupport($conditonalItems)`
+
+**Source:** `fluentform/app/Services/FormBuilder/BaseFieldManager.php` (line 49)
+
+---
+
+### `pushEditorElementPositions($placement_settings)`
+
+**Source:** `fluentform/app/Services/FormBuilder/BaseFieldManager.php` (line 72)
+
+---
+
+### `pushFormInputType($types)`
+
+**Source:** `fluentform/app/Services/FormBuilder/BaseFieldManager.php` (line 55)
+
+---
+
+### `pushTags($tags, $form)`
+
+**Source:** `fluentform/app/Services/FormBuilder/BaseFieldManager.php` (line 121)
+
+---
+
+### `register()`
+
+**Source:** `fluentform/app/Services/FormBuilder/BaseFieldManager.php` (line 26)
+
+---
+
+### render($data, $form)
 ```php
-    public function getAdvancedEditorElements()
-    {
-        return [
-            'name',
-            'help_message',
-            'container_class',
-            'class',
-            'conditional_logics',
-        ];
-    }
-```
-
-You should implement this method if you want to add or remove any settings.
-
-Please note that, These keys need to be matched with either your component’s settings or attributes keys.
-
-### Element Settings UI components for EditorElements
-There has 69 UI components for making any type of settings ui for your element. You can even implement your own by implementing `generalEditorElement` and `advancedEditorElement` method. Please check the source code or phone field element in pro version.
-
-**Where to find the built-in UI components:** Please check in the [GitHub source file here](https://github.com/fluentform/fluentform/blob/5f400dbcdc/app/Services/FormBuilder/ElementCustomization.php)
-
-## Implementing this class
-Create a php class and then extend this class. Here is the example where we can use they must use methods
-
-```php
-class MyAwesomeFFElement extends \FluentForm\App\Services\FormBuilder\BaseFieldManager
-{
-    public function __construct()
-    {
-        parent::__construct(
-            'key',
-            'Element title',
-            ['tag1', 'tag2', 'tag3'],
-            'general' // where to push general/advanced
-        );
-    }
-
-    function getComponent()
-    {
-        return []; // return your element structure
-    }
-
-    public function getGeneralEditorElements()
-    {
-        return []; // return your general settings keys
-    }
-
-    public function getAdvancedEditorElements()
-    {
-        return []; // return your advanced settings keys
-    }
-
-    public function render($data, $form)
-    {
-        // print your valid html for this element
-    }
-}
-
-/*
- * Finally initialize the class
- */
-add_action('fluentform/loaded', function () {
-    new MyAwesomeFFElement();
-});
-```
-## Further read
-### Validate data of inputed from frontend
-If you want to validate user input data for your form submission you have implement a filter hook
-```php
-add_filter('fluentform/validate_input_item_{YOUR_ELEMENT_KEY}', function ($errorMessage, $field, $formData, $fields, $form) {
-    $fieldName = $field['name'];
-    if (empty($formData[$fieldName])) {
-        return $errorMessage;
-    }
-    $value = $formData[$fieldName]; // This is the user input value
-
     /*
-     * You can validate this value and return $errorMessage
+     * Implement render html for your form element. You have to print your element html
+     * @param: $element array - Contain the total element with attributes, settings etc
+     * @param: $form object - Form Object of the current form rendering in that time.
+     * @return void
      */
-
-    return [$errorMessage];
-
-}, 10, 5);
+    abstract function render($element, $form);
 ```
+You have to implement this method and print the final html for your custom element. Please check other implementations in pro versions `fluentformpro/src/Components` folder. The DOM need to be symmetric, and you must have to use the parent class function to generate the DOM's to make the conditional logic/error messages work.
 
-Learn more about this validation [here](/hooks/filters/#_fluentform_response_render______field__element__)
+Please check the all element `render(compile())` method in these files.
+
+[https://github.com/fluentform/fluentform/tree/master/app/Services/FormBuilder/Components](https://github.com/fluentform/fluentform/tree/master/app/Services/FormBuilder/Components)
 
 ### Transforming Input Data in Entries/Emails
 Maybe you collected the data as array or key of any dynamic data, and you need to transform that data to anywhere that is viewable at admin panel entries/email/3rd party integrations.
@@ -322,3 +354,25 @@ add_action('fluentform/loaded', function () {
 It’s highly recommended to explore our source files and try to understand the design. Once you get if it’s very easy to implement your own custom input elements. Also, please check our a step by step your custom new field creation guide here [How to Create Your Own Custom Field in Fluentforms](https://fluentforms.com/docs/how-to-create-your-own-custom-field-with-fluent-forms/).
 
 If you have any question please feel free to reach at our [support team](https://wpmanageninja.com/support-tickets/) or ask questions in our [facebook community group](https://www.facebook.com/groups/fluentforms/)
+
+### Validate data of inputed from frontend
+If you want to validate user input data for your form submission you have implement a filter hook
+```php
+add_filter('fluentform/validate_input_item_{YOUR_ELEMENT_KEY}', function ($errorMessage, $field, $formData, $fields, $form) {
+    $fieldName = $field['name'];
+    if (empty($formData[$fieldName])) {
+        return $errorMessage;
+    }
+    $value = $formData[$fieldName]; // This is the user input value
+
+    /*
+     * You can validate this value and return $errorMessage
+     */
+
+    return [$errorMessage];
+
+}, 10, 5);
+```
+
+Learn more about this validation [here](/hooks/filters/#_fluentform_response_render______field__element__)
+

--- a/src/api/classes/base-payment-method/index.md
+++ b/src/api/classes/base-payment-method/index.md
@@ -34,6 +34,22 @@ class MyCustomPaymentMethod extends BasePaymentMethod
      }
 ```
 
+### getGlobalFields()
+This method will return all the admin settings for the current payment method. You can add your own settings also here. In the end of this page you will see an example with the settings format.
+
+```php
+abstract public function getGlobalFields();
+```
+
+### getGlobalSettings()
+This method should return the saved data from the database. It will be based on the settings that were provided by [getGlobalFields()](/api/classes/base-payment-method/#getglobalfields) method. You can get your settings like this `get_option(‘fluentform_payment_settings_{method_key}’, [])`;
+
+```php
+abstract public function getGlobalSettings();
+```
+
+## Further read
+
 ### init()
 This is the main function that will run all the required actions for this payment settings and processing. These hooks will be called dynamically during the payment processing & settings after the payment method setup is completed.
 ```php
@@ -52,6 +68,22 @@ This is the main function that will run all the required actions for this paymen
             [$this, 'pushPaymentMethodToForm']
         );
     }
+```
+
+### modifyTransaction($transaction)
+This method modifies a transaction record with the payment method dashboard entry url. Use this to link the transaction with your payment method’s dashboard transaction page using the `$transaction->charge_id` charge id. The `$transaction` parameter is available with the [fluentform/transaction_data_{$key}](/hooks/filters/#fluentform_transaction_data___key_) hook.
+
+```php
+/*
+* @param $transaction - Transaction Data array
+*/
+public function modifyTransaction($transaction)
+{
+   if ($transaction->charge_id) {
+        $transaction->action_url =  'https://dashboard.mypaymentsitedemo.com/app/payments/'.$transaction->charge_id;
+    }
+    return $transaction;
+}
 ```
 
 ### pushPaymentMethodToForm($methods)
@@ -79,38 +111,6 @@ public function pushPaymentMethodToForm($methods)
     return $methods;
 }
 ```
-
-### modifyTransaction($transaction)
-This method modifies a transaction record with the payment method dashboard entry url. Use this to link the transaction with your payment method’s dashboard transaction page using the `$transaction->charge_id` charge id. The `$transaction` parameter is available with the [fluentform/transaction_data_{$key}](/hooks/filters/#fluentform_transaction_data___key_) hook.
-
-```php
-/*
-* @param $transaction - Transaction Data array
-*/
-public function modifyTransaction($transaction)
-{
-   if ($transaction->charge_id) {
-        $transaction->action_url =  'https://dashboard.mypaymentsitedemo.com/app/payments/'.$transaction->charge_id;
-    }
-    return $transaction;
-}
-```
-
-### getGlobalFields()
-This method will return all the admin settings for the current payment method. You can add your own settings also here. In the end of this page you will see an example with the settings format.
-
-```php
-abstract public function getGlobalFields();
-```
-
-### getGlobalSettings()
-This method should return the saved data from the database. It will be based on the settings that were provided by [getGlobalFields()](/api/classes/base-payment-method/#getglobalfields) method. You can get your settings like this `get_option(‘fluentform_payment_settings_{method_key}’, [])`;
-
-```php
-abstract public function getGlobalSettings();
-```
-
-## Further read
 
 ### Validate settings of payment method
 If you want to validate the payment admin settings use this hook
@@ -234,3 +234,4 @@ class MyCustomPaymentMethod extends BasePaymentMethod
 It’s highly recommended to explore our source files and try to understand the procedure. Once you understand it’s very easy to implement your own custom payment method.
 
 If you have any questions please feel free to reach to our [support team](https://wpmanageninja.com/support-tickets/) or ask questions in our [facebook community group](https://www.facebook.com/groups/fluentforms/)
+

--- a/src/api/classes/base-processor/index.md
+++ b/src/api/classes/base-processor/index.md
@@ -24,96 +24,6 @@ The API Functions are automatically called when the form has the selected paymen
 - [`setMetaData()`](/api/classes/base-processor/#setmetadata)
 - [`getReturnData()`](/api/classes/base-processor/#getreturndata)
 
-### init()
-You need to override this method using the following hooks. You can call it with your custom payment method class extended from the [BasePaymentMethod](/api/classes/base-payment-method) class. At the bottom of this page, you will see an example implementation of this method with all available parameters of these hooks.
-```php
-/*
-* $this->method Should match your payment method key
-*/
-public function init()
-{
-    add_action('fluentform/process_payment_' . $this->method, array($this, 'handlePaymentAction'), 10, 6);
-    add_action('fluentform/payment_frameless_' . $this->method, array($this, 'handleSessionRedirectBack'));
-
-    add_action('fluentform/ipn_endpoint_' . $this->method, function () {
-            //if IPN verification is needed
-    });
-}
-```
-
-### handlePaymentAction()
-This is an abstract class that you have to implement in your own class. This is the most crucial part where the payment should be processed and then the transaction data is inserted into the database.
-
-```php
-/* 
-* Process and finalize the payment transaction
-* 
-* 
-* @param  int $submissionId  - Form Submission ID
-* @param array $submissionData - Form Submission Data Array
-* @param object $form - Form Object
-* @param array $methodSettings - Payment Method Settings Data Array
-* @param boolean $subscriptionItems - Payment has subscription item
-* @param int $totalPayable - Total payable amount
-*/
-
-public abstract function handlePaymentAction($submissionId, $submissionData, $form, $methodSettings)
-```
-
-### setSubmissionId($submissionId)
-This method will set the form submission ID property. It should be called from handlePaymentAction where the $submissionId parameter is available. The following methods does not need to be created in your class you can call these methods from the base class.
-
-```php
-/*
-* Set the currrent submission ID
-* @param $submissionId  - Form Submission ID
-*/
-public function setSubmissionId($submissionId)
-```
-
-### insertTransaction($data)
-This method will insert the transaction data into the database. It should be called from the [`handlePaymentAction()`](/api/classes/base-processor/#handlepaymentaction) method or when you need to insert a transaction record after verifying data.
-
-```php
-/*
-* @param data - Transaction Data array
-*/
-public function insertTransaction($data)
-```
-
-### insertRefund($data)
-This method is used to insert refund data.
-
-```php
-/*
-* @param data - Refund Data array
-*/
-public function insertRefund($data)
-```
-
-
-### getTransaction($transactionId, $column = ‘id’)
-This method is called to get transaction data. You can use this inside [`handlePaymentAction()`](/api/classes/base-processor/#handlepaymentaction) method to process the transaction.
-
-```php
-/*
-* @param transactionId - Transaction ID
-* $column - Column Name to match with 
-*/
-public function getTransaction($transactionId, $column = 'id')
-```
-
-### getRefund($refundId, $column = ‘id’)
-Use this method to get refund data.
-
-```php
-/*
-* @param @refundId - RefundId ID
-* $column - Column Name to match with 
-*/
-public function getRefund($refundId, $column = 'id')
-```
-
 ### changeSubmissionPaymentStatus($newStatus)
 Update the current submission status for example paid or pending. After processing a transaction update the payment status using this method.
 
@@ -135,44 +45,82 @@ Use this method to update the status of the transaction.
 public function changeTransactionStatus($transactionId, $newStatus)
 ```
 
-### recalculatePaidTotal()
-Use this method to recalculate the current submission total amount. This method does not need to be created in your class you can call this method from the base class.
+### `completePaymentSubmission($isAjax = true)`
 
-```php
-public function recalculatePaidTotal()
-```
+**Source:** `fluentformpro/src/Payments/PaymentMethods/BaseProcessor.php` (line 382)
 
-### updateTransaction($transactionId, $data)
-This method updates transaction data.
+---
+
+### `createInitialPendingTransaction($submission = false, $hasSubscriptions = false)`
+
+**Source:** `fluentformpro/src/Payments/PaymentMethods/BaseProcessor.php` (line 1090)
+
+---
+
+### `deleteMetaData($name)`
+
+**Source:** `fluentformpro/src/Payments/PaymentMethods/BaseProcessor.php` (line 497)
+
+---
+
+### `getAmountTotal()`
+
+**Source:** `fluentformpro/src/Payments/PaymentMethods/BaseProcessor.php` (line 765)
+
+---
+
+### `getDiscountItems()`
+
+**Source:** `fluentformpro/src/Payments/PaymentMethods/BaseProcessor.php` (line 474)
+
+---
+
+### `getForm()`
+
+**Source:** `fluentformpro/src/Payments/PaymentMethods/BaseProcessor.php` (line 451)
+
+---
+
+### `getLastTransaction($submissionId)`
+
+**Source:** `fluentformpro/src/Payments/PaymentMethods/BaseProcessor.php` (line 208)
+
+---
+
+### `getMetaData($metaKey)`
+
+**Source:** `fluentformpro/src/Payments/PaymentMethods/BaseProcessor.php` (line 505)
+
+---
+
+### `getOrderItems()`
+
+**Source:** `fluentformpro/src/Payments/PaymentMethods/BaseProcessor.php` (line 466)
+
+---
+
+### `getPaymentCountsAndTotal($subscriptionId, $paymentMethod = false)`
+
+**Source:** `fluentformpro/src/Payments/PaymentMethods/BaseProcessor.php` (line 954)
+
+---
+
+### getRefund($refundId, $column = ‘id’)
+Use this method to get refund data.
 
 ```php
 /*
-/*
-*@param $transactionId - Transaction ID 
-*@param $data - Transaction data array 
+* @param @refundId - RefundId ID
+* $column - Column Name to match with 
 */
-
-public function updateTransaction($transactionId, $data)
+public function getRefund($refundId, $column = 'id')
 ```
 
-### handleSessionRedirectBack($data)
-This method handles the payment session redirect back.
+### `getRefundTotal()`
 
-```php
-public function handleSessionRedirectBack($data)
-```
+**Source:** `fluentformpro/src/Payments/PaymentMethods/BaseProcessor.php` (line 306)
 
-### setMetaData()
-Submission metadata is saved using this method.
-
-```php
-/*
-/*
-* @param $name - Meta Name
-* @param @value - Meta Value
-*/
-public function setMetaData($name, $value)
-```
+---
 
 ### getReturnData()
 This method will return submission data which will be used during the final payment processing.
@@ -282,7 +230,6 @@ class MyPaymentProcessor extends BaseProcessor
         ], 200);
     }
 
-
     /*
     * This method is called when you are redirected back to your site.
     *
@@ -339,3 +286,227 @@ class MyPaymentProcessor extends BaseProcessor
 
 ## Final Note
 Please check the existing payment processor files to get a more clear concept of this class and implement your custom payment system. There are other methods also to help with possessing a payment. If you have any questions please feel free to reach to our [support team](https://wpmanageninja.com/support-tickets/) or ask questions in our [facebook community group](https://www.facebook.com/groups/fluentforms/)
+
+### `getSubmission()`
+
+**Source:** `fluentformpro/src/Payments/PaymentMethods/BaseProcessor.php` (line 429)
+
+---
+
+### `getSubmissionId()`
+
+**Source:** `fluentformpro/src/Payments/PaymentMethods/BaseProcessor.php` (line 142)
+
+Log a security-relevant payment event.
+
+---
+
+### `getSubscriptions($status = false)`
+
+**Source:** `fluentformpro/src/Payments/PaymentMethods/BaseProcessor.php` (line 818)
+
+---
+
+### getTransaction($transactionId, $column = ‘id’)
+This method is called to get transaction data. You can use this inside [`handlePaymentAction()`](/api/classes/base-processor/#handlepaymentaction) method to process the transaction.
+
+```php
+/*
+* @param transactionId - Transaction ID
+* $column - Column Name to match with 
+*/
+public function getTransaction($transactionId, $column = 'id')
+```
+
+### `getTransactionByChargeId($chargeId)`
+
+**Source:** `fluentformpro/src/Payments/PaymentMethods/BaseProcessor.php` (line 200)
+
+Log a security-relevant payment event.
+
+---
+
+### `getTransactionDefaults()`
+
+**Source:** `fluentformpro/src/Payments/PaymentMethods/BaseProcessor.php` (line 1032)
+
+---
+
+### handlePaymentAction()
+This is an abstract class that you have to implement in your own class. This is the most crucial part where the payment should be processed and then the transaction data is inserted into the database.
+
+```php
+/* 
+* Process and finalize the payment transaction
+* 
+* 
+* @param  int $submissionId  - Form Submission ID
+* @param array $submissionData - Form Submission Data Array
+* @param object $form - Form Object
+* @param array $methodSettings - Payment Method Settings Data Array
+* @param boolean $subscriptionItems - Payment has subscription item
+* @param int $totalPayable - Total payable amount
+*/
+
+public abstract function handlePaymentAction($submissionId, $submissionData, $form, $methodSettings)
+```
+
+### handleSessionRedirectBack($data)
+This method handles the payment session redirect back.
+
+```php
+public function handleSessionRedirectBack($data)
+```
+
+### init()
+You need to override this method using the following hooks. You can call it with your custom payment method class extended from the [BasePaymentMethod](/api/classes/base-payment-method) class. At the bottom of this page, you will see an example implementation of this method with all available parameters of these hooks.
+```php
+/*
+* $this->method Should match your payment method key
+*/
+public function init()
+{
+    add_action('fluentform/process_payment_' . $this->method, array($this, 'handlePaymentAction'), 10, 6);
+    add_action('fluentform/payment_frameless_' . $this->method, array($this, 'handleSessionRedirectBack'));
+
+    add_action('fluentform/ipn_endpoint_' . $this->method, function () {
+            //if IPN verification is needed
+    });
+}
+```
+
+### insertRefund($data)
+This method is used to insert refund data.
+
+```php
+/*
+* @param data - Refund Data array
+*/
+public function insertRefund($data)
+```
+
+### insertTransaction($data)
+This method will insert the transaction data into the database. It should be called from the [`handlePaymentAction()`](/api/classes/base-processor/#handlepaymentaction) method or when you need to insert a transaction record after verifying data.
+
+```php
+/*
+* @param data - Transaction Data array
+*/
+public function insertTransaction($data)
+```
+
+### `limitLength($string, $limit = 127)`
+
+**Source:** `fluentformpro/src/Payments/PaymentMethods/BaseProcessor.php` (line 1017)
+
+---
+
+### `loadView($view, $data = [])`
+
+**Source:** `fluentformpro/src/Payments/PaymentMethods/BaseProcessor.php` (line 585)
+
+---
+
+### `maybeInsertSubscriptionCharge($item)`
+
+**Source:** `fluentformpro/src/Payments/PaymentMethods/BaseProcessor.php` (line 844)
+
+---
+
+### recalculatePaidTotal()
+Use this method to recalculate the current submission total amount. This method does not need to be created in your class you can call this method from the base class.
+
+```php
+public function recalculatePaidTotal()
+```
+
+### `refund($refund_amount, $transaction, $submission, $method = '', $refundId = '', $refundNote = 'Refunded')`
+
+**Source:** `fluentformpro/src/Payments/PaymentMethods/BaseProcessor.php` (line 594)
+
+---
+
+### setMetaData()
+Submission metadata is saved using this method.
+
+```php
+/*
+/*
+* @param $name - Meta Name
+* @param @value - Meta Value
+*/
+public function setMetaData($name, $value)
+```
+
+### setSubmissionId($submissionId)
+This method will set the form submission ID property. It should be called from handlePaymentAction where the $submissionId parameter is available. The following methods does not need to be created in your class you can call these methods from the base class.
+
+```php
+/*
+* Set the currrent submission ID
+* @param $submissionId  - Form Submission ID
+*/
+public function setSubmissionId($submissionId)
+```
+
+### `showPaymentView($returnData)`
+
+**Source:** `fluentformpro/src/Payments/PaymentMethods/BaseProcessor.php` (line 519)
+
+---
+
+### `updateRefund($totalRefund, $transaction, $submission, $method = '', $refundId = '', $refundNote = 'Refunded')`
+
+**Source:** `fluentformpro/src/Payments/PaymentMethods/BaseProcessor.php` (line 671)
+
+---
+
+### `updateSubmission($id, $data)`
+
+**Source:** `fluentformpro/src/Payments/PaymentMethods/BaseProcessor.php` (line 1008)
+
+---
+
+### `updateSubscription($id, $data)`
+
+**Source:** `fluentformpro/src/Payments/PaymentMethods/BaseProcessor.php` (line 835)
+
+---
+
+### `updateSubscriptionStatus($subscription, $newStatus, $note = '')`
+
+**Source:** `fluentformpro/src/Payments/PaymentMethods/BaseProcessor.php` (line 1142)
+
+---
+
+### updateTransaction($transactionId, $data)
+This method updates transaction data.
+
+```php
+/*
+/*
+*@param $transactionId - Transaction ID 
+*@param $data - Transaction data array 
+*/
+
+public function updateTransaction($transactionId, $data)
+```
+
+### `validatePaymentConfirmation($transaction, $submissionId)`
+
+**Source:** `fluentformpro/src/Payments/PaymentMethods/BaseProcessor.php` (line 38)
+
+Validate a payment confirmation request before processing.
+Checks that the transaction exists, is in a confirmable state,
+and the submission hasn't already been paid.
+
+---
+
+### `verifyPaymentNonce($submissionId, $method)`
+
+**Source:** `fluentformpro/src/Payments/PaymentMethods/BaseProcessor.php` (line 85)
+
+Verify a payment nonce for the given submission.
+
+---
+

--- a/src/api/classes/integration-manager-controller/index.md
+++ b/src/api/classes/integration-manager-controller/index.md
@@ -53,6 +53,59 @@ public function __construct(Application $application)
 }
 ```
 
+### `addActiveNotificationType($types)`
+
+**Source:** `fluentform/app/Http/Controllers/IntegrationManagerController.php` (line 137)
+
+---
+
+### `addGlobalMenu($setting)`
+
+**Source:** `fluentform/app/Http/Controllers/IntegrationManagerController.php` (line 120)
+
+---
+
+### `addNotificationType($types)`
+
+**Source:** `fluentform/app/Http/Controllers/IntegrationManagerController.php` (line 131)
+
+---
+
+### fluentform/save_integration_value_{integrationKey}
+
+Filter hook for validating integration settings.
+
+```php
+add_filter('fluentform/save_integration_value_' . $this->integrationKey, [$this, 'yourValidationMethodBeforeSave'], 10, 3);
+```
+
+Example of a validation:
+
+```php
+public function yourValidationMethodBeforeSave($settings, $integrationId, $formId)
+{   
+    try {
+        $error = "";                                   // check your conditions
+        if ($error){
+            throw new \Exception('Error message ');   // throw error
+        }
+    } catch (\Exception $e) {
+        wp_send_json_error([
+            'message' => $e->getMessage(),
+            'status' => false
+        ], 400);
+    }
+
+    return $settings;
+}
+```
+
+### `getApiSettings()`
+
+**Source:** `fluentform/app/Http/Controllers/IntegrationManagerController.php` (line 216)
+
+---
+
 ### getGlobalFields()
 This method will need to return the settings data format for the integration API connection. You have to keep the structure as same as the example. This setting will store the API key & additional required data to connect with your Integration API.
 
@@ -105,89 +158,6 @@ Here is an **example** of the method:
     }
 ```
 
-
-### saveGlobalSettings()
-Here you will get the settings data after user submission, and you can use the data connect with your API or do your required task. Then save the data or return error using your own validation.
-
-**For example :**
-
-```php
-public function saveGlobalSettings($settings)
-    {
-        if (!$settings['apiKey']) {
-            $mySettings = [
-                'apiKey' => '',
-                'status' => false
-            ];
-            
-            update_option($this->optionKey, $mySettings, 'no');
-            wp_send_json_success([
-                'message' => __('Your settings has been updated and disconnected', 'fluentform'),
-                'status'  => false
-            ], 200);
-        }
-
-        // Verify API key
-        try {
-             
-        // Connect with your api using the apiKey
-        // Your code
-            
-        } catch (\Exception $exception) {
-            wp_send_json_error([
-                'message' => $exception->getMessage()
-            ], 400);
-        }
-
-        // API key is verified now
-        $settings = [
-            'apiKey' => sanitize_text_field($settings['apiKey']),
-            'status' => true
-        ];
-
-        // Update options with the key
-        update_option($this->optionKey, $settings, 'no`');
-
-        wp_send_json_success([
-            'message' => __('Your MyAwesomeIntegration api key has been verified and successfully set', 'fluentform'),
-            'status'  => true
-        ], 200);
-    }
-```
-After you have successfully completed this step along with the previous methods, your integration will appear int the fluent form modules list.
-
-<img :src="$withBase('/assets/img/modules/custom-integration.png')" alt="Fluent Custom Integration Modules" />
-
-
-After you enable your new integration, you can go to the integration settings page where settings will be displayed according to your global field settings from getGlobalFields.
-
-After the integration is up and running the integration needs to be pushed in the form feed, so a user can use this in his form. Following method will achieve this.
-
-### pushIntegration()
-Adding your integration into the form feeds. Here you will get two parameters `$integrations, $formId`,
-
-Here is screenshot when the integration is pushed :
-
-<img :src="$withBase('/assets/img/modules/push-custom-integration.png')" alt="Fluent Custom Integration Modules" />
-
-If the integration is configured it will push the integration into the form feed or else it will show a message to configure the API. The isConfigured() method, to check if the integration is configured is built in , you just need to call it.
-
-```php
-public function pushIntegration($integrations, $formId)
-{
-    $integrations[$this->integrationKey] = [
-        'title'                 => $this->title . ' Integration',
-        'logo'                  => $this->logo,
-        'is_active'             => $this->isConfigured(),
-        'configure_title'       => 'Configuration required!',
-        'global_configure_url'  => admin_url('admin.php?page=fluent_forms_settings#{your settings page url}'),
-        'configure_message'     => 'MyAwesomeIntegration is not configured yet! Please configure your API first',
-        'configure_button_text' => 'Set MyAwesomeIntegration API'
-    ];
-    return $integrations;
-}
-```
-
 ### getIntegrationDefaults
 This method will return your Integration feed settings default data format. You will get two parameters here `$settings`, `$formId`.
 Here is an example of this method.
@@ -206,6 +176,12 @@ Here is an example of this method.
     'enabled' => true
 ];
 ```
+
+### getMergeFields()
+In this method you will get three parameters `$list`, `$listId`, `$formId`.
+This method is called after every select option change. When you have field depending on one another, you need to modify subfields based on a primary field you can use this method and return modified data based on one primary field.
+
+For reference check [Mailchimp integration](https://github.com/fluentform/fluentform/blob/master/app/Services/Integrations/MailChimp/MailChimpIntegration.php)
 
 ### getSettingsFields
 This method will render input fields for the integration feed settings page, based on the returned input data format. You will get two parameters here `$settings`, `$formId`.
@@ -277,11 +253,17 @@ All your input field will be generated dynamically based on your provided data. 
 <img :src="$withBase('/assets/img/modules/custom-integration-feed.png')" alt="Fluent Custom Integration Modules" />
 In the default settings [getIntegrationDefaults()](/api/classes/integration-manager-controller/#getintegrationdefaults) we gave a value `enabled` as true, that is why you can see that the field with this key `checkbox-single` checked which means it is true.
 
-### getMergeFields()
-In this method you will get three parameters `$list`, `$listId`, `$formId`.
-This method is called after every select option change. When you have field depending on one another, you need to modify subfields based on a primary field you can use this method and return modified data based on one primary field.
+### `isConfigured()`
 
-For reference check [Mailchimp integration](https://github.com/fluentform/fluentform/blob/master/app/Services/Integrations/MailChimp/MailChimpIntegration.php)
+**Source:** `fluentform/app/Http/Controllers/IntegrationManagerController.php` (line 205)
+
+---
+
+### `isEnabled()`
+
+**Source:** `fluentform/app/Http/Controllers/IntegrationManagerController.php` (line 211)
+
+---
 
 ### notify()
 This method will be called upon form submission, you will get four parameters `$feed`, `$formData`, `$entry`, `$form`. This is the most important method, here you will your necessary task upon form submission
@@ -289,31 +271,115 @@ This method will be called upon form submission, you will get four parameters `$
 Here is a filter that you can use to validate your settings.
 
 ## Further read
-### fluentform/save_integration_value_{integrationKey}
 
-Filter hook for validating integration settings.
+### `prepareIntegrationFeed($setting, $feed, $formId)`
+
+**Source:** `fluentform/app/Http/Controllers/IntegrationManagerController.php` (line 164)
+
+---
+
+### pushIntegration()
+Adding your integration into the form feeds. Here you will get two parameters `$integrations, $formId`,
+
+Here is screenshot when the integration is pushed :
+
+<img :src="$withBase('/assets/img/modules/push-custom-integration.png')" alt="Fluent Custom Integration Modules" />
+
+If the integration is configured it will push the integration into the form feed or else it will show a message to configure the API. The isConfigured() method, to check if the integration is configured is built in , you just need to call it.
 
 ```php
-add_filter('fluentform/save_integration_value_' . $this->integrationKey, [$this, 'yourValidationMethodBeforeSave'], 10, 3);
-```
-
-Example of a validation:
-
-```php
-public function yourValidationMethodBeforeSave($settings, $integrationId, $formId)
-{   
-    try {
-        $error = "";                                   // check your conditions
-        if ($error){
-            throw new \Exception('Error message ');   // throw error
-        }
-    } catch (\Exception $e) {
-        wp_send_json_error([
-            'message' => $e->getMessage(),
-            'status' => false
-        ], 400);
-    }
-
-    return $settings;
+public function pushIntegration($integrations, $formId)
+{
+    $integrations[$this->integrationKey] = [
+        'title'                 => $this->title . ' Integration',
+        'logo'                  => $this->logo,
+        'is_active'             => $this->isConfigured(),
+        'configure_title'       => 'Configuration required!',
+        'global_configure_url'  => admin_url('admin.php?page=fluent_forms_settings#{your settings page url}'),
+        'configure_message'     => 'MyAwesomeIntegration is not configured yet! Please configure your API first',
+        'configure_button_text' => 'Set MyAwesomeIntegration API'
+    ];
+    return $integrations;
 }
 ```
+
+### `registerAdminHooks()`
+
+**Source:** `fluentform/app/Http/Controllers/IntegrationManagerController.php` (line 54)
+
+---
+
+### `registerNotificationHooks()`
+
+**Source:** `fluentform/app/Http/Controllers/IntegrationManagerController.php` (line 106)
+
+---
+
+### saveGlobalSettings()
+Here you will get the settings data after user submission, and you can use the data connect with your API or do your required task. Then save the data or return error using your own validation.
+
+**For example :**
+
+```php
+public function saveGlobalSettings($settings)
+    {
+        if (!$settings['apiKey']) {
+            $mySettings = [
+                'apiKey' => '',
+                'status' => false
+            ];
+            
+            update_option($this->optionKey, $mySettings, 'no');
+            wp_send_json_success([
+                'message' => __('Your settings has been updated and disconnected', 'fluentform'),
+                'status'  => false
+            ], 200);
+        }
+
+        // Verify API key
+        try {
+             
+        // Connect with your api using the apiKey
+        // Your code
+            
+        } catch (\Exception $exception) {
+            wp_send_json_error([
+                'message' => $exception->getMessage()
+            ], 400);
+        }
+
+        // API key is verified now
+        $settings = [
+            'apiKey' => sanitize_text_field($settings['apiKey']),
+            'status' => true
+        ];
+
+        // Update options with the key
+        update_option($this->optionKey, $settings, 'no`');
+
+        wp_send_json_success([
+            'message' => __('Your MyAwesomeIntegration api key has been verified and successfully set', 'fluentform'),
+            'status'  => true
+        ], 200);
+    }
+```
+After you have successfully completed this step along with the previous methods, your integration will appear int the fluent form modules list.
+
+<img :src="$withBase('/assets/img/modules/custom-integration.png')" alt="Fluent Custom Integration Modules" />
+
+After you enable your new integration, you can go to the integration settings page where settings will be displayed according to your global field settings from getGlobalFields.
+
+After the integration is up and running the integration needs to be pushed in the form feed, so a user can use this in his form. Following method will achieve this.
+
+### `setFeedAttributes($feed, $formId)`
+
+**Source:** `fluentform/app/Http/Controllers/IntegrationManagerController.php` (line 198)
+
+---
+
+### `setMetaKey($data)`
+
+**Source:** `fluentform/app/Http/Controllers/IntegrationManagerController.php` (line 158)
+
+---
+

--- a/src/api/classes/pdf-template-manager/index.md
+++ b/src/api/classes/pdf-template-manager/index.md
@@ -31,70 +31,11 @@ class FluentExtraTemplateDemo extends TemplateManager
 }
 ```
 
-### getDefaultSettings()
-This method will store the default settings of the PDF template. You will need to return array of the settings key & value.
-```php
-    public function getDefaultSettings()
-    {
-        return [
-            'header' => '<h2>Hello From My Demo Template</h2>',
-            'footer' => '<p>Footer</p>',
-            'body'   => 'Hello There',
-            'demo'   => ''
-        ];
-    }
-```
+### `downloadPDF($submissionId, $settings)`
 
-### getSettingsFields()
-This method will render input fields for the PDF template settings page, based on the returned data. The key value used in these fields needs to match with the [getDefaultSettings()](/api/classes/pdf-template-manager/#getdefaultsettings)
+**Source:** `fluentforms-pdf/Modules/FluentForms/Templates/TemplateManager.php` (line 61)
 
-You can use the prebuilt input components to create your settings page, here is a documentation [link](https://fluentforms.com/docs/integration-feed-fields-api/) where you can find the details list about these input component.
-
-Required properties for the fields array:
-- `key` : Settings Unique Key
-- `label` : Settings Input Label
-- `component` : Pass to prebuild input component.
-
-Here is example of this method:
-```php
-public function getSettingsFields()
-{
-    return array(
-        [
-            'key'        => 'header',
-            'label'      => 'Header Content',
-            'tips'       => 'Write your header content which will be shown every page of the PDF',
-            'component'  => 'text'
-        ],
-        [
-            'key'       => 'body',
-            'label'     => 'PDF Body Content',
-            'tips'      => 'Write your Body content for actual PDF body',
-            'component' => 'wp-editor'
-        ],
-        [
-            'key'       => 'footer',
-            'label'     => 'Footer Content',
-            'tips'      => 'Write your Footer content which will be shown every page of the PDF',
-            'component' => 'wp-editor'
-        ],
-        [
-            'key'       => 'demo',
-            'label'     => 'Demo Input',
-            'tips'      => 'Input Help Text',
-            'component' => 'text'
-        ],
-
-
-    );
-}
-```
-
-The filed `tips` will show the additional help text on hover, this method is almost identical to `getSettingsFields()` in the [Integration Manager Controller Class](/api/classes/integration-manager-controller/#getsettingsfields).
-
-Here is a screenshot of the above code :
-
-<img :src="$withBase('/assets/img/modules/custom-pdf-template.png')" alt="Fluent Custom PDF Templates" />
+---
 
 ### generatePdf()
 This is the most important method where the PDF will be generated. You will get four parameters here :
@@ -238,3 +179,98 @@ add_action('plugins_loaded', function () {
 ```
 
 You can include more classes and add new templates using this method. If you have any query feel free to reach our [support team](https://wpmanageninja.com/support-tickets/) or ask questions in our [facebook community group](https://www.facebook.com/groups/fluentforms/). Also do not forget to share your thoughts on this documentation, by adding your comment or a click on the icons below.
+
+### getDefaultSettings()
+This method will store the default settings of the PDF template. You will need to return array of the settings key & value.
+```php
+    public function getDefaultSettings()
+    {
+        return [
+            'header' => '<h2>Hello From My Demo Template</h2>',
+            'footer' => '<p>Footer</p>',
+            'body'   => 'Hello There',
+            'demo'   => ''
+        ];
+    }
+```
+
+### `getGenerator($mpdfConfig)`
+
+**Source:** `fluentforms-pdf/Modules/FluentForms/Templates/TemplateManager.php` (line 66)
+
+---
+
+### `getPdfCss($appearance)`
+
+**Source:** `fluentforms-pdf/Modules/FluentForms/Templates/TemplateManager.php` (line 208)
+
+---
+
+### getSettingsFields()
+This method will render input fields for the PDF template settings page, based on the returned data. The key value used in these fields needs to match with the [getDefaultSettings()](/api/classes/pdf-template-manager/#getdefaultsettings)
+
+You can use the prebuilt input components to create your settings page, here is a documentation [link](https://fluentforms.com/docs/integration-feed-fields-api/) where you can find the details list about these input component.
+
+Required properties for the fields array:
+- `key` : Settings Unique Key
+- `label` : Settings Input Label
+- `component` : Pass to prebuild input component.
+
+Here is example of this method:
+```php
+public function getSettingsFields()
+{
+    return array(
+        [
+            'key'        => 'header',
+            'label'      => 'Header Content',
+            'tips'       => 'Write your header content which will be shown every page of the PDF',
+            'component'  => 'text'
+        ],
+        [
+            'key'       => 'body',
+            'label'     => 'PDF Body Content',
+            'tips'      => 'Write your Body content for actual PDF body',
+            'component' => 'wp-editor'
+        ],
+        [
+            'key'       => 'footer',
+            'label'     => 'Footer Content',
+            'tips'      => 'Write your Footer content which will be shown every page of the PDF',
+            'component' => 'wp-editor'
+        ],
+        [
+            'key'       => 'demo',
+            'label'     => 'Demo Input',
+            'tips'      => 'Input Help Text',
+            'component' => 'text'
+        ],
+
+    );
+}
+```
+
+The filed `tips` will show the additional help text on hover, this method is almost identical to `getSettingsFields()` in the [Integration Manager Controller Class](/api/classes/integration-manager-controller/#getsettingsfields).
+
+Here is a screenshot of the above code :
+
+<img :src="$withBase('/assets/img/modules/custom-pdf-template.png')" alt="Fluent Custom PDF Templates" />
+
+### `outputPDF($submissionId, $settings, $fileName = '', $forceClear = false)`
+
+**Source:** `fluentforms-pdf/Modules/FluentForms/Templates/TemplateManager.php` (line 45)
+
+---
+
+### `pdfBuilder($fileName, $feed, $body = '', $footer = '', $outPut = 'I')`
+
+**Source:** `fluentforms-pdf/Modules/FluentForms/Templates/TemplateManager.php` (line 127)
+
+---
+
+### `viewPDF($submissionId, $settings)`
+
+**Source:** `fluentforms-pdf/Modules/FluentForms/Templates/TemplateManager.php` (line 40)
+
+---
+

--- a/src/api/endpoints/README.md
+++ b/src/api/endpoints/README.md
@@ -1,0 +1,28 @@
+# REST API Endpoints
+
+<Badge type="tip" vertical="top" text="REST API" /> <Badge type="warning" vertical="top" text="Auto-extracted" />
+
+Reference for every route registered in `app/Http/Routes/api.php`. Each row links to its group page.
+
+Base URL: `https://your-site.com/wp-json/fluentform/v1/`
+Auth: `X-WP-Nonce` header (admin REST nonce)
+PUT/PATCH/DELETE sent as POST with `X-HTTP-Method-Override` header.
+
+**Total endpoints:** 84 across 14 groups.
+
+| Group | Endpoints |
+|-------|----------:|
+| [analytics](./analytics.md) | 1 |
+| [form-submit](./form-submit.md) | 1 |
+| [forms](./forms.md) | 16 |
+| [global-search](./global-search.md) | 1 |
+| [global-settings](./global-settings.md) | 2 |
+| [integrations](./integrations.md) | 8 |
+| [logs](./logs.md) | 3 |
+| [managers](./managers.md) | 4 |
+| [notice](./notice.md) | 1 |
+| [report](./report.md) | 15 |
+| [roles](./roles.md) | 2 |
+| [settings](./settings.md) | 12 |
+| [submissions](./submissions.md) | 15 |
+| [suggested-plugins](./suggested-plugins.md) | 3 |

--- a/src/api/endpoints/analytics.md
+++ b/src/api/endpoints/analytics.md
@@ -1,0 +1,21 @@
+# Analytics — REST Endpoints
+
+<Badge type="tip" vertical="top" text="REST API" /> <Badge type="warning" vertical="top" text="1 Endpoints" />
+
+All endpoints under `/wp-json/fluentform/v1/analytics/...`. Auto-extracted from `app/Http/Routes/api.php`.
+
+Auth: `X-WP-Nonce` header. PUT/PATCH/DELETE sent as POST with `X-HTTP-Method-Override` header.
+
+### `POST` `/wp-json/fluentform/v1/analytics/{form_id}/reset`
+
+- **Controller:** `AnalyticsController@reset`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 142
+
+```bash
+curl -X POST \
+  'https://your-site.com/wp-json/fluentform/v1/analytics/{form_id}/reset' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+

--- a/src/api/endpoints/form-submit.md
+++ b/src/api/endpoints/form-submit.md
@@ -1,0 +1,21 @@
+# Form Submit — REST Endpoints
+
+<Badge type="tip" vertical="top" text="REST API" /> <Badge type="warning" vertical="top" text="1 Endpoints" />
+
+All endpoints under `/wp-json/fluentform/v1/form-submit/...`. Auto-extracted from `app/Http/Routes/api.php`.
+
+Auth: `X-WP-Nonce` header. PUT/PATCH/DELETE sent as POST with `X-HTTP-Method-Override` header.
+
+### `POST` `/wp-json/fluentform/v1/form-submit`
+
+- **Controller:** `SubmissionHandlerController@submit`
+- **Policy:** `—`
+- **Source:** `app/Http/Routes/api.php` line 148
+
+```bash
+curl -X POST \
+  'https://your-site.com/wp-json/fluentform/v1/form-submit' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+

--- a/src/api/endpoints/forms.md
+++ b/src/api/endpoints/forms.md
@@ -1,0 +1,216 @@
+# Forms — REST Endpoints
+
+<Badge type="tip" vertical="top" text="REST API" /> <Badge type="warning" vertical="top" text="16 Endpoints" />
+
+All endpoints under `/wp-json/fluentform/v1/forms/...`. Auto-extracted from `app/Http/Routes/api.php`.
+
+Auth: `X-WP-Nonce` header. PUT/PATCH/DELETE sent as POST with `X-HTTP-Method-Override` header.
+
+### `GET` `/wp-json/fluentform/v1/forms`
+
+- **Controller:** `FormController@index`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 13
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/forms' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `POST` `/wp-json/fluentform/v1/forms`
+
+- **Controller:** `FormController@store`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 14
+
+```bash
+curl -X POST \
+  'https://your-site.com/wp-json/fluentform/v1/forms' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/forms/ping`
+
+- **Controller:** `FormController@ping`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 16
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/forms/ping' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/forms/templates`
+
+- **Controller:** `FormController@templates`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 15
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/forms/templates' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `DELETE` `/wp-json/fluentform/v1/forms/{form_id}`
+
+- **Controller:** `FormController@delete`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 21
+
+```bash
+curl -X DELETE \
+  'https://your-site.com/wp-json/fluentform/v1/forms/{form_id}' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/forms/{form_id}`
+
+- **Controller:** `FormController@find`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 19
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/forms/{form_id}' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `POST` `/wp-json/fluentform/v1/forms/{form_id}`
+
+- **Controller:** `FormController@update`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 20
+
+```bash
+curl -X POST \
+  'https://your-site.com/wp-json/fluentform/v1/forms/{form_id}' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `POST` `/wp-json/fluentform/v1/forms/{form_id}/clearHistory`
+
+- **Controller:** `FormController@clearEditHistory`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 30
+
+```bash
+curl -X POST \
+  'https://your-site.com/wp-json/fluentform/v1/forms/{form_id}/clearHistory' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `POST` `/wp-json/fluentform/v1/forms/{form_id}/convert`
+
+- **Controller:** `FormController@convert`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 23
+
+```bash
+curl -X POST \
+  'https://your-site.com/wp-json/fluentform/v1/forms/{form_id}/convert' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `POST` `/wp-json/fluentform/v1/forms/{form_id}/duplicate`
+
+- **Controller:** `FormController@duplicate`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 22
+
+```bash
+curl -X POST \
+  'https://your-site.com/wp-json/fluentform/v1/forms/{form_id}/duplicate' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/forms/{form_id}/editHistory`
+
+- **Controller:** `FormController@formEditHistory`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 29
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/forms/{form_id}/editHistory' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/forms/{form_id}/fields`
+
+- **Controller:** `FormController@fields`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 26
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/forms/{form_id}/fields' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/forms/{form_id}/findShortCodePage`
+
+- **Controller:** `FormController@findShortCodePage`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 28
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/forms/{form_id}/findShortCodePage' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/forms/{form_id}/pages`
+
+- **Controller:** `FormController@pages`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 25
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/forms/{form_id}/pages' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/forms/{form_id}/resources`
+
+- **Controller:** `FormController@resources`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 24
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/forms/{form_id}/resources' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/forms/{form_id}/shortcodes`
+
+- **Controller:** `FormController@shortcodes`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 27
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/forms/{form_id}/shortcodes' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+

--- a/src/api/endpoints/global-search.md
+++ b/src/api/endpoints/global-search.md
@@ -1,0 +1,21 @@
+# Global Search — REST Endpoints
+
+<Badge type="tip" vertical="top" text="REST API" /> <Badge type="warning" vertical="top" text="1 Endpoints" />
+
+All endpoints under `/wp-json/fluentform/v1/global-search/...`. Auto-extracted from `app/Http/Routes/api.php`.
+
+Auth: `X-WP-Nonce` header. PUT/PATCH/DELETE sent as POST with `X-HTTP-Method-Override` header.
+
+### `GET` `/wp-json/fluentform/v1/global-search`
+
+- **Controller:** `GlobalSearchController@index`
+- **Policy:** `—`
+- **Source:** `app/Http/Routes/api.php` line 180
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/global-search' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+

--- a/src/api/endpoints/global-settings.md
+++ b/src/api/endpoints/global-settings.md
@@ -1,0 +1,34 @@
+# Global Settings — REST Endpoints
+
+<Badge type="tip" vertical="top" text="REST API" /> <Badge type="warning" vertical="top" text="2 Endpoints" />
+
+All endpoints under `/wp-json/fluentform/v1/global-settings/...`. Auto-extracted from `app/Http/Routes/api.php`.
+
+Auth: `X-WP-Nonce` header. PUT/PATCH/DELETE sent as POST with `X-HTTP-Method-Override` header.
+
+### `GET` `/wp-json/fluentform/v1/global-settings`
+
+- **Controller:** `GlobalSettingsController@index`
+- **Policy:** `GlobalSettingsPolicy`
+- **Source:** `app/Http/Routes/api.php` line 117
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/global-settings' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `POST` `/wp-json/fluentform/v1/global-settings`
+
+- **Controller:** `GlobalSettingsController@store`
+- **Policy:** `GlobalSettingsPolicy`
+- **Source:** `app/Http/Routes/api.php` line 118
+
+```bash
+curl -X POST \
+  'https://your-site.com/wp-json/fluentform/v1/global-settings' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+

--- a/src/api/endpoints/integrations.md
+++ b/src/api/endpoints/integrations.md
@@ -1,0 +1,112 @@
+# Integrations — REST Endpoints
+
+<Badge type="tip" vertical="top" text="REST API" /> <Badge type="warning" vertical="top" text="8 Endpoints" />
+
+All endpoints under `/wp-json/fluentform/v1/integrations/...`. Auto-extracted from `app/Http/Routes/api.php`.
+
+Auth: `X-WP-Nonce` header. PUT/PATCH/DELETE sent as POST with `X-HTTP-Method-Override` header.
+
+### `GET` `/wp-json/fluentform/v1/integrations`
+
+- **Controller:** `GlobalIntegrationController@index`
+- **Policy:** `—`
+- **Source:** `app/Http/Routes/api.php` line 97
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/integrations' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `POST` `/wp-json/fluentform/v1/integrations`
+
+- **Controller:** `GlobalIntegrationController@updateIntegration`
+- **Policy:** `—`
+- **Source:** `app/Http/Routes/api.php` line 98
+
+```bash
+curl -X POST \
+  'https://your-site.com/wp-json/fluentform/v1/integrations' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `POST` `/wp-json/fluentform/v1/integrations/update-status`
+
+- **Controller:** `GlobalIntegrationController@updateModuleStatus`
+- **Policy:** `—`
+- **Source:** `app/Http/Routes/api.php` line 99
+
+```bash
+curl -X POST \
+  'https://your-site.com/wp-json/fluentform/v1/integrations/update-status' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `DELETE` `/wp-json/fluentform/v1/integrations/{form_id}`
+
+- **Controller:** `FormIntegrationController@delete`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 108
+
+```bash
+curl -X DELETE \
+  'https://your-site.com/wp-json/fluentform/v1/integrations/{form_id}' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/integrations/{form_id}`
+
+- **Controller:** `FormIntegrationController@find`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 106
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/integrations/{form_id}' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `POST` `/wp-json/fluentform/v1/integrations/{form_id}`
+
+- **Controller:** `FormIntegrationController@update`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 107
+
+```bash
+curl -X POST \
+  'https://your-site.com/wp-json/fluentform/v1/integrations/{form_id}' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/integrations/{form_id}/form-integrations`
+
+- **Controller:** `FormIntegrationController@index`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 105
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/integrations/{form_id}/form-integrations' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/integrations/{form_id}/integration-list-id`
+
+- **Controller:** `FormIntegrationController@integrationListComponent`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 110
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/integrations/{form_id}/integration-list-id' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+

--- a/src/api/endpoints/logs.md
+++ b/src/api/endpoints/logs.md
@@ -1,0 +1,47 @@
+# Logs — REST Endpoints
+
+<Badge type="tip" vertical="top" text="REST API" /> <Badge type="warning" vertical="top" text="3 Endpoints" />
+
+All endpoints under `/wp-json/fluentform/v1/logs/...`. Auto-extracted from `app/Http/Routes/api.php`.
+
+Auth: `X-WP-Nonce` header. PUT/PATCH/DELETE sent as POST with `X-HTTP-Method-Override` header.
+
+### `DELETE` `/wp-json/fluentform/v1/logs`
+
+- **Controller:** `LogController@remove`
+- **Policy:** `SubmissionPolicy`
+- **Source:** `app/Http/Routes/api.php` line 90
+
+```bash
+curl -X DELETE \
+  'https://your-site.com/wp-json/fluentform/v1/logs' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/logs`
+
+- **Controller:** `LogController@get`
+- **Policy:** `SubmissionPolicy`
+- **Source:** `app/Http/Routes/api.php` line 89
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/logs' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/logs/filters`
+
+- **Controller:** `LogController@getFilters`
+- **Policy:** `SubmissionPolicy`
+- **Source:** `app/Http/Routes/api.php` line 91
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/logs/filters' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+

--- a/src/api/endpoints/managers.md
+++ b/src/api/endpoints/managers.md
@@ -1,0 +1,60 @@
+# Managers — REST Endpoints
+
+<Badge type="tip" vertical="top" text="REST API" /> <Badge type="warning" vertical="top" text="4 Endpoints" />
+
+All endpoints under `/wp-json/fluentform/v1/managers/...`. Auto-extracted from `app/Http/Routes/api.php`.
+
+Auth: `X-WP-Nonce` header. PUT/PATCH/DELETE sent as POST with `X-HTTP-Method-Override` header.
+
+### `DELETE` `/wp-json/fluentform/v1/managers`
+
+- **Controller:** `ManagersController@removeManager`
+- **Policy:** `RoleManagerPolicy`
+- **Source:** `app/Http/Routes/api.php` line 133
+
+```bash
+curl -X DELETE \
+  'https://your-site.com/wp-json/fluentform/v1/managers' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/managers`
+
+- **Controller:** `ManagersController@index`
+- **Policy:** `RoleManagerPolicy`
+- **Source:** `app/Http/Routes/api.php` line 131
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/managers' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `POST` `/wp-json/fluentform/v1/managers`
+
+- **Controller:** `ManagersController@addManager`
+- **Policy:** `RoleManagerPolicy`
+- **Source:** `app/Http/Routes/api.php` line 132
+
+```bash
+curl -X POST \
+  'https://your-site.com/wp-json/fluentform/v1/managers' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/managers/users`
+
+- **Controller:** `ManagersController@getUsers`
+- **Policy:** `RoleManagerPolicy`
+- **Source:** `app/Http/Routes/api.php` line 134
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/managers/users' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+

--- a/src/api/endpoints/notice.md
+++ b/src/api/endpoints/notice.md
@@ -1,0 +1,21 @@
+# Notice — REST Endpoints
+
+<Badge type="tip" vertical="top" text="REST API" /> <Badge type="warning" vertical="top" text="1 Endpoints" />
+
+All endpoints under `/wp-json/fluentform/v1/notice/...`. Auto-extracted from `app/Http/Routes/api.php`.
+
+Auth: `X-WP-Nonce` header. PUT/PATCH/DELETE sent as POST with `X-HTTP-Method-Override` header.
+
+### `POST` `/wp-json/fluentform/v1/notice`
+
+- **Controller:** `AdminNoticeController@noticeActions`
+- **Policy:** `—`
+- **Source:** `app/Http/Routes/api.php` line 175
+
+```bash
+curl -X POST \
+  'https://your-site.com/wp-json/fluentform/v1/notice' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+

--- a/src/api/endpoints/report.md
+++ b/src/api/endpoints/report.md
@@ -1,0 +1,203 @@
+# Report — REST Endpoints
+
+<Badge type="tip" vertical="top" text="REST API" /> <Badge type="warning" vertical="top" text="15 Endpoints" />
+
+All endpoints under `/wp-json/fluentform/v1/report/...`. Auto-extracted from `app/Http/Routes/api.php`.
+
+Auth: `X-WP-Nonce` header. PUT/PATCH/DELETE sent as POST with `X-HTTP-Method-Override` header.
+
+### `GET` `/wp-json/fluentform/v1/report/api-logs`
+
+- **Controller:** `ReportController@getApiLogs`
+- **Policy:** `ReportPolicy`
+- **Source:** `app/Http/Routes/api.php` line 160
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/report/api-logs' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/report/completion-rate`
+
+- **Controller:** `ReportController@getCompletionRate`
+- **Policy:** `ReportPolicy`
+- **Source:** `app/Http/Routes/api.php` line 156
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/report/completion-rate' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/report/country-heatmap`
+
+- **Controller:** `ReportController@getCountryHeatmap`
+- **Policy:** `ReportPolicy`
+- **Source:** `app/Http/Routes/api.php` line 159
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/report/country-heatmap' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/report/form-stats`
+
+- **Controller:** `ReportController@getFormStats`
+- **Policy:** `ReportPolicy`
+- **Source:** `app/Http/Routes/api.php` line 157
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/report/form-stats' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/report/forms/{form_id}`
+
+- **Controller:** `ReportController@form`
+- **Policy:** `ReportPolicy`
+- **Source:** `app/Http/Routes/api.php` line 170
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/report/forms/{form_id}' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/report/heatmap-data`
+
+- **Controller:** `ReportController@getHeatmapData`
+- **Policy:** `ReportPolicy`
+- **Source:** `app/Http/Routes/api.php` line 158
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/report/heatmap-data' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/report/net-revenue`
+
+- **Controller:** `ReportController@netRevenue`
+- **Policy:** `ReportPolicy`
+- **Source:** `app/Http/Routes/api.php` line 167
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/report/net-revenue' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/report/overview-chart`
+
+- **Controller:** `ReportController@getOverviewChart`
+- **Policy:** `ReportPolicy`
+- **Source:** `app/Http/Routes/api.php` line 154
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/report/overview-chart' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/report/payment-types`
+
+- **Controller:** `ReportController@getPaymentTypes`
+- **Policy:** `ReportPolicy`
+- **Source:** `app/Http/Routes/api.php` line 163
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/report/payment-types' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/report/revenue-chart`
+
+- **Controller:** `ReportController@getRevenueChart`
+- **Policy:** `ReportPolicy`
+- **Source:** `app/Http/Routes/api.php` line 155
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/report/revenue-chart' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/report/select-forms`
+
+- **Controller:** `ReportController@getFormsDropdown`
+- **Policy:** `ReportPolicy`
+- **Source:** `app/Http/Routes/api.php` line 166
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/report/select-forms' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `POST` `/wp-json/fluentform/v1/report/submissions`
+
+- **Controller:** `ReportController@submissions`
+- **Policy:** `ReportPolicy`
+- **Source:** `app/Http/Routes/api.php` line 169
+
+```bash
+curl -X POST \
+  'https://your-site.com/wp-json/fluentform/v1/report/submissions' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/report/submissions-analysis`
+
+- **Controller:** `ReportController@submissionsAnalysis`
+- **Policy:** `ReportPolicy`
+- **Source:** `app/Http/Routes/api.php` line 168
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/report/submissions-analysis' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/report/subscriptions`
+
+- **Controller:** `ReportController@getSubscriptions`
+- **Policy:** `ReportPolicy`
+- **Source:** `app/Http/Routes/api.php` line 162
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/report/subscriptions' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/report/top-performing-forms`
+
+- **Controller:** `ReportController@getTopPerformingForms`
+- **Policy:** `ReportPolicy`
+- **Source:** `app/Http/Routes/api.php` line 161
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/report/top-performing-forms' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+

--- a/src/api/endpoints/roles.md
+++ b/src/api/endpoints/roles.md
@@ -1,0 +1,34 @@
+# Roles — REST Endpoints
+
+<Badge type="tip" vertical="top" text="REST API" /> <Badge type="warning" vertical="top" text="2 Endpoints" />
+
+All endpoints under `/wp-json/fluentform/v1/roles/...`. Auto-extracted from `app/Http/Routes/api.php`.
+
+Auth: `X-WP-Nonce` header. PUT/PATCH/DELETE sent as POST with `X-HTTP-Method-Override` header.
+
+### `GET` `/wp-json/fluentform/v1/roles`
+
+- **Controller:** `RolesController@index`
+- **Policy:** `RoleManagerPolicy`
+- **Source:** `app/Http/Routes/api.php` line 124
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/roles' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `POST` `/wp-json/fluentform/v1/roles`
+
+- **Controller:** `RolesController@addCapability`
+- **Policy:** `RoleManagerPolicy`
+- **Source:** `app/Http/Routes/api.php` line 125
+
+```bash
+curl -X POST \
+  'https://your-site.com/wp-json/fluentform/v1/roles' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+

--- a/src/api/endpoints/settings.md
+++ b/src/api/endpoints/settings.md
@@ -1,0 +1,164 @@
+# Settings — REST Endpoints
+
+<Badge type="tip" vertical="top" text="REST API" /> <Badge type="warning" vertical="top" text="12 Endpoints" />
+
+All endpoints under `/wp-json/fluentform/v1/settings/...`. Auto-extracted from `app/Http/Routes/api.php`.
+
+Auth: `X-WP-Nonce` header. PUT/PATCH/DELETE sent as POST with `X-HTTP-Method-Override` header.
+
+### `DELETE` `/wp-json/fluentform/v1/settings/{form_id}`
+
+- **Controller:** `FormSettingsController@remove`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 41
+
+```bash
+curl -X DELETE \
+  'https://your-site.com/wp-json/fluentform/v1/settings/{form_id}' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/settings/{form_id}`
+
+- **Controller:** `FormSettingsController@index`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 39
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/settings/{form_id}' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `POST` `/wp-json/fluentform/v1/settings/{form_id}`
+
+- **Controller:** `FormSettingsController@store`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 40
+
+```bash
+curl -X POST \
+  'https://your-site.com/wp-json/fluentform/v1/settings/{form_id}' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/settings/{form_id}/conversational-design`
+
+- **Controller:** `FormSettingsController@conversationalDesign`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 51
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/settings/{form_id}/conversational-design' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/settings/{form_id}/customizer`
+
+- **Controller:** `FormSettingsController@customizer`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 46
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/settings/{form_id}/customizer' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `POST` `/wp-json/fluentform/v1/settings/{form_id}/customizer`
+
+- **Controller:** `FormSettingsController@storeCustomizer`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 47
+
+```bash
+curl -X POST \
+  'https://your-site.com/wp-json/fluentform/v1/settings/{form_id}/customizer' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `POST` `/wp-json/fluentform/v1/settings/{form_id}/entry-columns`
+
+- **Controller:** `FormSettingsController@storeEntryColumns`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 49
+
+```bash
+curl -X POST \
+  'https://your-site.com/wp-json/fluentform/v1/settings/{form_id}/entry-columns' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/settings/{form_id}/general`
+
+- **Controller:** `FormSettingsController@general`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 43
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/settings/{form_id}/general' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `POST` `/wp-json/fluentform/v1/settings/{form_id}/general`
+
+- **Controller:** `FormSettingsController@saveGeneral`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 44
+
+```bash
+curl -X POST \
+  'https://your-site.com/wp-json/fluentform/v1/settings/{form_id}/general' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/settings/{form_id}/preset`
+
+- **Controller:** `FormSettingsController@getPreset`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 53
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/settings/{form_id}/preset' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `POST` `/wp-json/fluentform/v1/settings/{form_id}/save-preset`
+
+- **Controller:** `FormSettingsController@savePreset`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 54
+
+```bash
+curl -X POST \
+  'https://your-site.com/wp-json/fluentform/v1/settings/{form_id}/save-preset' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `POST` `/wp-json/fluentform/v1/settings/{form_id}/store-conversational-design`
+
+- **Controller:** `FormSettingsController@storeConversationalDesign`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 52
+
+```bash
+curl -X POST \
+  'https://your-site.com/wp-json/fluentform/v1/settings/{form_id}/store-conversational-design' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+

--- a/src/api/endpoints/submissions.md
+++ b/src/api/endpoints/submissions.md
@@ -1,0 +1,203 @@
+# Submissions — REST Endpoints
+
+<Badge type="tip" vertical="top" text="REST API" /> <Badge type="warning" vertical="top" text="15 Endpoints" />
+
+All endpoints under `/wp-json/fluentform/v1/submissions/...`. Auto-extracted from `app/Http/Routes/api.php`.
+
+Auth: `X-WP-Nonce` header. PUT/PATCH/DELETE sent as POST with `X-HTTP-Method-Override` header.
+
+### `GET` `/wp-json/fluentform/v1/submissions`
+
+- **Controller:** `SubmissionController@index`
+- **Policy:** `SubmissionPolicy`
+- **Source:** `app/Http/Routes/api.php` line 61
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/submissions' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/submissions/all`
+
+- **Controller:** `SubmissionController@all`
+- **Policy:** `SubmissionPolicy`
+- **Source:** `app/Http/Routes/api.php` line 65
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/submissions/all' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `POST` `/wp-json/fluentform/v1/submissions/bulk-actions`
+
+- **Controller:** `SubmissionController@handleBulkActions`
+- **Policy:** `SubmissionPolicy`
+- **Source:** `app/Http/Routes/api.php` line 63
+
+```bash
+curl -X POST \
+  'https://your-site.com/wp-json/fluentform/v1/submissions/bulk-actions' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/submissions/print`
+
+- **Controller:** `SubmissionController@print`
+- **Policy:** `SubmissionPolicy`
+- **Source:** `app/Http/Routes/api.php` line 64
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/submissions/print' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/submissions/resources`
+
+- **Controller:** `SubmissionController@resources`
+- **Policy:** `SubmissionPolicy`
+- **Source:** `app/Http/Routes/api.php` line 62
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/submissions/resources' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `DELETE` `/wp-json/fluentform/v1/submissions/{entry_id}`
+
+- **Controller:** `SubmissionController@remove`
+- **Policy:** `SubmissionPolicy`
+- **Source:** `app/Http/Routes/api.php` line 66
+
+```bash
+curl -X DELETE \
+  'https://your-site.com/wp-json/fluentform/v1/submissions/{entry_id}' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/submissions/{entry_id}`
+
+- **Controller:** `SubmissionController@find`
+- **Policy:** `SubmissionPolicy`
+- **Source:** `app/Http/Routes/api.php` line 69
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/submissions/{entry_id}' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `POST` `/wp-json/fluentform/v1/submissions/{entry_id}/is-favorite`
+
+- **Controller:** `SubmissionController@toggleIsFavorite`
+- **Policy:** `SubmissionPolicy`
+- **Source:** `app/Http/Routes/api.php` line 72
+
+```bash
+curl -X POST \
+  'https://your-site.com/wp-json/fluentform/v1/submissions/{entry_id}/is-favorite' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `DELETE` `/wp-json/fluentform/v1/submissions/{entry_id}/logs`
+
+- **Controller:** `SubmissionLogController@remove`
+- **Policy:** `SubmissionPolicy`
+- **Source:** `app/Http/Routes/api.php` line 75
+
+```bash
+curl -X DELETE \
+  'https://your-site.com/wp-json/fluentform/v1/submissions/{entry_id}/logs' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/submissions/{entry_id}/logs`
+
+- **Controller:** `SubmissionLogController@get`
+- **Policy:** `SubmissionPolicy`
+- **Source:** `app/Http/Routes/api.php` line 74
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/submissions/{entry_id}/logs' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/submissions/{entry_id}/notes`
+
+- **Controller:** `SubmissionNoteController@get`
+- **Policy:** `SubmissionPolicy`
+- **Source:** `app/Http/Routes/api.php` line 77
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/submissions/{entry_id}/notes' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `POST` `/wp-json/fluentform/v1/submissions/{entry_id}/notes`
+
+- **Controller:** `SubmissionNoteController@store`
+- **Policy:** `SubmissionPolicy`
+- **Source:** `app/Http/Routes/api.php` line 78
+
+```bash
+curl -X POST \
+  'https://your-site.com/wp-json/fluentform/v1/submissions/{entry_id}/notes' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `POST` `/wp-json/fluentform/v1/submissions/{entry_id}/status`
+
+- **Controller:** `SubmissionController@updateStatus`
+- **Policy:** `SubmissionPolicy`
+- **Source:** `app/Http/Routes/api.php` line 71
+
+```bash
+curl -X POST \
+  'https://your-site.com/wp-json/fluentform/v1/submissions/{entry_id}/status' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `GET` `/wp-json/fluentform/v1/submissions/{entry_id}/submission-users`
+
+- **Controller:** `SubmissionController@submissionUsers`
+- **Policy:** `SubmissionPolicy`
+- **Source:** `app/Http/Routes/api.php` line 80
+
+```bash
+curl -X GET \
+  'https://your-site.com/wp-json/fluentform/v1/submissions/{entry_id}/submission-users' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `POST` `/wp-json/fluentform/v1/submissions/{entry_id}/update-submission-user`
+
+- **Controller:** `SubmissionController@updateSubmissionUser`
+- **Policy:** `SubmissionPolicy`
+- **Source:** `app/Http/Routes/api.php` line 81
+
+```bash
+curl -X POST \
+  'https://your-site.com/wp-json/fluentform/v1/submissions/{entry_id}/update-submission-user' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+

--- a/src/api/endpoints/suggested-plugins.md
+++ b/src/api/endpoints/suggested-plugins.md
@@ -1,0 +1,47 @@
+# Suggested Plugins — REST Endpoints
+
+<Badge type="tip" vertical="top" text="REST API" /> <Badge type="warning" vertical="top" text="3 Endpoints" />
+
+All endpoints under `/wp-json/fluentform/v1/suggested-plugins/...`. Auto-extracted from `app/Http/Routes/api.php`.
+
+Auth: `X-WP-Nonce` header. PUT/PATCH/DELETE sent as POST with `X-HTTP-Method-Override` header.
+
+### `POST` `/wp-json/fluentform/v1/suggested-plugins/activate-plugin`
+
+- **Controller:** `SuggestedPluginsController@activatePlugin`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 188
+
+```bash
+curl -X POST \
+  'https://your-site.com/wp-json/fluentform/v1/suggested-plugins/activate-plugin' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `POST` `/wp-json/fluentform/v1/suggested-plugins/check-plugin-statuses`
+
+- **Controller:** `SuggestedPluginsController@checkPluginStatuses`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 186
+
+```bash
+curl -X POST \
+  'https://your-site.com/wp-json/fluentform/v1/suggested-plugins/check-plugin-statuses' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+
+### `POST` `/wp-json/fluentform/v1/suggested-plugins/install-plugin`
+
+- **Controller:** `SuggestedPluginsController@installPlugin`
+- **Policy:** `FormPolicy`
+- **Source:** `app/Http/Routes/api.php` line 187
+
+```bash
+curl -X POST \
+  'https://your-site.com/wp-json/fluentform/v1/suggested-plugins/install-plugin' \
+  -H 'X-WP-Nonce: <nonce>' \
+  -H 'Content-Type: application/json'
+```
+

--- a/src/api/extending-rest-api/index.md
+++ b/src/api/extending-rest-api/index.md
@@ -129,9 +129,6 @@ public function create()
 }
 ```
 
-
-
-
 ## Policies
 Policies are classes that are used to authorize requests to routes. 
 The `verifyRequest` method is used to check if the current user has permission to access a route or method.
@@ -167,7 +164,6 @@ class MyPolicy extends Policy
 }
 
 ```
-
 
 ## Directory Structure
 Your directory structure may look something like this:

--- a/src/changelog/index.md
+++ b/src/changelog/index.md
@@ -1,0 +1,154 @@
+---
+editLink: false
+---
+
+# Changelog
+
+Flat per-release notes for Fluent Forms Free and Pro. For deeper migration / developer guidance, see the [Upgrade Guide](/upgrade-guide/6.2.0/).
+
+---
+
+## 6.2.3 — May 21, 2026
+
+### Free plugin
+
+- Adds option-group support for Dropdown and Multi-select fields
+- Adds pinned-column support in the entries table
+- Adds new icon presets, SVG icon support, and active/inactive color options for the Ratings field
+- Adds search to the form switcher in entries
+- Improves keyboard navigation in the entries table
+- Improves accessibility for fixed columns and action buttons in entries
+- Updates DOMPurify, PostCSS, and the Babel transform helper to address security vulnerabilities (CVE-2026-44728)
+- Fixes conditional logic settings not showing for custom fields in the editor
+- Fixes conditional logic not-equal check when the target field has no value
+- Fixes Name field layout when a sub-field has no label
+- Fixes text and list formatting differences between the editor and preview
+- Fixes AI form builder losing field hints for non-English prompts
+- Fixes missing submission date in Excel exports
+- Fixes garbled export filenames for forms with non-Latin titles
+- Fixes form import breaking confirmation and notification settings
+- Fixes the Find feature missing forms inside page-builder popups
+- Fixes entries not sorting by actual submission date
+- Fixes form import corrupting custom CSS and JavaScript code
+- Fixes visual artifacts in the collapsed form-settings sidebar
+- Fixes Global Settings sidebar collapse toggle not working on desktop
+- Fixes the Excel export option incorrectly labeled as xlsv
+- Fixes entry Next and Previous navigation breaking on sites that use a custom DB table prefix
+- Fixes fatal error when a Textarea field receives an array value during submission processing
+- Fixes multi-word Google Fonts not loading in conversational forms
+- Fixes `textdomain_just_in_time` notice on WordPress 6.7 and later, including WP Staging staging environments
+- Fixes several strings that could not be translated on non-English admin sites
+- Fixes the Entries page label showing garbled text on German-language sites
+- Fixes confirmation redirect URL losing query-string values with encoded characters
+
+### Pro plugin
+
+- Adds Tabs style for multi-step forms with Top and Left layouts, clickable step navigation, and a compact progress bar option
+- Adds a new Ranking field for ranking options by drag and drop in list or grid layout with quiz and report support
+- Adds PayPal Orders API v2 and Subscriptions API support
+- Adds image cropping for file upload fields with ratio and exact-dimension options
+- Adds pretty URL support for Landing Page and Conversational Form share pages
+- Adds keyboard shortcut support for saving form settings
+- Improves Conversational Form share options with email and embed copy buttons
+- Improves Landing Page share settings
+- Improves the Advanced Entries Filter UX with cleaner labels, grouped operators, and tidier value inputs
+- Improves the Advanced Entries Filter to support not-in and not-equal operators
+- Upgrades HubSpot integration to CRM v3 and Lists v3 APIs
+- Fixes custom radio and checkbox styles not rendering correctly on Safari and iOS
+- Fixes payment status filter on translated admin sites
+- Fixes ACF grouped fields not showing in post feed mapping
+- Fixes Google Sheets integration failing when a worksheet name contains special characters
+- Fixes repeater field including non-input fields in its response table
+- Fixes HubSpot checkbox values being sent with an extra semicolon
+- Fixes long HubSpot custom field labels being cut off in the settings dropdown
+- Fixes taxonomy field showing IDs instead of names in entries and notifications
+- Fixes AmoCRM OAuth redirect for amocrm.ru users
+- Fixes subscription description showing recurring text when billing is set to once with a signup fee
+- Fixes Landing Page media-left layout cutting off form fields
+- Fixes Save Progress email not respecting SMTP plugin reply-to settings
+- Fixes Authorize.Net treating held-for-review payments as failures
+- Fixes Authorize.Net payment failing due to phone number validation
+- Fixes HubSpot field mapping incorrectly converting text values to dates
+- Fixes Dynamic field startsWith and endsWith filter options being swapped
+- Fixes Advanced entries filter returning no results for numeric, date, and text searches
+- Fixes italic text not rendering in custom HTML fields in conversational forms
+- Fixes multi-word Google Fonts not loading in conversational forms
+- Fixes save-and-resume drafts being visible across logged-in users on shared accounts
+- Fixes Pipedrive Persons feed duplicating the Marketing Status field
+- Fixes Pipedrive failing the API call when Marketing Status is set to No Consent
+- Fixes Pipedrive integration error when campaigns are active
+- Fixes Pipedrive Lead field mappings sending wrong data types for date and numeric custom fields
+- Fixes Brevo integration not sending boolean field values correctly
+- Fixes Brevo integration not mapping multiple-choice and category attribute types from Checkbox and Multi-select form fields
+- Fixes the Offline payment method label not translatable in notifications
+
+---
+
+## 6.2.2 — April 23, 2026
+
+### Free plugin
+
+- Adds subscription field support in payment calculations
+- Fix raw cookie values for smartcodes
+- Hardens email attachment path resolution to keep notification attachments inside allowed paths
+- Hardens predefined form payload handling and confirmation validation
+- Improves compatibility for legacy predefined field option validation
+- Improves form-scoped access for submission collection and print endpoints
+- Tightens allowed-forms scope handling for form managers
+- Ensures form settings are normalized before use
+- Fix integration ActiveCampaign issue
+- Preserves post feed draft values on resume
+- Respects user locale in the form editor
+- Improves ACL permission checks and helper coverage for delegated and full-access flows
+- Hardens form HTML sanitization by blocking event handlers and escaping permission-message shortcode output
+- Improve global integration settings access restriction and protects payment-filters AJAX metadata endpoint
+- Sanitizes form step settings while preserving safe HTML in step button text
+- Improves entry export to honor submission-info selection
+- Improves multisite site setup until initialization
+- Improves long entry content previews
+
+### Pro plugin
+
+- Adds support for subscription payments calculation
+- Fixes resent email attachment path hardening and public uploaded-file deletion safety
+- Hardens public UI output, modal shortcode attributes, save-and-resume email links, and webhook transport URLs
+- Hardens Razorpay modal verification and validates Razorpay payments against the expected order amount
+- Fixes currency-formatted payment values rejected during WPForms entry import
+- Improves CSV and chained-select upload compatibility with framework v2 request files
+- Fixes long partial-entry export URLs
+- Loads frontend TinyMCE table and code plugins from Pro assets
+- Adds `fluentform/admin_approval_confirmation_message` filter hook and preserves admin-approval raw HTML settings
+- Improves post-field behavior with taxonomy-hierarchy support, safer public post-details lookup, and post-update image-state reset
+
+---
+
+## 6.2.1 — April 16, 2026
+
+### Free plugin
+
+- Hardens form-scoped permissions across legacy AJAX and REST actions
+- Adds opt-in legacy HMAC fallback for pre-6.2.0 encrypted tokens to ease upgrade compatibility
+- Adds filter hooks for honeypot, Akismet, and CAPTCHA spam/failed messages
+- Adds database indexes to the `fluentform_form_analytics` table for faster reporting queries
+- Adds mbstring fallback for servers without the extension
+- Improves frontend submission reliability by falling back to the form instance AJAX URL when global vars are missing
+- Fixes public PDF download support for legacy links
+- Fixes draft submissions table support in entry export
+- Fixes entries search ACL issue
+- Fixes All Entries page localStorage persistence
+- Fixes character-limit validation showing the configured message instead of a raw field name
+- Fixes numeric validation so numeric-looking text is no longer treated as a number
+- Fixes WPML addon activation failing with an "Invalid plugin" error
+
+### Pro plugin
+
+- Fixes imported entries after framework v2 request namespace changes
+- Fixes imported form styles not being restored correctly
+- Hardens entry, preview, webhook, Zapier, import, and resend actions with form-scoped authorization checks
+- Hardens payment bulk actions and legacy payment AJAX fallbacks against unauthorized form access
+
+---
+
+## 6.2.0 — April 1, 2026
+
+See the [6.2.0 upgrade guide](/upgrade-guide/6.2.0/) for the framework v2 migration (Collection return type, namespace renames, deprecated classes, hook-name normalization).

--- a/src/cli/index.md
+++ b/src/cli/index.md
@@ -1,55 +1,27 @@
-# Fluent Forms CLI
+# WP-CLI Commands
 
-<Badge type="tip" vertical="top" text="Fluent Forms Core" /> <Badge type="warning" vertical="top" text="Advanced" />
+<Badge type="tip" vertical="top" text="WP-CLI" /> <Badge type="warning" vertical="top" text="Auto-extracted" />
 
-Fluent Forms integrates with [WP-CLI](https://wp-cli.org/), enabling you to run certain Fluent Forms tasks via the command line interface, without using a web browser.
-
-## What is WordPress CLI?
-
-WP-CLI is a command line interface for [WordPress](https://wordpress.org/). It offers an alternative to the WordPress admin bar. Using the command line makes it easier for developers, agencies and hosting providers to run actions with fewer clicks, run them remotely, and even perform complex scripts based on certain conditions.
-
-## What is Fluent Forms CLI?
-
-Fluent Forms CLI is a set of commands integrated into WP-CLI to allow developers to run certain Fluent Forms tasks in a command line.
-
-## Syntax
-
-CLI commands syntax:
+Fluent Forms registers the root command `wp fluentform` with the following subcommands. Source: `app/Modules/CLI/Commands.php`.
 
 ```bash
-wp fluentform <command> [--argument]
+wp fluentform <subcommand> [options]
 ```
 
-## Available Commands
+## `wp fluentform activate_license`
 
-Currently, the following Fluent Forms commands are available:
+**Source:** `app/Modules/CLI/Commands.php` (line 37)
 
-### `wp fluentform stats`
-It will return overall Fluent Forms stats like forms, submissions
+---
 
-### `wp fluentform activate_license`
-Activate Fluent Forms Pro license key via command line
+## `wp fluentform license_status`
 
-**Arguments**
-- `key` Your Fluent Forms Pro License Key
+**Source:** `app/Modules/CLI/Commands.php` (line 72)
 
-**Example**
-```bash
-wp fluentform activate_license --key=YOUR_LICENSE_KEY
-```
+---
 
-### `wp fluentform license_status`
-See Fluent Forms Pro License Status
+## `wp fluentform stats`
 
-**Example**
-```bash
-wp fluentform license_status
-```
+**Source:** `app/Modules/CLI/Commands.php` (line 10)
 
-## Help
-
-For information about an individual command, use the following format:
-
-```bash
-wp help fluentform <command>
-```
+---

--- a/src/database/index.md
+++ b/src/database/index.md
@@ -28,7 +28,6 @@ This table store the fields and settings of a form.
 </td></tr><tr><th>updated_at</th><td><span title="">timestamp</span> <i>NULL</i></td><td>
 </td></tr></tbody></table>
 
-
 ## fluentform_submissions
 Storing the form submissions
 
@@ -77,6 +76,8 @@ Storing the scheduled actions details
 </td></tr></tbody></table>
 
 ## fluentform_coupons
+
+<Badge type="tip" vertical="top" text="Pro" />
 Storing coupon data
 <table cellspacing="0" class="nowrap">
 <thead><tr><th>Column</th><td>Type</td><td>Comment</td></tr></thead>
@@ -98,6 +99,8 @@ Storing coupon data
 </td></tr></tbody></table>
 
 ## fluentform_draft_submissions
+
+<Badge type="tip" vertical="top" text="Pro" />
 Draft submission for saved form state and multi step forms.
 <table cellspacing="0" class="nowrap">
 <thead><tr><th>Column</th><td>Type</td><td>Comment</td></tr></thead>
@@ -127,7 +130,6 @@ Submission Entry Details
 </td></tr><tr><th>sub_field_name</th><td><span title="utf8mb4_unicode_520_ci">varchar(255)</span> <i>NULL</i></td><td>
 </td></tr><tr class="odd"><th>field_value</th><td><span title="utf8mb4_unicode_520_ci">longtext</span> <i>NULL</i></td><td>
 </td></tr></tbody></table>
-
 
 ## fluentform_form_analytics
 Form analytics data
@@ -172,6 +174,8 @@ Store Form activity & api log
 </td></tr></tbody></table>
 
 ## fluentform_order_items
+
+<Badge type="tip" vertical="top" text="Pro" />
 Fluent Form Payment order Items
 
 <table cellspacing="0" class="nowrap">
@@ -208,6 +212,8 @@ Form Submission meta
 </td></tr></tbody></table>
 
 ## fluentform_subscriptions
+
+<Badge type="tip" vertical="top" text="Pro" />
 Payment Subscriptions
 
 <table cellspacing="0" class="nowrap">
@@ -243,8 +249,9 @@ Payment Subscriptions
 </td></tr><tr><th>updated_at</th><td><span title="">timestamp</span> <i>NULL</i></td><td>
 </td></tr></tbody></table>
 
-
 ## fluentform_transactions
+
+<Badge type="tip" vertical="top" text="Pro" />
 Payment Transactions
 <table cellspacing="0" class="nowrap">
 <thead><tr><th>Column</th><td>Type</td><td>Comment</td></tr></thead>

--- a/src/database/models/README.md
+++ b/src/database/models/README.md
@@ -1,0 +1,20 @@
+# Models
+
+Models map to tables in the `fluentform_` prefix and follow an Eloquent-like ORM. Each model exposes attributes, fillable lists, casts, and relationships.
+
+| Model | Table | Description |
+|-------|-------|-------------|
+| [`Entry`](./entry.md) | `fluentform_submissions` | |
+| [`EntryDetails`](./entrydetails.md) | `fluentform_entry_details` | |
+| [`EntryMeta`](./entrymeta.md) | `fluentform_submission_meta` | |
+| [`Form`](./form.md) | `fluentform_forms` | |
+| [`FormAnalytics`](./formanalytics.md) | `fluentform_form_analytics` | |
+| [`FormMeta`](./formmeta.md) | `fluentform_form_meta` | |
+| [`Log`](./log.md) | `fluentform_logs` | |
+| [`OrderItem`](./orderitem.md) | `fluentform_order_items` | |
+| [`Scheduler`](./scheduler.md) | `fluentform_ff_scheduled_actions` | |
+| [`Submission`](./submission.md) | `fluentform_submissions` | |
+| [`SubmissionMeta`](./submissionmeta.md) | `fluentform_submission_meta` | |
+| [`Subscription`](./subscription.md) | `fluentform_subscriptions` | |
+| [`Transaction`](./transaction.md) | `fluentform_transactions` | |
+| [`User`](./user.md) | `fluentform_users` | |

--- a/src/database/models/entry.md
+++ b/src/database/models/entry.md
@@ -1,0 +1,38 @@
+# `Entry` Model
+
+<Badge type="tip" vertical="top" text="Model" /> <Badge type="warning" vertical="top" text="Auto-extracted" />
+
+## Class
+
+- **Class:** `FluentForm\App\Models\Entry`
+- **Extends:** `Model`
+- **Source:** `app/Models/Entry.php`
+- **Table:** `{$wpdb->prefix}fluentform_submissions` (raw: `fluentform_submissions`)
+- **Primary key:** `id`
+
+## Relationships
+
+- **`form()`** — `belongsTo` → `Form::class`
+- **`entryMeta()`** — `hasMany` → `EntryMeta::class`
+- **`logs()`** — `hasMany` → `Log::class`
+- **`entryDetails()`** — `hasMany` → `EntryDetails::class`
+
+## Public Methods
+
+### `paginateEntries($attributes = [])`
+
+### `countByGroup($formId)`
+
+### `amend($id, $data = [])`
+
+### `remove($entryIds)`
+
+## Quick example
+
+```php
+use FluentForm\App\Models\Entry;
+
+// Query
+$entry = Entry::find($id);
+$entry_set = Entry::where('id', '>', 0)->limit(10)->get();
+```

--- a/src/database/models/entrydetails.md
+++ b/src/database/models/entrydetails.md
@@ -1,0 +1,26 @@
+# `EntryDetails` Model
+
+<Badge type="tip" vertical="top" text="Model" /> <Badge type="warning" vertical="top" text="Auto-extracted" />
+
+## Class
+
+- **Class:** `FluentForm\App\Models\EntryDetails`
+- **Extends:** `Model`
+- **Source:** `app/Models/EntryDetails.php`
+- **Table:** `{$wpdb->prefix}fluentform_entry_details` (raw: `fluentform_entry_details`)
+- **Primary key:** `id`
+
+## Relationships
+
+- **`form()`** — `belongsTo` → `Form::class`
+- **`submission()`** — `belongsTo` → `Submission::class`
+
+## Quick example
+
+```php
+use FluentForm\App\Models\EntryDetails;
+
+// Query
+$entrydetails = EntryDetails::find($id);
+$entrydetails_set = EntryDetails::where('id', '>', 0)->limit(10)->get();
+```

--- a/src/database/models/entrymeta.md
+++ b/src/database/models/entrymeta.md
@@ -1,0 +1,26 @@
+# `EntryMeta` Model
+
+<Badge type="tip" vertical="top" text="Model" /> <Badge type="warning" vertical="top" text="Auto-extracted" />
+
+## Class
+
+- **Class:** `FluentForm\App\Models\EntryMeta`
+- **Extends:** `Model`
+- **Source:** `app/Models/EntryMeta.php`
+- **Table:** `{$wpdb->prefix}fluentform_submission_meta` (raw: `fluentform_submission_meta`)
+- **Primary key:** `id`
+
+## Relationships
+
+- **`form()`** — `belongsTo` → `Form::class`
+- **`entry()`** — `belongsTo` → `Entry::class`
+
+## Quick example
+
+```php
+use FluentForm\App\Models\EntryMeta;
+
+// Query
+$entrymeta = EntryMeta::find($id);
+$entrymeta_set = EntryMeta::where('id', '>', 0)->limit(10)->get();
+```

--- a/src/database/models/form.md
+++ b/src/database/models/form.md
@@ -1,0 +1,45 @@
+# `Form` Model
+
+<Badge type="tip" vertical="top" text="Model" /> <Badge type="warning" vertical="top" text="Auto-extracted" />
+
+## Class
+
+- **Class:** `FluentForm\App\Models\Form`
+- **Extends:** `Model`
+- **Source:** `app/Models/Form.php`
+- **Table:** `{$wpdb->prefix}fluentform_forms` (raw: `fluentform_forms`)
+- **Primary key:** `id`
+
+## Relationships
+
+- **`formMeta()`** — `hasMany` → `FormMeta::class`
+- **`conversationalMeta()`** — `hasOne` → `FormMeta::class`
+- **`submissions()`** — `hasMany` → `Submission::class`
+- **`submissionMeta()`** — `hasMany` → `SubmissionMeta::class`
+- **`entryDetails()`** — `hasMany` → `EntryDetails::class`
+- **`formAnalytics()`** — `hasMany` → `FormAnalytics::class`
+- **`logs()`** — `hasMany` → `Log::class`
+- **`transactions()`** — `hasMany` → `Transaction::class`
+- **`orderItems()`** — `hasMany` → `OrderItem::class`
+
+## Public Methods
+
+### `prepare($attributes = [])`
+
+### `getFormMeta($metaKey, $formId = null)`
+
+### `getFormsDefaultSettings($formId = false)`
+
+### `getAdvancedValidationSettings($formId)`
+
+### `remove($formId)`
+
+## Quick example
+
+```php
+use FluentForm\App\Models\Form;
+
+// Query
+$form = Form::find($id);
+$form_set = Form::where('id', '>', 0)->limit(10)->get();
+```

--- a/src/database/models/formanalytics.md
+++ b/src/database/models/formanalytics.md
@@ -1,0 +1,25 @@
+# `FormAnalytics` Model
+
+<Badge type="tip" vertical="top" text="Model" /> <Badge type="warning" vertical="top" text="Auto-extracted" />
+
+## Class
+
+- **Class:** `FluentForm\App\Models\FormAnalytics`
+- **Extends:** `Model`
+- **Source:** `app/Models/FormAnalytics.php`
+- **Table:** `{$wpdb->prefix}fluentform_form_analytics` (raw: `fluentform_form_analytics`)
+- **Primary key:** `id`
+
+## Relationships
+
+- **`form()`** — `belongsTo` → `Form::class`
+
+## Quick example
+
+```php
+use FluentForm\App\Models\FormAnalytics;
+
+// Query
+$formanalytics = FormAnalytics::find($id);
+$formanalytics_set = FormAnalytics::where('id', '>', 0)->limit(10)->get();
+```

--- a/src/database/models/formmeta.md
+++ b/src/database/models/formmeta.md
@@ -1,0 +1,37 @@
+# `FormMeta` Model
+
+<Badge type="tip" vertical="top" text="Model" /> <Badge type="warning" vertical="top" text="Auto-extracted" />
+
+## Class
+
+- **Class:** `FluentForm\App\Models\FormMeta`
+- **Extends:** `Model`
+- **Source:** `app/Models/FormMeta.php`
+- **Table:** `{$wpdb->prefix}fluentform_form_meta` (raw: `fluentform_form_meta`)
+- **Primary key:** `id`
+
+## Relationships
+
+- **`form()`** — `belongsTo` → `Form::class`
+
+## Public Methods
+
+### `prepare($attributes, $predefinedForm)`
+
+### `retrieve($key, $formId = null, $default  = null)`
+
+### `store(Form $form, $formMeta)`
+
+### `persist($formId, $metaKey, $metaValue)`
+
+### `remove($formId, $metaKey)`
+
+## Quick example
+
+```php
+use FluentForm\App\Models\FormMeta;
+
+// Query
+$formmeta = FormMeta::find($id);
+$formmeta_set = FormMeta::where('id', '>', 0)->limit(10)->get();
+```

--- a/src/database/models/index.md
+++ b/src/database/models/index.md
@@ -3,7 +3,7 @@
 ## Introduction
 Fluent Forms ORM provides a beautiful, simple ActiveRecord implementation for working with database tables. Each database table has a corresponding "Model" which is used to interact with that table. Models allow you to query for data in db tables, as well as insert new records into the table.
 
-<p class="warning">
+<p class="info">
 NOTE: Fluent Forms offers helper functions and methods to interact with Fluent Forms's database so you may use those things instead of Models directly. We are documenting these for our internal usage and very-high level usage by 3rd-party develoeprs.
 </p>
 
@@ -68,7 +68,6 @@ $max = FluentForm\App\Models\Form::where('status', 'active')->max('id');
 ```
 
 Available aggregate methods such as `count`, `max`, `min`, `avg`, and `sum`.
-
 
 # Inserting & Updating Models
 

--- a/src/database/models/log.md
+++ b/src/database/models/log.md
@@ -1,0 +1,25 @@
+# `Log` Model
+
+<Badge type="tip" vertical="top" text="Model" /> <Badge type="warning" vertical="top" text="Auto-extracted" />
+
+## Class
+
+- **Class:** `FluentForm\App\Models\Log`
+- **Extends:** `Model`
+- **Source:** `app/Models/Log.php`
+- **Table:** `{$wpdb->prefix}fluentform_logs` (raw: `fluentform_logs`)
+- **Primary key:** `id`
+
+## Relationships
+
+- **`form()`** — `belongsTo` → `Form::class`
+
+## Quick example
+
+```php
+use FluentForm\App\Models\Log;
+
+// Query
+$log = Log::find($id);
+$log_set = Log::where('id', '>', 0)->limit(10)->get();
+```

--- a/src/database/models/orderitem.md
+++ b/src/database/models/orderitem.md
@@ -1,0 +1,34 @@
+# `OrderItem` Model
+
+<Badge type="tip" vertical="top" text="Model" /> <Badge type="warning" vertical="top" text="Auto-extracted" />
+
+## Class
+
+- **Class:** `FluentForm\App\Models\OrderItem`
+- **Extends:** `Model`
+- **Source:** `app/Models/OrderItem.php`
+- **Table:** `{$wpdb->prefix}fluentform_order_items` (raw: `fluentform_order_items`)
+- **Primary key:** `id`
+
+## Relationships
+
+- **`form()`** — `belongsTo` → `Form::class`
+- **`submission()`** — `belongsTo` → `Submission::class`
+
+## Public Methods
+
+### `scopeBySubmission($query, $submissionId)`
+
+### `scopeProducts($query)`
+
+### `scopeDiscounts($query)`
+
+## Quick example
+
+```php
+use FluentForm\App\Models\OrderItem;
+
+// Query
+$orderitem = OrderItem::find($id);
+$orderitem_set = OrderItem::where('id', '>', 0)->limit(10)->get();
+```

--- a/src/database/models/scheduler.md
+++ b/src/database/models/scheduler.md
@@ -1,0 +1,26 @@
+# `Scheduler` Model
+
+<Badge type="tip" vertical="top" text="Model" /> <Badge type="warning" vertical="top" text="Auto-extracted" />
+
+## Class
+
+- **Class:** `FluentForm\App\Models\Scheduler`
+- **Extends:** `Model`
+- **Source:** `app/Models/Scheduler.php`
+- **Table:** `{$wpdb->prefix}ff_scheduled_actions` (raw: `ff_scheduled_actions`)
+- **Primary key:** `id`
+
+## Relationships
+
+- **`form()`** — `belongsTo` → `Form::class`
+- **`submission()`** — `belongsTo` → `Submission::class`
+
+## Quick example
+
+```php
+use FluentForm\App\Models\Scheduler;
+
+// Query
+$scheduler = Scheduler::find($id);
+$scheduler_set = Scheduler::where('id', '>', 0)->limit(10)->get();
+```

--- a/src/database/models/submission.md
+++ b/src/database/models/submission.md
@@ -1,0 +1,59 @@
+# `Submission` Model
+
+<Badge type="tip" vertical="top" text="Model" /> <Badge type="warning" vertical="top" text="Auto-extracted" />
+
+## Class
+
+- **Class:** `FluentForm\App\Models\Submission`
+- **Extends:** `Model`
+- **Source:** `app/Models/Submission.php`
+- **Table:** `{$wpdb->prefix}fluentform_submissions` (raw: `fluentform_submissions`)
+- **Primary key:** `id`
+
+## Relationships
+
+- **`user()`** — `belongsTo` → `User::class`
+- **`form()`** — `belongsTo` → `Form::class`
+- **`submissionMeta()`** — `hasMany` → `SubmissionMeta::class`
+- **`logs()`** — `hasMany` → `Log::class`
+- **`entryDetails()`** — `hasMany` → `EntryDetails::class`
+- **`transactions()`** — `hasMany` → `Transaction::class`
+- **`subscriptions()`** — `hasMany` → `Subscription::class`
+- **`orderItems()`** — `hasMany` → `OrderItem::class`
+
+## Public Methods
+
+### `getSortColumn()`
+
+Returns the column the entries listing should be sorted by.
+Defaults to created_at so imported entries respect their original
+submission date. Site owners can switch back to legacy id-based
+ordering via the fluentform/entries_default_sort_column filter.
+
+### `customQuery($attributes = [], $searchExtender = null)`
+
+### `paginateEntries($attributes = [])`
+
+### `findAdjacentSubmission($attributes = [])`
+
+### `countByGroup($formId)`
+
+### `amend($id, $data = [])`
+
+### `remove($submissionIds)`
+
+### `allSubmissions($attributes = [])`
+
+### `availableForms()`
+
+### `report($attributes)`
+
+## Quick example
+
+```php
+use FluentForm\App\Models\Submission;
+
+// Query
+$submission = Submission::find($id);
+$submission_set = Submission::where('id', '>', 0)->limit(10)->get();
+```

--- a/src/database/models/submissionmeta.md
+++ b/src/database/models/submissionmeta.md
@@ -1,0 +1,34 @@
+# `SubmissionMeta` Model
+
+<Badge type="tip" vertical="top" text="Model" /> <Badge type="warning" vertical="top" text="Auto-extracted" />
+
+## Class
+
+- **Class:** `FluentForm\App\Models\SubmissionMeta`
+- **Extends:** `Model`
+- **Source:** `app/Models/SubmissionMeta.php`
+- **Table:** `{$wpdb->prefix}fluentform_submission_meta` (raw: `fluentform_submission_meta`)
+- **Primary key:** `id`
+
+## Relationships
+
+- **`form()`** — `belongsTo` → `Form::class`
+- **`submission()`** — `belongsTo` → `Submission::class`
+
+## Public Methods
+
+### `retrieve($key, $submissionId = null, $default  = null)`
+
+### `persist($submissionId, $metaKey, $metaValue, $formId = null)`
+
+### `persistArray($submissionId, $metaKey, $metaValue, $formId = null)`
+
+## Quick example
+
+```php
+use FluentForm\App\Models\SubmissionMeta;
+
+// Query
+$submissionmeta = SubmissionMeta::find($id);
+$submissionmeta_set = SubmissionMeta::where('id', '>', 0)->limit(10)->get();
+```

--- a/src/database/models/subscription.md
+++ b/src/database/models/subscription.md
@@ -1,0 +1,39 @@
+# `Subscription` Model
+
+<Badge type="tip" vertical="top" text="Model" /> <Badge type="warning" vertical="top" text="Auto-extracted" />
+
+## Class
+
+- **Class:** `FluentForm\App\Models\Subscription`
+- **Extends:** `Model`
+- **Source:** `app/Models/Subscription.php`
+- **Table:** `{$wpdb->prefix}fluentform_subscriptions` (raw: `fluentform_subscriptions`)
+- **Primary key:** `id`
+
+## Relationships
+
+- **`form()`** — `belongsTo` → `Form::class`
+- **`submission()`** — `belongsTo` → `Submission::class`
+- **`transactions()`** — `hasMany` → `Transaction::class`
+
+## Public Methods
+
+### `getOriginalPlanAttribute($value)`
+
+### `getVendorResponseAttribute($value)`
+
+### `scopeBySubmission($query, $submissionId)`
+
+### `scopeByVendorSubscriptionId($query, $vendorId)`
+
+### `scopeActive($query)`
+
+## Quick example
+
+```php
+use FluentForm\App\Models\Subscription;
+
+// Query
+$subscription = Subscription::find($id);
+$subscription_set = Subscription::where('id', '>', 0)->limit(10)->get();
+```

--- a/src/database/models/transaction.md
+++ b/src/database/models/transaction.md
@@ -1,0 +1,41 @@
+# `Transaction` Model
+
+<Badge type="tip" vertical="top" text="Model" /> <Badge type="warning" vertical="top" text="Auto-extracted" />
+
+## Class
+
+- **Class:** `FluentForm\App\Models\Transaction`
+- **Extends:** `Model`
+- **Source:** `app/Models/Transaction.php`
+- **Table:** `{$wpdb->prefix}fluentform_transactions` (raw: `fluentform_transactions`)
+- **Primary key:** `id`
+
+## Relationships
+
+- **`form()`** — `belongsTo` → `Form::class`
+- **`submission()`** — `belongsTo` → `Submission::class`
+- **`subscription()`** — `belongsTo` → `Subscription::class`
+
+## Public Methods
+
+### `scopeBySubmission($query, $submissionId)`
+
+### `scopeByChargeId($query, $chargeId)`
+
+### `scopeOnetime($query)`
+
+### `scopeRefunds($query)`
+
+### `scopeSubscriptionType($query)`
+
+### `scopePaid($query)`
+
+## Quick example
+
+```php
+use FluentForm\App\Models\Transaction;
+
+// Query
+$transaction = Transaction::find($id);
+$transaction_set = Transaction::where('id', '>', 0)->limit(10)->get();
+```

--- a/src/database/models/user.md
+++ b/src/database/models/user.md
@@ -1,0 +1,39 @@
+# `User` Model
+
+<Badge type="tip" vertical="top" text="Model" /> <Badge type="warning" vertical="top" text="Auto-extracted" />
+
+## Class
+
+- **Class:** `FluentForm\App\Models\User`
+- **Extends:** `Model`
+- **Source:** `app/Models/User.php`
+- **Table:** `{$wpdb->prefix}users` (raw: `users`)
+- **Primary key:** `id`
+
+## Public Methods
+
+### `getIdAttribute()`
+
+The table associated with the model.
+
+### `getNameAttribute()`
+
+Get the name of the user.
+
+### `getEmailAttribute()`
+
+Get the email of the user.
+
+### `getPermalinkAttribute()`
+
+Get the permalink of the user.
+
+## Quick example
+
+```php
+use FluentForm\App\Models\User;
+
+// Query
+$user = User::find($id);
+$user_set = User::where('id', '>', 0)->limit(10)->get();
+```

--- a/src/database/orm/collections.md
+++ b/src/database/orm/collections.md
@@ -2,7 +2,6 @@
 
 <Badge type="tip" vertical="top" text="Fluent Framework" /> <Badge type="warning" vertical="top" text="ORM" />
 
-
 ## Introduction
 All multi-result sets returned by Fluent ORM are instances of the `FluentForm\Framework\Database\Orm\Collection` object, including results retrieved via the `get` method or accessed via a relationship. The Fluent ORM collection naturally inherits dozens of methods used to fluently work with the underlying array of Fluent ORM models.
 
@@ -1159,7 +1158,6 @@ $groups->toArray();
  
 // [[1, 2], [3, 4], [5]]
 ```
-
 
 ### sum()
 The sum method returns the sum of all items in the collection:

--- a/src/database/orm/index.md
+++ b/src/database/orm/index.md
@@ -13,7 +13,6 @@ _Note: Fluent ORM is compatible the PHP Laravel Framework's Eloquent ORM. If you
 
 To get started, let's create a Fluent model. Models typically live in the `app/Models` directory, but you are free to place them anywhere that can be auto-loaded according to your `composer.json` file. All Fluent models extend `FluentForm\Framework\Database\Orm\Model` class.
 
-
 ## Fluent Model Conventions
 
 Now, let's look at an example `Form` model, which we will use to retrieve and store information from our `fluentform_forms` database table:
@@ -196,7 +195,6 @@ $form = FluentForm\App\Models\Form::findOrFail(1);
 $form = FluentForm\App\Models\Form::where('age', '>', 21)->firstOrFail();
 ```
 
-
 ## Retrieving Aggregates
 You may also use the `count`, `sum`, `max`, and other <a :href="$withBase('/database/query-builder/#aggregates')">aggregate methods</a> provided by the <a :href="$withBase('/database/query-builder')">query builder</a>. These methods return the appropriate scalar value instead of a full model instance:
 ```php
@@ -260,7 +258,6 @@ FluentForm\App\Models\Form::where('has_payment', 1)
           ->update(['status' => 'published']);
 ```
 The `update` method expects an array of column and value pairs representing the columns that should be updated.
-
 
 ## Mass Assignment
 
@@ -353,7 +350,6 @@ $form = FluentForm\App\Models\Form::updateOrCreate(
 );
 ```
 
-
 ## Deleting Models
 
 To delete a model, call the `delete` method on a model instance:
@@ -378,7 +374,6 @@ Of course, you may also run a delete statement on a set of models. In this examp
 ```php
 $deletedRows = FluentForm\App\Models\Form::where('status', 'unpublished')->delete();
 ```
-
 
 ## Soft Deleting
 
@@ -411,7 +406,6 @@ if ($form->trashed()) {
     //
 }
 ```
-
 
 ## Querying Soft Deleted Models
 
@@ -460,7 +454,6 @@ $form->forceDelete();
 // Force deleting all related models...
 $form->history()->forceDelete();
 ```
-
 
 ## Query Scopes
 
@@ -572,7 +565,6 @@ Form::withoutGlobalScopes([
     FirstScope::class, SecondScope::class
 ])->get();
 ```
-
 
 ## Local Scopes
 

--- a/src/database/orm/mutators.md
+++ b/src/database/orm/mutators.md
@@ -2,10 +2,8 @@
 
 <Badge type="tip" vertical="top" text="Fluent Framework" /> <Badge type="warning" vertical="top" text="ORM" />
 
-
 ## Introduction
 Accessors and mutators allow you to format Fluent ORM attribute values when you retrieve or set them on model instances.
-
 
 ## Accessors & Mutators
 
@@ -140,7 +138,6 @@ class Flight extends Model
 }
 ```
 
-
 ## Attribute Casting
 
 The `$casts` property on your model provides a convenient method of converting attributes to common data types. The `$casts` property should be an array where the key is the name of the attribute being cast and the value is the type you wish to cast the column to. The supported cast types are: `int`, `integer`, `real`, `float`, `double`, `string`, `boolean`, `bool`, `object`, `array`, `json`, `collection`, `date`, `datetime`, and `timestamp`.
@@ -173,7 +170,6 @@ if ($user->is_admin) {
     //
 }
 ```
-
 
 ## Array & JSON Casting
 
@@ -209,7 +205,6 @@ $user->options = $options;
  
 $user->save();
 ```
-
 
 ## Date Casting
 

--- a/src/database/orm/relationship.md
+++ b/src/database/orm/relationship.md
@@ -2,7 +2,6 @@
 
 <Badge type="tip" vertical="top" text="Fluent Framework" /> <Badge type="warning" vertical="top" text="ORM" />
 
-
 ## Introduction
 
 Database tables are often related to one another. For example, a form may have many submissions, or submission could be related to the user who submit it. Fluent ORM makes managing and working with these relationships easy, and supports several types of relationships:
@@ -13,7 +12,6 @@ Database tables are often related to one another. For example, a form may have m
 - [`Has Many Through`](./relationship/#has-many-through)
 - [`Polymorphic Relations`](./relationship/#polymorphic-relations)
 - [`Many To Many Polymorphic Relations`](./relationship/#many-to-many-polymorphic-relations)
-
 
 ## Defining Relationships
 
@@ -545,7 +543,6 @@ $user->forms()->where('status', 'published')->get();
 ```
 You are able to use any of the query builder methods on the relationship, so be sure to explore the <a :href="$withBase('/database/query-builder')">query builders</a> documentation to learn about all the methods that are available to you.
 
-
 ### Relationship Methods Vs. Dynamic Properties
 If you do not need to add additional constraints to an Fluent ORM relationship query, you may access the relationship as if it were a property. For example, continuing to use our `User` and `Form` example models, we may access all of a user's forms like so:
 ```php
@@ -556,7 +553,6 @@ foreach ($user->forms as $form) {
 }
 ```
 Dynamic properties are "lazy loading", meaning they will only load their relationship data when you actually access them. Eager loading provides a significant reduction in SQL queries that must be executed to load a model's relations.
-
 
 ### Querying Relationship Existence
 When accessing the records for a model, you may wish to limit your results based on the existence of a relationship. For example, imagine you want to retrieve all forms that have at least one submission. To do so, you may pass the name of the relationship to the `has` and `orHas` methods:
@@ -582,7 +578,6 @@ $forms = FluentForm\App\Models\Form::whereHas('submissions', function ($query) {
 })->get();
 ```
 
-
 ### Querying Relationship Absence
 
 When accessing the records for a model, you may wish to limit your results based on the absence of a relationship. For example, imagine you want to retrieve all forms that don't have any submissions. To do so, you may pass the name of the relationship to the `doesntHave` and `orDoesntHave` methods:
@@ -601,7 +596,6 @@ $forms = FluentForm\App\Models\Form::whereDoesntHave('submissions.user_id', func
     $query->where('banned', 1);
 })->get();
 ```
-
 
 ### Counting Related Models
 If you want to count the number of results from a relationship without actually loading them you may use the `withCount` method, which will place a `{relation}_count` column on your resulting models. For example:
@@ -634,7 +628,6 @@ echo $forms[0]->submissions_count;
  
 echo $forms[0]->pending_submissions_count;
 ```
-
 
 ### Eager Loading
 When accessing Fluent ORM relationships as properties, the relationship data is "lazy loaded". This means the relationship data is not actually loaded until you first access the property. However, Fluent ORM can "eager load" relationships at the time you query the parent model. Eager loading alleviates the N + 1 query problem. To illustrate the N + 1 query problem, consider a Book model that is related to Author:
@@ -712,7 +705,6 @@ $users = FluentForm\App\Models\User::with(['forms' => function ($query) {
     $query->orderBy('created_at', 'desc');
 }])->get();
 ```
-
 
 ## Inserting & Updating Related Models
 
@@ -841,7 +833,6 @@ $user = FluentForm\App\Models\User::find(1);
  
 $user->roles()->updateExistingPivot($roleId, $attributes);
 ```
-
 
 ## Touching Parent Timestamps
 

--- a/src/database/orm/serialization.md
+++ b/src/database/orm/serialization.md
@@ -2,7 +2,6 @@
 
 <Badge type="tip" vertical="top" text="Fluent Framework" /> <Badge type="warning" vertical="top" text="ORM" />
 
-
 ## Introduction
 
 When building JSON APIs, you will often need to convert your models and relationships to arrays or JSON. Fluent ORM includes convenient methods for making these conversions, as well as controlling which attributes are included in your serializations.
@@ -32,7 +31,6 @@ return $form->toJson();
  
 return $form->toJson(JSON_PRETTY_PRINT);
 ```
-
 
 ## Hiding Attributes From JSON
 
@@ -64,7 +62,6 @@ Likewise, if you would like to make some typically visible attributes hidden on 
 ```php
 return $form->makeHidden('attribute')->toArray();
 ```
-
 
 ## Appending Values To JSON
 

--- a/src/database/query-builder.md
+++ b/src/database/query-builder.md
@@ -1,6 +1,5 @@
 # Fluent Forms Query Builder
 
-
 ## Introduction
 Fluent Forms database query builder provides a convenient, fluent interface to creating and running database queries. It can be used to perform most database operations in your application.
 
@@ -19,7 +18,6 @@ $query = wpFluent()->table('fluentform_forms')
             })
             ->orderBy('id', 'ASC');
 ```
-
 
 # Retrieving Results
 
@@ -128,13 +126,11 @@ $price = wpFluent()->table('fluentform_transaction')
                 ->avg('payment_total');
 ```
 
-
 ### Determining If Records Exist
 Instead of using the `count` method to determine if any records exist that match your query's constraints, you may use the `exists`:
 ```php
 return wpFluent()->table('fluentform_transaction')->where('payment_methods', 'stripe')->exists();
 ```
-
 
 ## Selects
 
@@ -155,7 +151,6 @@ $query = wpFluent()->table('fluentform_forms')->select('title');
  
 $forms = $query->addSelect('form_fields')->get();
 ```
-
 
 ## Raw Expressions
 Sometimes you may need to use a raw expression in a query. To create a raw expression, you may use the `raw` method:
@@ -204,7 +199,6 @@ $forms = wpFluent()->table('fluentform_forms')
                 ->get();
 ```
 
-
 ## Joins
 
 ### Inner Join Clause
@@ -252,7 +246,6 @@ wpFluent()->table('fluentform_submissions')
         ->get();
 ```
 
-
 ## Unions
 
 The query builder also provides a quick way to "union" two queries together. For example, you may create an initial query and use the `union` method to union it with a second query:
@@ -265,7 +258,6 @@ $user = wpFluent()->table('users')
             ->union($first)
             ->get();
 ```
-
 
 ## Where Clauses
 
@@ -425,7 +417,6 @@ $forms = wpFluent()->table('fluentform_forms')
                 ])->get();
 ```
 
-
 ### Where Exists Clauses
 The `whereExists` method allows you to write where exists SQL clauses. The `whereExists` method accepts a `Closure` argument, which will receive a query builder instance allowing you to define the query that should be placed inside the "exists" clause:
 ```php
@@ -445,7 +436,6 @@ where exists (
     select 1 from fluentform_order_items where fluentform_order_items.form_id = fluentform_forms.id
 )
 ```
-
 
 ### Ordering, Grouping, Limit, & Offset
 
@@ -505,7 +495,6 @@ $forms = wpFluent()->table('fluentform_forms')
                 ->get();
 ```
 
-
 ### Conditional Clauses
 Sometimes you may want clauses to apply to a query only when something else is true. For instance, you may only want to apply a `where` statement if a given input value is present on the incoming request. You may accomplish this using `when` method:
 ```php
@@ -532,7 +521,6 @@ $forms = wpFluent()->table('fluentform_forms')
                 ->get();
 ```
 
-
 ### Inserts
 
 The query builder also provides an `insert` method for inserting records into the database table. The `insert` method accepts an array of column names and values:
@@ -557,7 +545,6 @@ $formId = wpFluent()->table('fluentform_forms')->insertGetId(
 );
 ```
 
-
 ### Updates
 
 Of course, in addition to inserting records into the database, the query builder can also update existing records using the `update` method. The `update` method, like the `insert` method, accepts an array of column and value pairs containing the columns to be updated. You may constrain the `update` query using `where` clauses:
@@ -566,7 +553,6 @@ wpFluent()->table('fluentform_forms')
             ->where('id', 1)
             ->update(['title' => 'New updated title']);
 ```
-
 
 ### Increment & Decrement
 
@@ -587,7 +573,6 @@ You may also specify additional columns to update during the operation:
 wpFluent()->table('fluentform_order_items')->increment('line_total', 1, ['item_price' => '99.99']);
 ```
 
-
 ### Deletes
 
 The query builder may also be used to delete records from the table via the `delete` method. You may constrain delete statements by adding where clauses before calling the `delete` method:
@@ -600,7 +585,6 @@ If you wish to truncate the entire table, which will remove all rows and reset t
 ```php
 wpFluent()->table('fluentform_order_items')->truncate();
 ```
-
 
 ### Pessimistic Locking
 

--- a/src/getting-started/index.md
+++ b/src/getting-started/index.md
@@ -3,6 +3,7 @@
 <Badge type="tip" vertical="top" text="Fluent Forms Core" /> <Badge type="warning" vertical="top" text="Basic" />
 
 Fluent Forms is a user-friendly drag-and-drop WordPress contact form plugin with more than 30 form fields, 3rd party integrations, built-in entry management system, etc. With Fluent Forms, you can create forms, payment forms, and quizzes in minutes.
+
 ## Fluent Forms Versions
 
 Fluent Forms comes in different versions:
@@ -11,29 +12,83 @@ Fluent Forms comes in different versions:
 
 **Fluent Forms Pro** is a paid version that adds a number of advanced features and options not found in the free version. It comes with lots of integrations and features including step forms, post creation and updates, user registration, payments with multiple gateways, and more.
 
+## Companion Add-ons
+
+Beyond Free and Pro, the Fluent Forms ecosystem ships several independent add-on plugins:
+
+- **fluent-conversational-js** — Vue 3 conversational form renderer (mounted by the free plugin's `FluentConversational` service)
+- **fluentform-signature** — digital signature pad field
+- **fluentforms-pdf** — PDF generator (v1, mPDF, General/Invoice/Report templates)
+- **fluent-pdf** — PDF generator v2 rewrite (Vue 3 + Element Plus + Vite, multi-product)
+- **multilingual-forms-fluent-forms-wpml** — WPML integration
+
+## System Requirements
+
+- PHP **7.4** or higher (tested through 8.4)
+- WordPress **6.4** or higher (tested through latest 7.0)
+
+The plugin enforces PHP 7.4 syntax only — no PHP 8.0+ features (`match`, nullsafe `?->`, union types, named arguments, `str_contains`, `str_starts_with`, `str_ends_with`) appear in core source.
+
 ## Directory Structure
 
 ```yaml
 ├── app
-│   ├── Api         # contains PHP API Utility classes
-│   └── Helpers     # Helper, Protector, Str utility classes
-│   └── Hooks       # actions and filters handlers
-│   └── Http        # REST API routes, controllers, policies
-│   └── Models      # Database Models
-│   └── Modules     # Old Modules Services
-│   └── Services    # Module Services
-│   └── views       # php view files
-│   └── App.php
+│   ├── Api          # public PHP facades (Form, Submission)
+│   ├── Helpers      # Helper, Protector, Str utility classes
+│   ├── Hooks        # actions.php, filters.php, Ajax.php, Handlers/
+│   ├── Http         # Controllers, Policies, Routes/, Requests/
+│   ├── Models       # Eloquent-like ORM models
+│   ├── Modules      # feature modules (Acl, Ai, CLI, Component, Entries,
+│   │                #   Form, HCaptcha, Payments, ReCaptcha, Registerer,
+│   │                #   Report, Renderer, SubmissionHandler, Transfer,
+│   │                #   Turnstile, Widgets, etc.)
+│   ├── Services     # business logic — Form, FormBuilder, Integrations,
+│   │                #   FluentConversational, Settings, Report, Migrator,
+│   │                #   Scheduler, Logger, Roles, GlobalSettings, etc.
+│   ├── Views        # PHP view templates
+│   └── App.php      # service container kernel
 │
-├── assets          # contains css,js, media files
-├── boot            # Plugin boot files and global functions
-├── config          # [internal] contains plugin framework top level config
-├── database        # [internal] Database migration files
-├── guten_block     # [internal] Guten Block files
-├── includes        # [internal] Old Framework deprecated classes
-├── language        # [internal] Language Files
-├── vendor          # [internal] Core Framework Files
-│
-└── fluentform.php  # Plugin entry File
+├── assets           # compiled CSS/JS (rebuilt from resources/ via Laravel Mix)
+├── boot             # app.php, bindings.php, globals.php
+├── database         # Migrations/ (Forms, FormMeta, Submissions, SubmissionDetails,
+│                    #   SubmissionMeta, FormAnalytics, ScheduledActions, Logs)
+├── guten_block      # React 18 / JSX source for the Gutenberg block
+├── resources        # source for compiled assets
+│   ├── assets       # Vue 2 admin, jQuery public, Elementor widget, SCSS
+│   └── languages    # .mo / .po translation files
+└── fluentform.php   # plugin entry file
 ```
 
+## Frontend Stacks
+
+| Surface | Stack | Source root |
+|---------|-------|-------------|
+| Admin SPA | Vue 2 Options API + Element UI 2.15 + Vuex | `resources/assets/admin/` |
+| Public forms | Vanilla JS + jQuery (server-rendered HTML) | `resources/assets/public/` |
+| Gutenberg block | React 18 / JSX | `guten_block/src/` |
+| Conversational | Vue 3 + Element Plus (separate `fluent-conversational-js` repo) | `../fluent-conversational-js/src/` |
+
+## REST API base
+
+`https://your-site.com/wp-json/fluentform/v1/`
+
+Auth: `X-WP-Nonce` header (admin REST nonce). PUT/PATCH/DELETE sent as POST with `X-HTTP-Method-Override` header.
+
+See the [Endpoint Reference](/api/endpoints/) for every route.
+
+## Custom Capabilities
+
+Fluent Forms ships its own capability system (NOT standard WP `edit_posts`):
+
+- `fluentform_full_access`
+- `fluentform_forms_manager`
+- `fluentform_entries_viewer`
+- `fluentform_settings_manager`
+- `fluentform_view_reports`
+
+Check with `FluentForm\App\Modules\Acl::hasPermission($cap)` or `Acl::verifyRequest()`.
+
+## Hook prefix convention
+<p class="warning">
+All hooks fire with the `fluentform/` slash prefix (e.g. `do_action('fluentform/submission_inserted', ...)`). Older `fluentform_` underscore-prefixed hooks still fire via `do_action_deprecated()` for back-compat but will be removed in 7.0. See the [6.2.0 upgrade guide](/upgrade-guide/6.2.0/) for migration details.
+</p>

--- a/src/global-functions/index.md
+++ b/src/global-functions/index.md
@@ -1,236 +1,235 @@
-## Global Functions
+# Global Functions
 
-Fluent Forms provides a set of global functions located in the `boot/globals.php` file. These functions are available throughout the plugin and can be used in your custom code, themes, or plugins.
+<Badge type="tip" vertical="top" text="Global Helpers" /> <Badge type="warning" vertical="top" text="Auto-extracted" />
 
-[[toc]]
+Helper functions registered at plugin boot and available in any PHP context. Source: `boot/globals.php`.
 
-### wpFluentForm($key = null): mixed
-Get the Fluent Forms application instance or a specific core module.
+## `fluentFormApi($module = 'forms')`
+
+**Source:** `boot/globals.php` (line 268)
+
+---
+
+## `fluentFormEditorShortCodes()`
+
+**Source:** `boot/globals.php` (line 119)
+
+---
+
+## `fluentFormGetAllEditorShortCodes($form)`
+
+**Source:** `boot/globals.php` (line 128)
+
+---
+
+## `fluentFormGetRandomPhoto()`
+
+**Source:** `boot/globals.php` (line 279)
+
+---
+
+## `fluentFormHandleScheduledEmailReport()`
+
+**Source:** `boot/globals.php` (line 253)
+
+---
+
+## `fluentFormHandleScheduledTasks()`
+
+**Source:** `boot/globals.php` (line 235)
+
+---
+
+## `fluentFormIsHandlingSubmission()`
+
+**Source:** `boot/globals.php` (line 210)
+
+---
+
+## `fluentFormMix($path = '')`
+
+**Source:** `boot/globals.php` (line 9)
+
+**** DO NOT CALL ANY FUNCTIONS DIRECTLY FROM THIS FILE ******
+This file will be loaded even before the framework is loaded
+so the $app is not available here, only declare functions here.
+
+/**
+Get fluentform instance or other core modules
 
 **Parameters**
-- `$key` `string|null` Module name (e.g., `'db'`, `'request'`, `'path.app'`)
 
-**Return** `mixed` — Application instance or the requested module
+- `$key` (`string`) — @return mixed
+- `$path` (`string`) — @return string
 
-**Usage**
-```php
-// Get the app instance
-$app = wpFluentForm();
-
-// Get the database module
-$db = wpFluentForm('db');
-
-// Get the request module
-$request = wpFluentForm('request');
-```
+**Returns:** `mixed` — /
 
 ---
 
-### wpFluent(): Builder
-Get the Fluent Forms database query builder instance for direct database queries.
+## `fluentFormPrintUnescapedInternalString($string)`
 
-**Return** `\FluentForm\Framework\Database\Query\Builder`
+**Source:** `boot/globals.php` (line 312)
 
-**Usage**
-```php
-// Query the submissions table
-$submissions = wpFluent()->table('fluentform_submissions')
-    ->where('form_id', 5)
-    ->get();
-```
+Print internal content (not user input) without escaping.
 
 ---
 
-### fluentFormApi($module = 'forms'): Form|Submission
-Get the Fluent Forms PHP API for forms or submissions. This is the recommended way to interact with Fluent Forms data programmatically.
+## `fluentFormRender($atts)`
+
+**Source:** `boot/globals.php` (line 296)
+
+---
+
+## `fluentFormSanitizer($input, $attribute = null, $fields = [])`
+
+**Source:** `boot/globals.php` (line 60)
+
+**Returns:** `\FluentForm\Framework\Database\Query\Builder|\FluentForm\Framework\Database\Query\WPDBConnection` — /
+
+---
+
+## `fluentFormWasSubmitted($action = 'fluentform_submit')`
+
+**Source:** `boot/globals.php` (line 197)
+
+---
+
+## `fluentImplodeRecursive($glue, array $array)`
+
+**Source:** `boot/globals.php` (line 145)
+
+Recursively implode a multi-dimentional array
 
 **Parameters**
-- `$module` `string` Module name — `'forms'` or `'submissions'`
 
-**Return** `\FluentForm\App\Api\Form` or `\FluentForm\App\Api\Submission`
+- `$glue` (`string`) — @param array  $array
 
-**Usage**
-```php
-// Get the Forms API
-$formsApi = fluentFormApi('forms');
-$form = $formsApi->find($formId);
-
-// Get the Submissions API
-$submissionsApi = fluentFormApi('submissions');
-```
+**Returns:** `string`
 
 ---
 
-### fluentFormRender($atts): string
-Render a Fluent Form programmatically (equivalent to the `[fluentform]` shortcode).
+## `fluentValidator($data = [], $rules = [], $messages = [])`
+
+**Source:** `boot/globals.php` (line 498)
+
+---
+
+## `fluentformCanUnfilteredHTML()`
+
+**Source:** `boot/globals.php` (line 486)
+
+---
+
+## `fluentformGetPages()`
+
+**Source:** `boot/globals.php` (line 503)
+
+---
+
+## `fluentformLoadFile($path)`
+
+**Source:** `boot/globals.php` (line 491)
+
+---
+
+## `fluentformSanitizeCSS($css)`
+
+**Source:** `boot/globals.php` (line 468)
+
+Sanitizes CSS.
+
+**Returns:** `mixed` — $css
+
+---
+
+## `fluentform_backend_sanitizer($inputs, $sanitizeMap = [])`
+
+**Source:** `boot/globals.php` (line 443)
+
+Sanitize inputs recursively.
 
 **Parameters**
-- `$atts` `array` Shortcode attributes:
-  - `id` `int` Form ID (required)
-  - `title` `string|null` Form title override
-  - `css_classes` `string` Additional CSS classes
-  - `permission` `string` Required user capability
-  - `type` `string` Form type — `'classic'` (default) or `'conversational'`
-  - `permission_message` `string` Message shown when user lacks permission
 
-**Return** `string` — Rendered form HTML
+- `$input` (`array`) — @param array $sanitizeMap
 
-**Usage**
-```php
-// Render form #5 in a template
-echo fluentFormRender(['id' => 5]);
-
-// With custom CSS class and permission check
-echo fluentFormRender([
-    'id'         => 5,
-    'css_classes' => 'my-custom-form',
-    'permission' => 'read',
-]);
-```
+**Returns:** `array` — $input
 
 ---
 
-### fluentFormSanitizer($input, $attribute, $fields): mixed
-Recursively sanitize form input values based on field type. Used internally during submission processing.
+## `fluentform_get_active_theme_slug()`
 
-**Parameters**
-- `$input` `mixed` The input value to sanitize
-- `$attribute` `string|null` The field attribute name
-- `$fields` `array` Form field definitions
-
-**Return** `mixed` — Sanitized input
-
-**Usage**
-```php
-$cleanValue = fluentFormSanitizer($userInput, 'email', $formFields);
-```
+**Source:** `boot/globals.php` (line 170)
 
 ---
 
-### fluentFormIsHandlingSubmission(): bool
-Check if the current request is a Fluent Forms submission or async request.
+## `fluentform_iframe_srcdoc_sanitize($value)`
 
-**Return** `bool`
-
-**Usage**
-```php
-if (fluentFormIsHandlingSubmission()) {
-    // Current request is a form submission
-}
-```
+**Source:** `boot/globals.php` (line 324)
 
 ---
 
-### fluentFormHandleScheduledTasks(): void
-Process failed scheduled actions (retry up to 4 times). Called by WordPress cron.
+## `fluentform_integrations_url()`
 
-**Usage**
-```php
-// Manually trigger scheduled task processing
-fluentFormHandleScheduledTasks();
-```
+**Source:** `boot/globals.php` (line 263)
 
 ---
 
-### fluentFormHandleScheduledEmailReport(): void
-Process scheduled email reports. Called by WordPress cron.
+## `fluentform_kses_js($content)`
+
+**Source:** `boot/globals.php` (line 433)
 
 ---
 
-### fluentFormEditorShortCodes(): array
-Get the list of available editor shortcodes for form notifications and confirmations.
+## `fluentform_mb_strpos($haystack, $needle)`
 
-**Return** `array` — Array of shortcode groups
-
----
-
-### fluentFormGetAllEditorShortCodes($form): array
-Get all editor shortcodes available for a specific form, including form-specific field shortcodes.
-
-**Parameters**
-- `$form` `object` The form object
-
-**Return** `array` — Array of all available shortcodes
+**Source:** `boot/globals.php` (line 226)
 
 ---
 
-### getFluentFormCountryList(): array
-Get the full list of countries with their codes.
+## `fluentform_options_sanitize($options)`
 
-**Return** `array` — Associative array of country code => country name
-
----
-
-### fluentFormMix($path): string
-Generate a URL for static assets within the Fluent Forms plugin.
-
-**Parameters**
-- `$path` `string` Relative path to the asset
-
-**Return** `string` — Full URL to the asset
+**Source:** `boot/globals.php` (line 319)
 
 ---
 
-### fluentform_sanitize_html($html): string
-Sanitize HTML content while preserving allowed tags (including iframes, SVGs, and custom elements). Removes event handlers and JavaScript protocols.
+## `fluentform_sanitize_html($html)`
 
-**Parameters**
-- `$html` `string` HTML content to sanitize
-
-**Return** `string` — Sanitized HTML
-
-**Usage**
-```php
-$safeHtml = fluentform_sanitize_html($rawHtml);
-```
+**Source:** `boot/globals.php` (line 339)
 
 ---
 
-### fluentform_backend_sanitizer($inputs, $sanitizeMap): array
-Sanitize backend inputs recursively using a map of sanitization callbacks.
+## `fluentform_upgrade_url()`
 
-**Parameters**
-- `$inputs` `array` Input data to sanitize
-- `$sanitizeMap` `array` Associative array of `key => callback` pairs
-
-**Return** `array` — Sanitized input data
-
-**Usage**
-```php
-$clean = fluentform_backend_sanitizer($data, [
-    'title' => 'sanitize_text_field',
-    'email' => 'sanitize_email',
-    'content' => 'wp_kses_post',
-]);
-```
+**Source:** `boot/globals.php` (line 258)
 
 ---
 
-### fluentformCanUnfilteredHTML(): bool
-Check if the current user can use unfiltered HTML or if field sanitization is disabled.
+## `getFluentFormCountryList()`
 
-**Return** `bool`
+**Source:** `boot/globals.php` (line 187)
 
 ---
 
-### fluentValidator($data, $rules, $messages): Validator
-Create a validation instance for data validation.
+## `isWpAsyncRequest($action)`
 
-**Parameters**
-- `$data` `array` Data to validate
-- `$rules` `array` Validation rules
-- `$messages` `array` Custom error messages
+**Source:** `boot/globals.php` (line 205)
 
-**Return** `Validator`
+---
 
-**Usage**
-```php
-$validator = fluentValidator($data, [
-    'email' => 'required|email',
-    'name'  => 'required|string',
-]);
+## `wpFluent()`
 
-if ($validator->validate()->fails()) {
-    $errors = $validator->errors();
-}
-```
+**Source:** `boot/globals.php` (line 64)
+
+---
+
+## `wpFluentForm($key = null)`
+
+**Source:** `boot/globals.php` (line 42)
+
+---
+
+## `wpFluentFormAddComponent(BaseComponent $component)`
+
+**Source:** `boot/globals.php` (line 72)
+
+---

--- a/src/helpers/arr.md
+++ b/src/helpers/arr.md
@@ -6,6 +6,15 @@
   [[toc]]
 
 <a name="method-array-add"></a>
+
+### `Arr::accessible($value)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 33)
+
+Determine whether the given value is array accessible.
+
+---
+
 ### `Arr::add()`
 
 The `Arr::add` method adds a given key / value pair to an array if the given key doesn't already exist in the array:
@@ -19,6 +28,31 @@ $array = Arr::add(['name' => 'Desk'], 'price', 100);
     
 
 <a name="method-array-collapse"></a>
+
+### `Arr::arrayKeyExists($array, $key)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 206)
+
+Alias of exists.
+
+---
+
+### `Arr::arsort($array, $flags = SORT_REGULAR)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 924)
+
+Sort an array in descending order and maintain index association.
+
+---
+
+### `Arr::asort($array, $flags = SORT_REGULAR)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 910)
+
+Sort an array in ascending order and maintain index association.
+
+---
+
 ### `Arr::collapse()`
 
 The `Arr::collapse` method collapses an array of arrays into a single array:
@@ -31,6 +65,39 @@ $array = Arr::collapse([[1, 2, 3], [4, 5, 6], [7, 8, 9]]);
 ```
 
 <a name="method-array-divide"></a>
+
+### `Arr::compare($array1, $array2, $path = [])`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1250)
+
+Compare two nested arrays side by side
+
+---
+
+### `Arr::contains(array $array, $values)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1183)
+
+Check if the value(s) exist in an array using "dot" notation.
+
+---
+
+### `Arr::containsAny(array $array, $values)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1217)
+
+Check if the any value exist in an array using "dot" notation.
+
+---
+
+### `Arr::crossJoin(...$arrays)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 84)
+
+Cross join the given arrays, returning all possible permutations.
+
+---
+
 ### `Arr::divide()`
 
 The `Arr::divide` method returns two arrays, one containing the keys, and the other containing the values of the given array:
@@ -45,6 +112,23 @@ use FluentForm\Framework\Support\Arr;
 ```
 
 <a name="method-array-dot"></a>
+
+### `Arr::DoesNotEndLike($array, $pattern)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1441)
+
+Return non-matching ending of items from array (similar to mysql's NOT LIKE%)
+
+---
+
+### `Arr::DoesNotStartLike($array, $pattern)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1409)
+
+Return non-matching starting of items from array (similar to mysql's NOT %LIKE)
+
+---
+
 ### `Arr::dot()`
 
 The `Arr::dot` method flattens a multi-dimensional array into a single level array that uses "dot" notation to indicate depth:
@@ -59,6 +143,24 @@ $flattened = Arr::dot($array);
 ```
 
 <a name="method-array-except"></a>
+
+### `Arr::endsLike($array, $pattern)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1425)
+
+Return matching ending of items from array (similar to mysql's LIKE%)
+
+---
+
+### `Arr::every($array, callable $callback)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1700)
+
+Tests whether all elements in the array pass the
+test implemented by the provided callback.
+
+---
+
 ### `Arr::except()`
 
 The `Arr::except` method removes the given key / value pairs from an array:
@@ -72,6 +174,57 @@ $filtered = Arr::except($array, ['price']);
 // ['name' => 'Desk']
 ```
 <a name="method-array-first"></a>
+
+### `Arr::exists($array, $key)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 176)
+
+Determine if the given key exists in the provided array.
+
+---
+
+### `Arr::filterRecursive($array, ?callable $cb = null, $mode = 0)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 271)
+
+Recursively filter an array like array_filter.
+
+---
+
+### `Arr::find($array, callable $callback, $findKey = false)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1719)
+
+Finds the first element in the array that satisfies the
+condition implemented by the callback function.
+
+---
+
+### `Arr::findKey($array, callable $callback)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1738)
+
+Finds the first key in the array that satisfies the
+condition implemented by the callback function.
+
+---
+
+### `Arr::findPath($array, $value, $ci = false)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 320)
+
+Recursively search the value and return the path of first match.
+
+---
+
+### `Arr::findSimilar($needle, array $haystack, $accuracy = 60)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1751)
+
+Find similar words in an array.
+
+---
+
 ### `Arr::first()`
 
 The `Arr::first` method returns the first element of an array passing a given truth test:
@@ -94,6 +247,16 @@ $first = Arr::first($array, $callback, $default);
 ```
 
 <a name="method-array-flatten"></a>
+
+### `Arr::firstKey($array, ?callable $callback = null)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 248)
+
+Returns the key of the first item (matching the specified
+callback if given) or null if there is no such item.
+
+---
+
 ### `Arr::flatten()`
 
 The `Arr::flatten` method flattens a multi-dimensional array into a single level array:
@@ -109,6 +272,7 @@ $flattened = Arr::flatten($array);
 ```
 
 <a name="method-array-forget"></a>
+
 ### `Arr::forget()`
 
 The `Arr::forget` method removes a given key / value pair from a deeply nested array using "dot" notation:
@@ -124,6 +288,7 @@ Arr::forget($array, 'products.desk');
 ```
 
 <a name="method-array-get"></a>
+
 ### `Arr::get()`
 
 The `Arr::get` method retrieves a value from a deeply nested array using "dot" notation:
@@ -148,6 +313,7 @@ $discount = Arr::get($array, 'products.desk.discount', 0);
 ```
 
 <a name="method-array-has"></a>
+
 ### `Arr::has()`
 
 The `Arr::has` method checks whether a given item or items exists in an array using "dot" notation:
@@ -167,6 +333,152 @@ $contains = Arr::has($array, ['product.price', 'product.discount']);
 ```
 
 <a name="method-array-last"></a>
+
+### `Arr::hasAny($array, $keys)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 530)
+
+Determine if any of the keys exist in an array using "dot" notation.
+
+---
+
+### `Arr::inArray($array, $value)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 562)
+
+Alias of contains.
+
+---
+
+### `Arr::insertAfter($array, $key, $newKey, $newValue)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1653)
+
+Inserts an item after the specified key in the given array. If the
+key is not found, inserts the item at the end of the array.
+
+---
+
+### `Arr::insertAt($array, $pos, $newItem)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1602)
+
+Insert a new item in the array at the given position.
+
+---
+
+### `Arr::insertBefore($array, $key, $newKey, $newValue)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1623)
+
+Inserts an item before the specified key in the given array. If the
+key is not found, inserts the item at the beginning of the array.
+
+---
+
+### `Arr::isAssoc(array $array)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 576)
+
+Determines if an array is associative.
+An array is "associative" if it doesn't have
+sequential numerical keys beginning with zero.
+
+---
+
+### `Arr::isList($array)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 590)
+
+Determines if an array is a list.
+An array is a "list" if all array keys are sequential
+integers starting from 0 with no gaps in between.
+
+---
+
+### `Arr::isTrue($array, $key)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 615)
+
+Determines if the given key contains a boolean value.
+Returns true for true, 1, "1", "true", "on" and "yes"
+Returns false for false, "0", "false", "off", "no", and ""
+Returns for all non-boolean values.
+
+---
+
+### `Arr::keyExists($array, $key)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 195)
+
+Alias of exists.
+
+---
+
+### `Arr::keysDoesNotEndLike($array, $pattern)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1577)
+
+Return non-matching ending of items from array by keys
+
+---
+
+### `Arr::keysDoesNotStartLike($array, $pattern)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1529)
+
+Return non-matching starting of items from array by keys
+
+---
+
+### `Arr::keysEndLike($array, $pattern)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1553)
+
+Return matching ending of items from array by keys
+
+---
+
+### `Arr::keysLike($array, $pattern)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1457)
+
+Return matching items from array by keys
+
+---
+
+### `Arr::keysNotLike($array, $pattern)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1481)
+
+Return non-matching items from array by keys
+
+---
+
+### `Arr::keysStartLike($array, $pattern)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1505)
+
+Return matching starting of items from array by keys
+
+---
+
+### `Arr::krsort($array, $flags = SORT_REGULAR)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 952)
+
+Sort an array by key in descending order.
+
+---
+
+### `Arr::ksort($array, $flags = SORT_REGULAR)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 938)
+
+Sort an array by key in ascending order.
+
+---
+
 ### `Arr::last()`
 
 The `Arr::last` method returns the last element of an array passing a given truth test:
@@ -190,6 +502,84 @@ $last = Arr::last($array, $callback, $default);
 ```
 
 <a name="method-array-only"></a>
+
+### `Arr::lastKey($array, ?callable $callback = null)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 361)
+
+Returns the key of the last item (matching the specified
+callback if given) or null if there is no such item.
+
+---
+
+### `Arr::like($array, $pattern)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1361)
+
+Return matching items from array (similar to mysql's %LIKE%)
+
+---
+
+### `Arr::map($value, $callback)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1171)
+
+Maps a function to all non-iterable elements of an array or an object.
+This is similar to `array_walk_recursive()` but acts upon objects too.
+
+---
+
+### `Arr::mergeMissing(&$array1, &$array2)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1300)
+
+Merge the items from the first array into the
+second array if the second array is missing it.
+
+---
+
+### `Arr::mergeMissingValues(array $array, array $defaults)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1328)
+
+Recursively merge the given array with defaults.
+Overwrite $array with $defaults if only $array
+contains null or empty values or doesn't exist.
+
+---
+
+### `Arr::natcasesort($array)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 978)
+
+Sort an array using a case insensitive "natural order" algorithm.
+
+---
+
+### `Arr::natsort($array)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 965)
+
+Sort an array using a "natural order" algorithm.
+
+---
+
+### `Arr::notLike($array, $pattern)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1377)
+
+Return non-matching items from array (similar to mysql's NOT %LIKE%)
+
+---
+
+### `Arr::of(array $array)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 22)
+
+Makes a collection from array
+
+---
+
 ### `Arr::only()`
 
 The `Arr::only` method returns only the specified key / value pairs from the given array:
@@ -203,6 +593,15 @@ $slice = Arr::only($array, ['name', 'price']);
 // ['name' => 'Desk', 'price' => 100]
 ```
 <a name="method-array-pluck"></a>
+
+### `Arr::passThrough(array $items, array $callbacks, $mode = 0)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1772)
+
+Pass the items through a series of callbacks.
+
+---
+
 ### `Arr::pluck()`
 
 The `Arr::pluck` method retrieves all of the values for a given key from an array:
@@ -227,6 +626,7 @@ $names = Arr::pluck($array, 'developer.name', 'developer.id');
 // [1 => 'Jewel', 2 => 'Adre']
 ```
 <a name="method-array-prepend"></a>
+
 ### `Arr::prepend()`
 
 The `Arr::prepend` method will push an item onto the beginning of an array:
@@ -252,6 +652,7 @@ $array = Arr::prepend($array, 'Desk', 'name');
 ```
 
 <a name="method-array-pull"></a>
+
 ### `Arr::pull()`
 
 The `Arr::pull` method returns and removes a key / value pair from an array:
@@ -274,6 +675,15 @@ use FluentForm\Framework\Support\Arr;
 $value = Arr::pull($array, $key, $default);
 ```
 <a name="method-array-random"></a>
+
+### `Arr::query($array)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 761)
+
+Convert the array into a query string.
+
+---
+
 ### `Arr::random()`
 
 The `Arr::random` method returns a random value from an array:
@@ -296,6 +706,23 @@ $items = Arr::random($array, 2);
 ```
 
 <a name="method-array-set"></a>
+
+### `Arr::rsort($array, $flags = SORT_REGULAR)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 896)
+
+Sort an array in descending order.
+
+---
+
+### `Arr::select($array, $keys)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 643)
+
+Select an array of values from an array.
+
+---
+
 ### `Arr::set()`
 
 The `Arr::set` method sets a value within a deeply nested array using "dot" notation:
@@ -310,6 +737,24 @@ Arr::set($array, 'products.desk.price', 200);
 ```
 
 <a name="method-array-sort"></a>
+
+### `Arr::shuffle($array, $seed = null)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 860)
+
+Shuffle the given array and return the result.
+
+---
+
+### `Arr::some($array, callable $callback)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1681)
+
+Tests whether at least one element in the array passes
+the test implemented by the provided callback.
+
+---
+
 ### `Arr::sort()`
 
 The `Arr::sort` method sorts an array by its values:
@@ -346,6 +791,7 @@ $sorted = array_values(Arr::sort($array, function ($value) {
 */
 ```
 <a name="method-array-sort-recursive"></a>
+
 ### `Arr::sortRecursive()`
 
 The `Arr::sortRecursive` method recursively sorts an array using the `sort` function for numeric sub=arrays and `ksort` for associative sub-arrays:
@@ -370,6 +816,74 @@ $sorted = Arr::sortRecursive($array);
 ```
 
 <a name="method-array-where"></a>
+
+### `Arr::sortRecursiveDesc($array,
+        $options = SORT_REGULAR,
+        $desc = false)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1065)
+
+Recursively sort an array by keys and values in Descending order.
+
+---
+
+### `Arr::startsLike($array, $pattern)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1393)
+
+Return matching starting of items from array (similar to mysql's %LIKE)
+
+---
+
+### `Arr::toCssClasses($array)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1080)
+
+Conditionally compile classes from an array into a CSS class list.
+
+---
+
+### `Arr::toObject($array)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1102)
+
+Transforms an array to \stdClass
+
+---
+
+### `Arr::uasort($array, callable $callback)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1005)
+
+Sort an array with a user-defined comparison
+function and maintain index association.
+
+---
+
+### `Arr::uksort($array, callable $callback)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1018)
+
+Sort an array by keys using a user-defined comparison function.
+
+---
+
+### `Arr::undot($array)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 144)
+
+Convert a flatten "dot" notation array into an expanded array.
+
+---
+
+### `Arr::usort($array, callable $callback)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 991)
+
+Sort an array by values using a user-defined comparison function.
+
+---
+
 ### `Arr::where()`
 
 The `Arr::where` method filters an array using the given Closure:
@@ -384,3 +898,27 @@ $filtered = Arr::where($array, function ($value, $key) {
 
 // [1 => '200', 3 => '400']
 ```
+
+### `Arr::whereNotNull($array)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1125)
+
+Filter items where the value is not null.
+
+---
+
+### `Arr::whereNotTrue($array, $strict = false)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1138)
+
+Filter items where the value is not null.
+
+---
+
+### `Arr::wrap($value)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Arr.php` (line 1151)
+
+If the given value is not an array and not null, wrap it in one.
+
+---

--- a/src/helpers/index.md
+++ b/src/helpers/index.md
@@ -3,7 +3,6 @@
 Fluent Forms provides few helper classes that you can interact easily to build advanced functionalities on your plugin.
 Many of these functions are used by the plugin itself; however, you are free to use them in your own addon if you find them convenient.
 
-
 # Fluent Forms Core Helper Class
 
 - Class with Namespace: `\FluentForm\App\Helpers\Helper`
@@ -12,94 +11,39 @@ Many of these functions are used by the plugin itself; however, you are free to 
 [[toc]]
 
 <a name="method-helper-get-forms"></a>
-### `Helper::getForms()`
 
-The `Helper::getForms` method returns all forms with form id as keyed array.
+### `Helper::advancedOptionsValueLabelMap($options)`
 
-```php
-use FluentForm\App\Helpers\Helper;
+**Source:** `app/Helpers/Helper.php` (line 137)
 
-$forms = Helper::getForms();
-/*
-[
-    0 => "Select a Fluent Forms"
-  335 => "Blank Form (335)"
-  333 => "Conversational Form (333)"
-  332 => "Blank Form (332)"
-  309 => "Chain Select field (309)"
-  306 => "Step Custom HTML (306)"
-  241 => "Polling Form (241)"
-  240 => "Conversational Form (240)"
-  237 => "User With Additional info (237)"
-]
-*/
-```
-------------------------------------------
+---
 
-<a name="method-helper-get-form"></a>
-### `Helper::getForm()`
+### `Helper::arrayFilterRecursive($arrayItems)`
 
-The `Helper::getForm` method return form as object.
+**Source:** `app/Helpers/Helper.php` (line 1116)
 
-**Arguments**
-- `form_id` - (int) Form ID
+---
 
-```php
-use FluentForm\App\Helpers\Helper;
+### `Helper::deleteFormMeta($formId, $metaKey)`
 
-$form = Helper::getForm(240); // pass your form id
-/*
-$form->type // form
-$form->title // Conversational Form (240)
-$form->created_at // 2023-03-10 10:44:00
-$form->updated_at // 2023-03-15 13:51:39
-$form->form_fields // "{"fields":[{"index":6,"element":"input_number","attributes":{...},"settings":{...}}, {...}], ..., "}"
-*/
-```
----------------------------------------
+**Source:** `app/Helpers/Helper.php` (line 303)
 
-<a name="method-helper-set-form-meta"></a>
-### `Helper::setFormMeta()`
+---
 
-The `Helper::setFormMeta` method set a meta value for specific form. If success return meta ID otherwise return null.
+### `Helper::fileUploadLocations()`
 
-**Arguments** 
-- `form_id` - (int) Form ID
-- `meta_key` - (string) Meta key
-- `meta_value` - (mixed) Meta value. If needed to be stored with json encrypted
+**Source:** `app/Helpers/Helper.php` (line 874)
 
-```php
-use FluentForm\App\Helpers\Helper;
+---
 
-$metaID = Helper::setFormMeta(240, '_my_meta_key', ['string', "mixed" => [45, '34', true, 'string']]);
-//meta id - 2656
-```
--------------------------------------
+### `Helper::flattenAdvancedOptions($options)`
 
-<a name="method-helper-get-form-meta"></a>
-### `Helper::getFormMeta()`
+**Source:** `app/Helpers/Helper.php` (line 110)
 
-The `Helper::getFormMeta` method returns a meta value for specific meta key. If not found return default value passed by arguments.
+Sanitize form inputs recursively.
 
-**Arguments** 
-- `form_id` - (int) Form ID
-- `meta_key` - (string) Meta key
-- `default` - (mixed) Default Meta value. Optional, if omitted pass '' as default;
+---
 
-```php
-use FluentForm\App\Helpers\Helper;
-
-$value = Helper::getFormMeta(240, '_my_meta_key');
-/* 
-[
-  0 => "string"
-  "mixed" => [45, '34', true, 'string']
-]
-*/
-```
----------------------------------------
-
-<a name="method-helper-form-extra-css-class"></a>
 ### `Helper::formExtraCssClass()`
 
 The `Helper::formExtraCssClass` method returns form extra css class that set in form settings page.
@@ -117,115 +61,55 @@ $extraCssClass = Helper::formExtraCssClass($form);
 -----------------------------------------
 
 <a name="method-helper-is-multi-step-form"></a>
-### `Helper::isMultiStepForm()`
 
-The `Helper::isMultiStepForm` method check form has multistep or not. If it has multistep return true otherwise false.
+### `Helper::getAjaxUrl()`
 
-**Arguments** 
-- `form_id` - (int) Form ID
+**Source:** `app/Helpers/Helper.php` (line 1401)
 
-```php
-use FluentForm\App\Helpers\Helper;
+Shortcode parse on validation message
 
-$isMultiStepForm = Helper::isMultiStepForm(240);
-// false
-```
------------------------------------------------
+---
 
-<a name="method-helper-is-conversational-form"></a>
-### `Helper::isConversionForm()`
+### `Helper::getCountryCodeFromHeaders()`
 
-The `Helper::isConversionForm` method check form is conversational or not. If conversational return true otherwise false.
+**Source:** `app/Helpers/Helper.php` (line 1524)
 
-**Arguments** 
-- `form_id` - (int) Form ID
+Determine pro payment script is compatible or not
+Script is compatible if pro version meets the minimum required version
 
-```php
-use FluentForm\App\Helpers\Helper;
+---
 
-$isConversionForm = Helper::isConversionForm(240);
-// true
-```
-------------------------------------------------
+### `Helper::getDefaultDateTimeFormatForMoment()`
 
-<a name="method-helper-get-preview-url"></a>
-### `Helper::getPreviewUrl()`
+**Source:** `app/Helpers/Helper.php` (line 1406)
 
-The `Helper::getPreviewUrl` method return form preview url.
+Shortcode parse on validation message
 
-**Arguments** 
-- `form_id` - (int) Form ID
-- `type` - (string) Form Type. Optional, if omitted return normal preview url
-  - `conversational` For conversational form preview url
-  - `classic` Form classic preview url
+---
 
-```php
-use FluentForm\App\Helpers\Helper;
+### `Helper::getDuplicateFieldNames()`
 
-$previewUrl = Helper::getPreviewUrl(240, 'conversational');
-// http://fluentformsite.test/?fluent-form=240
-```
---------------------------------------------------
-
-<a name="method-helper-set-submission-meta"></a>
-### `Helper::setSubmissionMeta()`
-
-The `Helper::setSubmissionMeta` method set a meta value for specific submission. If success return meta ID otherwise return null.
+The `Helper::getDuplicateFieldNames` method returns duplicate field name index name pair if it has.
 
 **Arguments**
-- `submission_id` - (int) Submission ID
-- `meta_key` - (string) Meta key
-- `meta_value` - (mixed) Meta value. If needed to be stored with serialized encrypted
-- `form_id` - (int) Form ID. Optional, it omitted form ID detect automatically.
+- `fields` - (string) Form Fields JSON String.
 
 ```php
 use FluentForm\App\Helpers\Helper;
 
-$metaID = Helper::setSubmissionMeta(2, '_my_meta_key', ['string', "mixed" => [45, '34', true, 'string']], 240);
-//meta id - 2657
+$form = Helper::getForm(240);
+$duplicates = Helper::getDuplicateFieldNames($form->form_fields);
+if ($duplicates) {
+    print_r($duplicates);
+    /*
+     * Array ( [7] => email )
+     */
+}
 ```
 --------------------------------------------------
 
-<a name="method-helper-get-submission-meta"></a>
-### `Helper::getSubmissionMeta()`
+<a name="method-helper-is-json"></a>
 
-The `Helper::getSubmissionMeta` method returns a submission meta value for specific meta key. If not found return default value passed by arguments.
-
-**Arguments**
-- `submission_id` - (int) Submission ID
-- `meta_key` - (string) Meta key
-- `default` - (mixed) Default Meta value. Optional, if omitted pass false as default;
-
-```php
-use FluentForm\App\Helpers\Helper;
-
-$value = Helper::getSubmissionMeta(2, '_my_meta_key');
-/* 
-[
-  0 => "string"
-  "mixed" => [45, '34', true, 'string']
-]
-*/
-```
---------------------------------------------------
-
-<a name="method-helper-unread-count"></a>
-### `Helper::unreadCount()`
-
-The `Helper::unreadCount` method returns total count of unread submission.
-
-**Arguments**
-- `form_id` - (int) Form ID
-
-```php
-use FluentForm\App\Helpers\Helper;
-
-$unreadSubmissionCount = Helper::unreadCount(240);
-// 5
-```
---------------------------------------------------
-
-<a name="method-helper-get-entry-statuses"></a>
 ### `Helper::getEntryStatuses()`
 
 The `Helper::getEntryStatuses` method returns fluentform submission core statuses array key name pair.
@@ -251,6 +135,152 @@ $entryStatuses = Helper::getEntryStatuses(240);
 --------------------------------------------------
 
 <a name="method-helper-get-numeric-formatted"></a>
+
+### `Helper::getForm()`
+
+The `Helper::getForm` method return form as object.
+
+**Arguments**
+- `form_id` - (int) Form ID
+
+```php
+use FluentForm\App\Helpers\Helper;
+
+$form = Helper::getForm(240); // pass your form id
+/*
+$form->type // form
+$form->title // Conversational Form (240)
+$form->created_at // 2023-03-10 10:44:00
+$form->updated_at // 2023-03-15 13:51:39
+$form->form_fields // "{"fields":[{"index":6,"element":"input_number","attributes":{...},"settings":{...}}, {...}], ..., "}"
+*/
+```
+---------------------------------------
+
+<a name="method-helper-set-form-meta"></a>
+
+### `Helper::getFormAdminPermalink($route, $form)`
+
+**Source:** `app/Helpers/Helper.php` (line 834)
+
+---
+
+### `Helper::getFormInstaceClass($formId)`
+
+**Source:** `app/Helpers/Helper.php` (line 375)
+
+---
+
+### `Helper::getFormMeta()`
+
+The `Helper::getFormMeta` method returns a meta value for specific meta key. If not found return default value passed by arguments.
+
+**Arguments** 
+- `form_id` - (int) Form ID
+- `meta_key` - (string) Meta key
+- `default` - (mixed) Default Meta value. Optional, if omitted pass '' as default;
+
+```php
+use FluentForm\App\Helpers\Helper;
+
+$value = Helper::getFormMeta(240, '_my_meta_key');
+/* 
+[
+  0 => "string"
+  "mixed" => [45, '34', true, 'string']
+]
+*/
+```
+---------------------------------------
+
+<a name="method-helper-form-extra-css-class"></a>
+
+### `Helper::getForms()`
+
+The `Helper::getForms` method returns all forms with form id as keyed array.
+
+```php
+use FluentForm\App\Helpers\Helper;
+
+$forms = Helper::getForms();
+/*
+[
+    0 => "Select a Fluent Forms"
+  335 => "Blank Form (335)"
+  333 => "Conversational Form (333)"
+  332 => "Blank Form (332)"
+  309 => "Chain Select field (309)"
+  306 => "Step Custom HTML (306)"
+  241 => "Polling Form (241)"
+  240 => "Conversational Form (240)"
+  237 => "User With Additional info (237)"
+]
+*/
+```
+------------------------------------------
+
+<a name="method-helper-get-form"></a>
+
+### `Helper::getFormSettingsUrl($form)`
+
+**Source:** `app/Helpers/Helper.php` (line 841)
+
+---
+
+### `Helper::getFormsIdsFromBlocks($content)`
+
+**Source:** `app/Helpers/Helper.php` (line 468)
+
+---
+
+### `Helper::getFrontendFacingUrl($args = '')`
+
+**Source:** `app/Helpers/Helper.php` (line 1519)
+
+Determine pro payment script is compatible or not
+Script is compatible if pro version meets the minimum required version
+
+---
+
+### `Helper::getHtmlElementClass($value1, $value2, $class = 'active', $default = '')`
+
+**Source:** `app/Helpers/Helper.php` (line 171)
+
+---
+
+### `Helper::getInputNameFromShortCode($value)`
+
+**Source:** `app/Helpers/Helper.php` (line 1044)
+
+---
+
+### `Helper::getIpinfo()`
+
+**Source:** `app/Helpers/Helper.php` (line 1089)
+
+---
+
+### `Helper::getLandingPageEnabledForms()`
+
+**Source:** `app/Helpers/Helper.php` (line 1495)
+
+Determine pro payment script is compatible or not
+Script is compatible if pro version meets the minimum required version
+
+---
+
+### `Helper::getLogInitiator($action, $type = 'log')`
+
+**Source:** `app/Helpers/Helper.php` (line 1072)
+
+---
+
+### `Helper::getNextTabIndex($increment = 1)`
+
+**Source:** `app/Helpers/Helper.php` (line 364)
+
+---
+
 ### `Helper::getNumericFormatted()`
 
 The `Helper::getNumericFormatted` method returns formatted numeric value in specify format depend on format config passed by arguments.
@@ -272,6 +302,13 @@ if ($formatterConfig) {
 --------------------------------------------------
 
 <a name="method-helper-get-numeric-value"></a>
+
+### `Helper::getNumericFormatters()`
+
+**Source:** `app/Helpers/Helper.php` (line 606)
+
+---
+
 ### `Helper::getNumericValue()`
 
 The `Helper::getNumericValue` method convert formatted numeric value to numeric value depend on format config passed by arguments, and returns numeric value.
@@ -293,80 +330,41 @@ if ($formatterConfig) {
 --------------------------------------------------
 
 <a name="method-helper-get-duplicate-field-names"></a>
-### `Helper::getDuplicateFieldNames()`
 
-The `Helper::getDuplicateFieldNames` method returns duplicate field name index name pair if it has.
+### `Helper::getPreviewUrl()`
 
-**Arguments**
-- `fields` - (string) Form Fields JSON String.
+The `Helper::getPreviewUrl` method return form preview url.
 
-```php
-use FluentForm\App\Helpers\Helper;
-
-$form = Helper::getForm(240);
-$duplicates = Helper::getDuplicateFieldNames($form->form_fields);
-if ($duplicates) {
-    print_r($duplicates);
-    /*
-     * Array ( [7] => email )
-     */
-}
-```
---------------------------------------------------
-
-<a name="method-helper-is-json"></a>
-### `Helper::isJson()`
-
-The `Helper::isJson` method check given value is json or not. If json return true otherwise false.
-
-**Arguments**
-- `data` - (string) Data to check.
+**Arguments** 
+- `form_id` - (int) Form ID
+- `type` - (string) Form Type. Optional, if omitted return normal preview url
+  - `conversational` For conversational form preview url
+  - `classic` Form classic preview url
 
 ```php
 use FluentForm\App\Helpers\Helper;
 
-$form = Helper::getForm(240);
-$isJson = Helper::isJson($form->form_fields);
-if ($isJson) {
-    /json_decode($form->form_fields)
-}
+$previewUrl = Helper::getPreviewUrl(240, 'conversational');
+// http://fluentformsite.test/?fluent-form=240
 ```
 --------------------------------------------------
 
-<a name="method-helper-is-entry-auto-delete-enabled"></a>
-### `Helper::isEntryAutoDeleteEnabled()`
+<a name="method-helper-set-submission-meta"></a>
 
-The `Helper::isEntryAutoDeleteEnabled` method check form has enabled submission auto delete or not. If enabled return true otherwise false.
+### `Helper::getRankingFieldsWithDuplicateOptionValues($fields)`
 
-**Arguments**
-- `form_id` - (int) Form ID.
+**Source:** `app/Helpers/Helper.php` (line 709)
 
-```php
-use FluentForm\App\Helpers\Helper;
+---
 
-$isEntryAutoDeleteEnable = Helper::isEntryAutoDeleteEnabled(240);
-if ($isEntryAutoDeleteEnable) {
-    // do stuff
-}
-```
---------------------------------------------------
+### `Helper::getReportableInputs()`
 
-<a name="method-helper-is-fluentform-admin-page"></a>
-### `Helper::isFluentAdminPage()`
+**Source:** `app/Helpers/Helper.php` (line 223)
 
-The `Helper::isFluentAdminPage` method check current page is fluentform admin page or not. If admin page return true otherwise false.
+Determines if the given string is a valid json.
 
-```php
-use FluentForm\App\Helpers\Helper;
+---
 
-$isFluentFormAdminPage = Helper::isFluentAdminPage();
-if ($isFluentFormAdminPage) {
-    // do stuff
-}
-```
---------------------------------------------------
-
-<a name="method-helper-get-rest-info"></a>
 ### `Helper::getRestInfo()`
 
 The `Helper::getRestInfo` method returns rest information configuration.
@@ -387,4 +385,417 @@ $restInfo = Helper::getRestInfo();
 ```
 --------------------------------------------------
 
+### `Helper::getShortCodeIds($content, $tag = 'fluentform', $selector = 'id')`
 
+**Source:** `app/Helpers/Helper.php` (line 421)
+
+---
+
+### `Helper::getSubFieldReportableInputs()`
+
+**Source:** `app/Helpers/Helper.php` (line 248)
+
+Determines if the given string is a valid json.
+
+---
+
+### `Helper::getSubmissionMeta()`
+
+The `Helper::getSubmissionMeta` method returns a submission meta value for specific meta key. If not found return default value passed by arguments.
+
+**Arguments**
+- `submission_id` - (int) Submission ID
+- `meta_key` - (string) Meta key
+- `default` - (mixed) Default Meta value. Optional, if omitted pass false as default;
+
+```php
+use FluentForm\App\Helpers\Helper;
+
+$value = Helper::getSubmissionMeta(2, '_my_meta_key');
+/* 
+[
+  0 => "string"
+  "mixed" => [45, '34', true, 'string']
+]
+*/
+```
+--------------------------------------------------
+
+<a name="method-helper-unread-count"></a>
+
+### `Helper::getTabularGridFormatValue($girdData,
+        $field,
+        $rowJoiner = '<br />',
+        $colJoiner = ', ',
+        $type = '')`
+
+**Source:** `app/Helpers/Helper.php` (line 991)
+
+---
+
+### `Helper::getWhiteListedFields($formId)`
+
+**Source:** `app/Helpers/Helper.php` (line 1356)
+
+---
+
+### `Helper::hasBrTag($content)`
+
+**Source:** `app/Helpers/Helper.php` (line 937)
+
+---
+
+### `Helper::hasFormElement($formId, $elementName)`
+
+**Source:** `app/Helpers/Helper.php` (line 549)
+
+---
+
+### `Helper::hasPartialEntries($formId)`
+
+**Source:** `app/Helpers/Helper.php` (line 594)
+
+---
+
+### `Helper::hasPro()`
+
+**Source:** `app/Helpers/Helper.php` (line 1490)
+
+Determine pro payment script is compatible or not
+Script is compatible if pro version meets the minimum required version
+
+---
+
+### `Helper::isAutoloadCaptchaEnabled()`
+
+**Source:** `app/Helpers/Helper.php` (line 1094)
+
+---
+
+### `Helper::isAutosaveEnabled()`
+
+**Source:** `app/Helpers/Helper.php` (line 1099)
+
+---
+
+### `Helper::isBlockEditor()`
+
+**Source:** `app/Helpers/Helper.php` (line 1127)
+
+---
+
+### `Helper::isConversionForm()`
+
+The `Helper::isConversionForm` method check form is conversational or not. If conversational return true otherwise false.
+
+**Arguments** 
+- `form_id` - (int) Form ID
+
+```php
+use FluentForm\App\Helpers\Helper;
+
+$isConversionForm = Helper::isConversionForm(240);
+// true
+```
+------------------------------------------------
+
+<a name="method-helper-get-preview-url"></a>
+
+### `Helper::isDefaultWPDateEnabled()`
+
+**Source:** `app/Helpers/Helper.php` (line 1461)
+
+Shortcode parse on validation message
+
+---
+
+### `Helper::isElementorEditor()`
+
+**Source:** `app/Helpers/Helper.php` (line 1598)
+
+If elementor editor is open
+
+---
+
+### `Helper::isEntryAutoDeleteEnabled()`
+
+The `Helper::isEntryAutoDeleteEnabled` method check form has enabled submission auto delete or not. If enabled return true otherwise false.
+
+**Arguments**
+- `form_id` - (int) Form ID.
+
+```php
+use FluentForm\App\Helpers\Helper;
+
+$isEntryAutoDeleteEnable = Helper::isEntryAutoDeleteEnabled(240);
+if ($isEntryAutoDeleteEnable) {
+    // do stuff
+}
+```
+--------------------------------------------------
+
+<a name="method-helper-is-fluentform-admin-page"></a>
+
+### `Helper::isFluentAdminPage()`
+
+The `Helper::isFluentAdminPage` method check current page is fluentform admin page or not. If admin page return true otherwise false.
+
+```php
+use FluentForm\App\Helpers\Helper;
+
+$isFluentFormAdminPage = Helper::isFluentAdminPage();
+if ($isFluentFormAdminPage) {
+    // do stuff
+}
+```
+--------------------------------------------------
+
+<a name="method-helper-get-rest-info"></a>
+
+### `Helper::isJson()`
+
+The `Helper::isJson` method check given value is json or not. If json return true otherwise false.
+
+**Arguments**
+- `data` - (string) Data to check.
+
+```php
+use FluentForm\App\Helpers\Helper;
+
+$form = Helper::getForm(240);
+$isJson = Helper::isJson($form->form_fields);
+if ($isJson) {
+    /json_decode($form->form_fields)
+}
+```
+--------------------------------------------------
+
+<a name="method-helper-is-entry-auto-delete-enabled"></a>
+
+### `Helper::isMultiStepForm()`
+
+The `Helper::isMultiStepForm` method check form has multistep or not. If it has multistep return true otherwise false.
+
+**Arguments** 
+- `form_id` - (int) Form ID
+
+```php
+use FluentForm\App\Helpers\Helper;
+
+$isMultiStepForm = Helper::isMultiStepForm(240);
+// false
+```
+-----------------------------------------------
+
+<a name="method-helper-is-conversational-form"></a>
+
+### `Helper::isOptionGroup($option)`
+
+**Source:** `app/Helpers/Helper.php` (line 59)
+
+Sanitize form inputs recursively.
+
+---
+
+### `Helper::isPaymentCompatible()`
+
+**Source:** `app/Helpers/Helper.php` (line 1467)
+
+---
+
+### `Helper::isProPaymentScriptCompatible()`
+
+**Source:** `app/Helpers/Helper.php` (line 1482)
+
+Determine pro payment script is compatible or not
+Script is compatible if pro version meets the minimum required version
+
+---
+
+### `Helper::isSiteEditor()`
+
+**Source:** `app/Helpers/Helper.php` (line 1611)
+
+Check if we're in block editor context (Site Editor, Template Editor, or Post/Page Editor)
+Covers all Gutenberg block editor contexts including mobile/tablet preview iframes
+
+---
+
+### `Helper::isSlackEnabled()`
+
+**Source:** `app/Helpers/Helper.php` (line 190)
+
+Determines if the given string is a valid json.
+
+---
+
+### `Helper::isTabIndexEnabled()`
+
+**Source:** `app/Helpers/Helper.php` (line 513)
+
+---
+
+### `Helper::isUniqueValidation($validation, $field, $formData, $fields, $form)`
+
+**Source:** `app/Helpers/Helper.php` (line 557)
+
+---
+
+### `Helper::makeMenuUrl($page = 'fluent_forms_settings', $component = null)`
+
+**Source:** `app/Helpers/Helper.php` (line 148)
+
+---
+
+### `Helper::maybeDecryptUrl($url)`
+
+**Source:** `app/Helpers/Helper.php` (line 1105)
+
+---
+
+### `Helper::replaceBrTag($content, $with = '')`
+
+**Source:** `app/Helpers/Helper.php` (line 924)
+
+---
+
+### `Helper::resetTabIndex()`
+
+**Source:** `app/Helpers/Helper.php` (line 382)
+
+---
+
+### `Helper::resolveValidationRulesGlobalOption(&$field)`
+
+**Source:** `app/Helpers/Helper.php` (line 1133)
+
+---
+
+### `Helper::safeUnserialize($data)`
+
+**Source:** `app/Helpers/Helper.php` (line 1586)
+
+Fixes PHP Object Injection Vulnerability
+
+---
+
+### `Helper::sanitizeAdvancedOptions($options, $depth = 0)`
+
+**Source:** `app/Helpers/Helper.php` (line 66)
+
+Sanitize form inputs recursively.
+
+---
+
+### `Helper::sanitizeArrayKeysAndValues($values)`
+
+**Source:** `app/Helpers/Helper.php` (line 1506)
+
+Determine pro payment script is compatible or not
+Script is compatible if pro version meets the minimum required version
+
+---
+
+### `Helper::sanitizeForCSV($content)`
+
+**Source:** `app/Helpers/Helper.php` (line 942)
+
+---
+
+### `Helper::sanitizeOrderValue($orderType = '')`
+
+**Source:** `app/Helpers/Helper.php` (line 955)
+
+---
+
+### `Helper::sanitizer($input, $attribute = null, $fields = [])`
+
+**Source:** `app/Helpers/Helper.php` (line 38)
+
+Sanitize form inputs recursively.
+
+---
+
+### `Helper::setFormMeta()`
+
+The `Helper::setFormMeta` method set a meta value for specific form. If success return meta ID otherwise return null.
+
+**Arguments** 
+- `form_id` - (int) Form ID
+- `meta_key` - (string) Meta key
+- `meta_value` - (mixed) Meta value. If needed to be stored with json encrypted
+
+```php
+use FluentForm\App\Helpers\Helper;
+
+$metaID = Helper::setFormMeta(240, '_my_meta_key', ['string', "mixed" => [45, '34', true, 'string']]);
+//meta id - 2656
+```
+-------------------------------------
+
+<a name="method-helper-get-form-meta"></a>
+
+### `Helper::setSubmissionMeta()`
+
+The `Helper::setSubmissionMeta` method set a meta value for specific submission. If success return meta ID otherwise return null.
+
+**Arguments**
+- `submission_id` - (int) Submission ID
+- `meta_key` - (string) Meta key
+- `meta_value` - (mixed) Meta value. If needed to be stored with serialized encrypted
+- `form_id` - (int) Form ID. Optional, it omitted form ID detect automatically.
+
+```php
+use FluentForm\App\Helpers\Helper;
+
+$metaID = Helper::setSubmissionMeta(2, '_my_meta_key', ['string', "mixed" => [45, '34', true, 'string']], 240);
+//meta id - 2657
+```
+--------------------------------------------------
+
+<a name="method-helper-get-submission-meta"></a>
+
+### `Helper::setSubmissionMetaAsArrayPush($submissionId, $metaKey, $value, $formId = false)`
+
+**Source:** `app/Helpers/Helper.php` (line 326)
+
+---
+
+### `Helper::shortCodeParseOnValidationMessage($message, $form, $fieldName)`
+
+**Source:** `app/Helpers/Helper.php` (line 1384)
+
+Shortcode parse on validation message
+
+---
+
+### `Helper::shouldHidePassword($formId)`
+
+**Source:** `app/Helpers/Helper.php` (line 969)
+
+---
+
+### `Helper::unreadCount()`
+
+The `Helper::unreadCount` method returns total count of unread submission.
+
+**Arguments**
+- `form_id` - (int) Form ID
+
+```php
+use FluentForm\App\Helpers\Helper;
+
+$unreadSubmissionCount = Helper::unreadCount(240);
+// 5
+```
+--------------------------------------------------
+
+<a name="method-helper-get-entry-statuses"></a>
+
+### `Helper::validateInput($field, $formData, $form, $fieldName = '', $inputValue = [])`
+
+**Source:** `app/Helpers/Helper.php` (line 1163)
+
+Validate form input value against database values
+
+---

--- a/src/helpers/integration-manager-helper.md
+++ b/src/helpers/integration-manager-helper.md
@@ -1,0 +1,49 @@
+# `IntegrationManagerHelper`
+
+<Badge type="tip" vertical="top" text="Helper" /> <Badge type="warning" vertical="top" text="Auto-extracted" />
+
+Static helpers used internally by integration controllers — exposed here for extension authors who need the same helpers (e.g. when building a custom integration that mirrors the standard registration / settings shape).
+
+Source: `app/Helpers/IntegrationManagerHelper.php`
+
+### `IntegrationManagerHelper::delete($settingsId)`
+
+**Source:** `app/Helpers/IntegrationManagerHelper.php` (line 51)
+
+---
+
+### `IntegrationManagerHelper::get($settingsId)`
+
+**Source:** `app/Helpers/IntegrationManagerHelper.php` (line 25)
+
+---
+
+### `IntegrationManagerHelper::getAll()`
+
+**Source:** `app/Helpers/IntegrationManagerHelper.php` (line 57)
+
+---
+
+### `IntegrationManagerHelper::getFormattedValue($setting)`
+
+**Source:** `app/Helpers/IntegrationManagerHelper.php` (line 119)
+
+---
+
+### `IntegrationManagerHelper::isIntegrationEnabled($key)`
+
+**Source:** `app/Helpers/IntegrationManagerHelper.php` (line 128)
+
+---
+
+### `IntegrationManagerHelper::save($settings)`
+
+**Source:** `app/Helpers/IntegrationManagerHelper.php` (line 34)
+
+---
+
+### `IntegrationManagerHelper::update($settingsId, $settings)`
+
+**Source:** `app/Helpers/IntegrationManagerHelper.php` (line 43)
+
+---

--- a/src/helpers/protector.md
+++ b/src/helpers/protector.md
@@ -6,35 +6,7 @@
 [[toc]]
 
 <a name="method-protector-get-salt"></a>
-### `Protector::getSalt()`
 
-The `Protector::getSalt` method returns Fluent Forms encryption and decryption security salt.
-
-```php 
-    use FluentForm\App\Helpers\Protector;
-
-    $ffSecuritySalt = Protector::getSalt();
-
-    // security slot
-```
-
-
-
-<a name="method-protector-encrypt"></a>
-### `Protector::encrypt()`
-
-The `Protector::encrypt` method convert normal text to encryption text using a predefined salt and return encrypted text.
-
-```php 
-    use FluentForm\App\Helpers\Protector;
-
-    $encryptedText = Protector::encrypt('sample text');
-
-    // xfQuSDtj2ywFsN+alzijiAtT9oJwSjoPiqVLSA80pN73U630bsRbf/mGM7haaNWazIawwDV6Kp04BBWJlyb/oA==
-```
-
-
-<a name="method-protector-decrypt"></a>
 ### `Protector::decrypt()`
 
 The `Protector::decrypt`  method convert encrypted text to normal text using a predefined salt and return decrypted text.
@@ -47,5 +19,30 @@ The `Protector::decrypt`  method convert encrypted text to normal text using a p
     // sample text
 ```
 
+### `Protector::encrypt()`
 
+The `Protector::encrypt` method convert normal text to encryption text using a predefined salt and return encrypted text.
 
+```php 
+    use FluentForm\App\Helpers\Protector;
+
+    $encryptedText = Protector::encrypt('sample text');
+
+    // xfQuSDtj2ywFsN+alzijiAtT9oJwSjoPiqVLSA80pN73U630bsRbf/mGM7haaNWazIawwDV6Kp04BBWJlyb/oA==
+```
+
+<a name="method-protector-decrypt"></a>
+
+### `Protector::getSalt()`
+
+The `Protector::getSalt` method returns Fluent Forms encryption and decryption security salt.
+
+```php 
+    use FluentForm\App\Helpers\Protector;
+
+    $ffSecuritySalt = Protector::getSalt();
+
+    // security slot
+```
+
+<a name="method-protector-encrypt"></a>

--- a/src/helpers/str.md
+++ b/src/helpers/str.md
@@ -3,50 +3,10 @@
 - Class with Namespace: `\FluentForm\Framework\Support\Str`
 - Method Types: `static`
 
-
 [[toc]]
 
-
 <a name="method-camel-case"></a>
-### `Str::camel()`
 
-The `Str::camel` method converts the given string to `camelCase`:
-
-```php 
-    use FluentForm\Framework\Support\Str;
-
-    $converted = Str::camel('foo_bar');
-
-    // fooBar
-```
-
-<a name="method-ends-with"></a>
-### `Str::endsWith()`
-
-The `Str::endsWith` method determines if the given string ends with the given value:
-
-```php 
-    use FluentForm\Framework\Support\Str;
-
-    $result = Str::endsWith('This is my name', 'name');
-
-    // true
-```
-
-<a name="method-kebab-case"></a>
-### `Str::kebab()`
-
-The `Str::kebab` method converts the given string to `kebab-case`:
-
-```php 
-    use FluentForm\Framework\Support\Str;
-
-    $converted = Str::kebab('fooBar');
-
-    // foo-bar
-```
-
-<a name="method-preg-replace-array"></a>
 ### `preg_replace_array()`
 
 The `preg_replace_array` function replaces a given pattern in the string sequentially using an array:
@@ -60,32 +20,15 @@ The `preg_replace_array` function replaces a given pattern in the string sequent
 ```
 
 <a name="method-snake-case"></a>
-### `Str::snake()`
 
-The `Str::snake` method converts the given string to `snake_case`:
+### `Str::acronym($string, $delimiter = '')`
 
-```php 
-    use FluentForm\Framework\Support\Str;
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 56)
 
-    $converted = Str::snake('fooBar');
+Makes an acronum from a string of words
 
-    // foo_bar
-```
+---
 
-<a name="method-starts-with"></a>
-### `Str::startsWith()`
-
-The `Str::startsWith` method determines if the given string begins with the given value:
-
-```php 
-    use FluentForm\Framework\Support\Str;
-
-    $result = Str::startsWith('This is my name', 'This');
-
-    // true
-```
-
-<a name="method-str-after"></a>
 ### `Str::after()`
 
 The `Str::after` method returns everything after the given value in a string:
@@ -99,6 +42,32 @@ The `Str::after` method returns everything after the given value in a string:
 ```
 
 <a name="method-str-before"></a>
+
+### `Str::afterLast($subject, $search)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 92)
+
+Return the remainder of a string after the last occurrence of a given value.
+
+---
+
+### `Str::apa($value)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1359)
+
+Convert the given string to APA-style title case.
+See: https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case
+
+---
+
+### `Str::ascii($value)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 114)
+
+Transliterate a UTF-8 value to ASCII.
+
+---
+
 ### `Str::before()`
 
 The `Str::before` method returns everything before the given value in a string:
@@ -111,6 +80,69 @@ The `Str::before` method returns everything before the given value in a string:
 ```
 
 <a name="method-str-contains"></a>
+
+### `Str::beforeLast($subject, $search)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 275)
+
+Get the portion of a string before the last occurrence of a given value.
+
+---
+
+### `Str::between($subject, $from, $to)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 298)
+
+Get the portion of a string between two given values.
+
+---
+
+### `Str::betweenFirst($subject, $from, $to)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 315)
+
+Get the smallest possible portion of a string between two given values.
+
+---
+
+### `Str::camel()`
+
+The `Str::camel` method converts the given string to `camelCase`:
+
+```php 
+    use FluentForm\Framework\Support\Str;
+
+    $converted = Str::camel('foo_bar');
+
+    // fooBar
+```
+
+<a name="method-ends-with"></a>
+
+### `Str::charAt($subject, $index)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 346)
+
+Get the character at the specified index.
+
+---
+
+### `Str::chopEnd($subject, $needle)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 382)
+
+Remove the given string(s) if it exists at the end of the haystack.
+
+---
+
+### `Str::chopStart($subject, $needle)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 364)
+
+Remove the given string(s) if it exists at the start of the haystack.
+
+---
+
 ### `Str::contains()`
 
 The `Str::contains` method determines if the given string contains the given value (case sensitive):
@@ -134,6 +166,38 @@ You may also pass an array of values to determine if the given string contains a
 ```
 
 <a name="method-str-finish"></a>
+
+### `Str::containsAll($haystack, $needles, $ignoreCase = false)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 432)
+
+Determine if a given string contains all array values.
+
+---
+
+### `Str::deduplicate(string $string, string $character = ' ')`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 451)
+
+Replace consecutive instances of a given character
+with a single character in the given string.
+
+---
+
+### `Str::endsWith()`
+
+The `Str::endsWith` method determines if the given string ends with the given value:
+
+```php 
+    use FluentForm\Framework\Support\Str;
+
+    $result = Str::endsWith('This is my name', 'name');
+
+    // true
+```
+
+<a name="method-kebab-case"></a>
+
 ### `Str::finish()`
 
 The `Str::finish` method adds a single instance of the given value to a string if it does not already end with the value:
@@ -151,6 +215,47 @@ The `Str::finish` method adds a single instance of the given value to a string i
 ```
 
 <a name="method-str-is"></a>
+
+### `Str::flushCache()`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1818)
+
+Remove all strings from the casing caches.
+
+---
+
+### `Str::fromBase64($string, $strict = false)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1694)
+
+Decode the given Base64 encoded string.
+
+---
+
+### `Str::headline($value)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1338)
+
+Convert the given string to title case for each word.
+
+---
+
+### `Str::incrementBySlug($slug = '')`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1806)
+
+Generate a deterministic unique id by a prefix.
+
+---
+
+### `Str::incrementCounter($prefix = '')`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1795)
+
+Increment a counter.
+
+---
+
 ### `Str::is()`
 
 The `Str::is` method determines if a given string matches a given pattern. Asterisks may be used to indicate wildcards:
@@ -168,6 +273,117 @@ The `Str::is` method determines if a given string matches a given pattern. Aster
 ```
 
 <a name="method-str-limit"></a>
+
+### `Str::isAscii($value)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 571)
+
+Determine if a given string is 7 bit ASCII.
+
+---
+
+### `Str::isCapital($str)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 602)
+
+Checks if the first character is in capital form.
+
+---
+
+### `Str::isCapitalized($str, $onlyFirst = false)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 582)
+
+Checks if the word(s) are in capitalized form.
+
+---
+
+### `Str::isJson($value)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 677)
+
+Determine if a given value is valid JSON.
+
+---
+
+### `Str::isLower($str)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 624)
+
+Checks if the chracters are in lower case
+
+---
+
+### `Str::isMatch($pattern, $value)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 902)
+
+Determine if a given string matches a given pattern.
+
+---
+
+### `Str::isSimilar($str1, $str2, $accuracy = 60)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 649)
+
+Checks if two words are similar
+
+---
+
+### `Str::isUpper($str)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 613)
+
+Checks if the chracters are in upper case
+
+---
+
+### `Str::isUrl($value, array $protocols = [])`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 699)
+
+Determine if a given value is a valid URL.
+
+---
+
+### `Str::isUuid($value)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 741)
+
+Determine if a given string is a valid UUID.
+
+---
+
+### `Str::kebab()`
+
+The `Str::kebab` method converts the given string to `kebab-case`:
+
+```php 
+    use FluentForm\Framework\Support\Str;
+
+    $converted = Str::kebab('fooBar');
+
+    // foo-bar
+```
+
+<a name="method-preg-replace-array"></a>
+
+### `Str::lcfirst($string)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1705)
+
+Make a string's first character lowercase.
+
+---
+
+### `Str::length($value, $encoding = null)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 764)
+
+Return the length of the given string.
+
+---
+
 ### `Str::limit()`
 
 The `Str::limit` method truncates the given string at the specified length:
@@ -191,6 +407,55 @@ You may also pass a third argument to change the string that will be appended to
 ```
 
 <a name="method-str-ordered-uuid"></a>
+
+### `Str::lower($value)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 811)
+
+Convert the given string to lower-case.
+
+---
+
+### `Str::ltrim(string $value, ?string $charlist = null)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1508)
+
+Remove all whitespace (including special Unicode spaces) from the beginning of a string.
+
+---
+
+### `Str::mask($string, $character, $index, $length = null, $encoding = 'UTF-8')`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 845)
+
+Masks a portion of a string with a repeated character.
+
+---
+
+### `Str::match($pattern, $subject)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 884)
+
+Get the string matching the given pattern.
+
+---
+
+### `Str::matchAll($pattern, $subject)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 928)
+
+Get the string matching the given pattern.
+
+---
+
+### `Str::of($string)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 44)
+
+Get a new stringable object from the given string.
+
+---
+
 ### `Str::orderedUuid()`
 
 The `Str::orderedUuid` method generates a "timestamp first" UUID that may be efficiently stored in an indexed database column:
@@ -202,6 +467,71 @@ The `Str::orderedUuid` method generates a "timestamp first" UUID that may be eff
 ```
 
 <a name="method-str-plural"></a>
+
+### `Str::padBoth($value, $length, $pad = ' ')`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 947)
+
+Pad both sides of a string with another.
+
+---
+
+### `Str::padLeft($value, $length, $pad = ' ')`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 960)
+
+Pad the left side of a string with another.
+
+---
+
+### `Str::padRight($value, $length, $pad = ' ')`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 973)
+
+Pad the right side of a string with another.
+
+---
+
+### `Str::parseCallback($callback, $default = null)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 985)
+
+Parse a Class[@]method style callback into class and method.
+
+---
+
+### `Str::parseFloat($value)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1009)
+
+Parse a floasting point number from a string.
+
+---
+
+### `Str::parseInt($value)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 996)
+
+Parse an integer from a string.
+
+---
+
+### `Str::parseNumber($value)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1022)
+
+Remove all non-numeric characters from a string.
+
+---
+
+### `Str::pascal($value)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1592)
+
+Convert a value to Pascal case.
+
+---
+
 ### `Str::plural()`
 
 The `Str::plural` method converts a string to its plural form. This function currently only supports the English language:
@@ -233,6 +563,24 @@ You may provide an integer as a second argument to the function to retrieve the 
 ```
 
 <a name="method-str-random"></a>
+
+### `Str::pluralStudly($value, $count = 2)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1046)
+
+Pluralize the last word of an English, studly caps case string.
+
+---
+
+### `Str::position($haystack, $needle, $offset = 0, $encoding = null)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1065)
+
+Find the multi-byte safe position of the first
+occurrence of a given substring in a string.
+
+---
+
 ### `Str::random()`
 
 The `Str::random` method generates a random string of the specified length. This function uses PHP's `random_bytes` function:
@@ -244,6 +592,31 @@ The `Str::random` method generates a random string of the specified length. This
 ```
 
 <a name="method-str-replace-array"></a>
+
+### `Str::remove($search, $subject, $caseSensitive = true)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1276)
+
+Remove any occurrence of the given string in the subject.
+
+---
+
+### `Str::repeat(string $string, int $times)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1104)
+
+Repeat the given string.
+
+---
+
+### `Str::replace($search, $replace, $subject, $caseSensitive = true)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1139)
+
+Replace the given value in the given string.
+
+---
+
 ### `Str::replaceArray()`
 
 The `Str::replaceArray` method replaces a given value in the string sequentially using an array:
@@ -259,6 +632,15 @@ The `Str::replaceArray` method replaces a given value in the string sequentially
 ```
 
 <a name="method-str-replace-first"></a>
+
+### `Str::replaceEnd($search, $replace, $subject)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1235)
+
+Replace the last occurrence of a given value if it appears at the end of the string.
+
+---
+
 ### `Str::replaceFirst()`
 
 The `Str::replaceFirst` method replaces the first occurrence of a given value in a string:
@@ -272,6 +654,7 @@ The `Str::replaceFirst` method replaces the first occurrence of a given value in
 ```
 
 <a name="method-str-replace-last"></a>
+
 ### `Str::replaceLast()`
 
 The `Str::replaceLast` method replaces the last occurrence of a given value in a string:
@@ -285,6 +668,47 @@ The `Str::replaceLast` method replaces the last occurrence of a given value in a
 ```
 
 <a name="method-str-singular"></a>
+
+### `Str::replaceMatches($pattern, $replace, $subject, $limit = -1)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1259)
+
+Replace the patterns matching the given regular expression.
+
+---
+
+### `Str::replaceStart($search, $replace, $subject)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1189)
+
+Replace the first occurrence of the given value if it appears at the start of the string.
+
+---
+
+### `Str::reverse(string $value)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1291)
+
+Reverse the given string.
+
+---
+
+### `Str::rtrim(string $value, ?string $charlist = null)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1521)
+
+Remove all whitespace (including special Unicode spaces) from the end of a string.
+
+---
+
+### `Str::similarityOf($str1, $str2)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 664)
+
+Checks if two words are similar
+
+---
+
 ### `Str::singular()`
 
 The `Str::singular` method converts a string to its singular form. This function currently only supports the English language:
@@ -302,6 +726,7 @@ The `Str::singular` method converts a string to its singular form. This function
 ```
 
 <a name="method-str-slug"></a>
+
 ### `Str::slug()`
 
 The `Str::slug` method generates a URL friendly "slug" from the given string:
@@ -315,6 +740,37 @@ The `Str::slug` method generates a URL friendly "slug" from the given string:
 ```
 
 <a name="method-str-start"></a>
+
+### `Str::snake()`
+
+The `Str::snake` method converts the given string to `snake_case`:
+
+```php 
+    use FluentForm\Framework\Support\Str;
+
+    $converted = Str::snake('fooBar');
+
+    // foo_bar
+```
+
+<a name="method-starts-with"></a>
+
+### `Str::soundsAlike($str1, $str2)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 636)
+
+Checks if two words sounds alike
+
+---
+
+### `Str::squish($value)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1532)
+
+Remove all "extra" blank space from the given string.
+
+---
+
 ### `Str::start()`
 
 The `Str::start` method adds a single instance of the given value to a string if it does not already start with the value:
@@ -332,6 +788,21 @@ The `Str::start` method adds a single instance of the given value to a string if
 ```
 
 <a name="method-studly-case"></a>
+
+### `Str::startsWith()`
+
+The `Str::startsWith` method determines if the given string begins with the given value:
+
+```php 
+    use FluentForm\Framework\Support\Str;
+
+    $result = Str::startsWith('This is my name', 'This');
+
+    // true
+```
+
+<a name="method-str-after"></a>
+
 ### `Str::studly()`
 
 The `Str::studly` method converts the given string to `StudlyCase`:
@@ -345,6 +816,47 @@ The `Str::studly` method converts the given string to `StudlyCase`:
 ```
 
 <a name="method-title-case"></a>
+
+### `Str::substr($string, $start, $length = null)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1605)
+
+Returns the portion of the string specified by the start and length parameters.
+
+---
+
+### `Str::substrCount($haystack, $needle, $offset = 0, $length = null)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1619)
+
+Returns the number of substring occurrences.
+
+---
+
+### `Str::substrReplace($string, $replace, $offset = 0, $length = null)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1638)
+
+Replace text within a portion of a string.
+
+---
+
+### `Str::swap(array $map, $subject)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1655)
+
+Swap multiple keywords in a string with other keywords.
+
+---
+
+### `Str::take($string, int $limit)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1667)
+
+Take the first or last {$limit} characters of a string.
+
+---
+
 ### `Str::title()`
 
 The `Str::title` method converts the given string to `Title Case`:
@@ -360,6 +872,63 @@ The `Str::title` method converts the given string to `Title Case`:
 If the specified translation key does not exist, the `trans` function will return the given key. So, using the example above, the `trans` function would return `messages.welcome` if the translation key does not exist.
 
 <a name="method-str-uuid"></a>
+
+### `Str::toBase64($string)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1682)
+
+Convert the given string to Base64 encoding.
+
+---
+
+### `Str::toBool($str)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 547)
+
+Converts a non-boolean value to boolean
+
+---
+
+### `Str::transliterate($string)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 239)
+
+Transliterate a string to its closest ASCII representation.
+
+---
+
+### `Str::trim(string $value, ?string $charlist = null)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1495)
+
+Remove all whitespace (including special Unicode spaces) from both ends of a string.
+
+---
+
+### `Str::ucfirst($string)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1718)
+
+Make a string's first character uppercase.
+
+---
+
+### `Str::ucsplit($string)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1731)
+
+Split a string into pieces by uppercase characters.
+
+---
+
+### `Str::upper($value)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1316)
+
+Convert the given string to upper-case.
+
+---
+
 ### `Str::uuid()`
 
 The `Str::uuid` method generates a UUID (version 4):
@@ -369,3 +938,38 @@ The `Str::uuid` method generates a UUID (version 4):
 
     return (string) Str::uuid();
 ```
+
+### `Str::wordCount(string $string)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1742)
+
+Count the number of words in a UTF-8 string.
+
+---
+
+### `Str::words($value, $words = 100, $end = '...')`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 824)
+
+Limit the number of words in a string.
+
+---
+
+### `Str::wordWrap($string,
+        $characters = 75,
+        $break = "\n",
+        $cutLongWords = false)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1758)
+
+Wrap a string to a given number of characters.
+
+---
+
+### `Str::wrap($value, $before, $after = null)`
+
+**Source:** `vendor/wpfluent/framework/src/WPFluent/Support/Str.php` (line 1776)
+
+Wrap the string with the given strings.
+
+---

--- a/src/hooks/actions/addon.md
+++ b/src/hooks/actions/addon.md
@@ -28,9 +28,6 @@ This hook is located in `fluentform/app/Views/admin/addons/index.php`.
 
 </explain-block>
 
---------------------------------
-
-
 <explain-block title="fluentform/addons_page_render_fluentform_pdf_settings">
 
 **Description**

--- a/src/hooks/actions/conversational.md
+++ b/src/hooks/actions/conversational.md
@@ -4,29 +4,37 @@
 
 These hooks fire during conversational form rendering.
 
-<explain-block title="fluentform/conversational_frame_head">
+<explain-block title="fluentform/conversational_enqueue_assets">
 
-**Description**
+<Badge type="warning" vertical="top" text="Added in 6.2.x" />
 
-This action runs after rendering the conversational frame header.
+Fires after the conversational form's CSS and JS bundles are enqueued. Hook in here to enqueue additional scripts/styles that depend on the conversational runtime being loaded, or to enqueue add-on assets only when the conversational view is active.
+
+**Parameters**
+
+- `$form` (object) The form being rendered
 
 **Usage**
-```php 
-add_action('fluentform/conversational_frame_head', function() {
-   // Do your stuff
-}, 10, 0);
+
+```php
+add_action('fluentform/conversational_enqueue_assets', function ($form) {
+    wp_enqueue_script(
+        'my-conversational-extension',
+        plugin_dir_url(__FILE__) . 'assets/extension.js',
+        ['fluent_forms_conversational_form'],
+        '1.0.0',
+        true
+    );
+}, 10, 1);
 ```
 
 **Reference**
 
-`do_action('fluentform/conversational_frame_head');`
+`do_action('fluentform/conversational_enqueue_assets', $form);`
 
-This action is located in `fluentform/app/Views/public/conversational-form.php`
+This action is located in `FluentForm\App\Services\FluentConversational\Classes\Form`.
 
 </explain-block>
-
-----------------------------------------------
-
 
 <explain-block title="fluentform/conversational_frame_footer">
 
@@ -44,6 +52,27 @@ add_action('fluentform/conversational_frame_footer', function() {
 **Reference**
 
 `do_action('fluentform/conversational_frame_footer');`
+
+This action is located in `fluentform/app/Views/public/conversational-form.php`
+
+</explain-block>
+
+<explain-block title="fluentform/conversational_frame_head">
+
+**Description**
+
+This action runs after rendering the conversational frame header.
+
+**Usage**
+```php 
+add_action('fluentform/conversational_frame_head', function() {
+   // Do your stuff
+}, 10, 0);
+```
+
+**Reference**
+
+`do_action('fluentform/conversational_frame_head');`
 
 This action is located in `fluentform/app/Views/public/conversational-form.php`
 

--- a/src/hooks/actions/editor.md
+++ b/src/hooks/actions/editor.md
@@ -4,78 +4,28 @@
 
 These hooks fire during the form editor — initialization, asset loading, and element rendering.
 
-<explain-block title="fluentform/editor_init">
+<explain-block title="fluentform/admin_nave_menu_{$itemKey}">
 
 **Description**
 
-This action runs right after initializing the fluent form editor in the admin panel. If you need to do anything in the background you can use this action.
+This action runs when admin menu render. You can hook into it and run your script when admin menu render.
 
-**Parameters**
-- `$components` (array) Editor Components
-
-**Usage**
+**Usage:**
 
 ```php
-add_action('fluentform/editor_init', function($components) {
-   // Do your stuff here
-}, 10, 1);
-```
-
-**Reference**
-
-`$this->app->doAction('fluentform/editor_init', $components);`
-
-This hook is located in `fluentform/app/Modules/Component/Component.php`.
-
-</explain-block>
-
-
-<explain-block title="fluentform/before_editor_start">
-
-**Description**
-
-This action runs before the fluent form editor in the admin panel. If you need to do anything in the background you can use this action.
-
-**Usage**
-
-```php
-add_action('fluentform/before_editor_start', function() {
+add_action('fluentform/admin_nave_menu_{$itemKey}', function() {
    // Do your stuff here
 }, 10, 0);
 ```
+**Note:** `{$itemKey}` is a dynamic nav item name. Replace `{$itemKey}` with Fluent Forms admin name item key.
 
 **Reference**
 
-`do_action('fluentform/before_editor_start');`
+`do_action("fluentform/admin_nav_menu_{$itemKey}");`
 
-This hook is located in `fluentform/app/Views/admin/form/editor.php`.
-
-</explain-block>
-
-
-<explain-block title="fluentform/after_editor_start">
-
-**Description**
-
-This action runs after the fluent form editor wrapper. If you need to do anything in the background you can use this action.
-
-**Usage**
-
-```php
-add_action('fluentform/after_editor_start', function() {
-   // Do your stuff here
-}, 10, 0);
-```
-
-**Reference**
-
-`do_action('fluentform/after_editor_start');`
-
-This hook is located in `fluentform/app/Views/admin/form/editor.php`.
+This action is located in `fluentform/app/Modules/Registerer/AdminBar.php`
 
 </explain-block>
-
-----------------------------------------
 
 <explain-block title="fluentform/after_all_entries_render">
 
@@ -99,7 +49,49 @@ This hook is located in `fluentform/app/views/admin/all_entries.php`.
 
 </explain-block>
 
-----------------------------------------
+<explain-block title="fluentform/after_editor_start">
+
+**Description**
+
+This action runs after the fluent form editor wrapper. If you need to do anything in the background you can use this action.
+
+**Usage**
+
+```php
+add_action('fluentform/after_editor_start', function() {
+   // Do your stuff here
+}, 10, 0);
+```
+
+**Reference**
+
+`do_action('fluentform/after_editor_start');`
+
+This hook is located in `fluentform/app/Views/admin/form/editor.php`.
+
+</explain-block>
+
+<explain-block title="fluentform/after_no_permission">
+
+**Description**
+
+This action runs after rendering no permission view.
+
+**Usage:**
+
+```php
+add_action('fluentform/after_no_permission', function() {
+   // Do your stuff here
+}, 10, 0);
+```
+
+**Reference**
+
+`do_action('fluentform/after_no_permission');`
+
+This action is located in `fluentform/app/Views/admin/no_permission.php`
+
+</explain-block>
 
 <explain-block title="fluentform/before_all_entries_render">
 
@@ -123,38 +115,33 @@ This hook is located in `fluentform/app/views/admin/all_entries.php`.
 
 </explain-block>
 
-
-<explain-block title="fluentform/admin_nave_menu_{$itemKey}">
+<explain-block title="fluentform/before_editor_start">
 
 **Description**
 
-This action runs when admin menu render. You can hook into it and run your script when admin menu render.
+This action runs before the fluent form editor in the admin panel. If you need to do anything in the background you can use this action.
 
-
-**Usage:**
+**Usage**
 
 ```php
-add_action('fluentform/admin_nave_menu_{$itemKey}', function() {
+add_action('fluentform/before_editor_start', function() {
    // Do your stuff here
 }, 10, 0);
 ```
-**Note:** `{$itemKey}` is a dynamic nav item name. Replace `{$itemKey}` with Fluent Forms admin name item key.
 
 **Reference**
 
-`do_action("fluentform/admin_nav_menu_{$itemKey}");`
+`do_action('fluentform/before_editor_start');`
 
-This action is located in `fluentform/app/Modules/Registerer/AdminBar.php`
+This hook is located in `fluentform/app/Views/admin/form/editor.php`.
 
 </explain-block>
-
 
 <explain-block title="fluentform/before_no_permission">
 
 **Description**
 
 This action runs before rendering no permission view.
-
 
 **Usage:**
 
@@ -172,26 +159,27 @@ This action is located in `fluentform/app/Views/admin/no_permission.php`
 
 </explain-block>
 
-
-<explain-block title="fluentform/after_no_permission">
+<explain-block title="fluentform/editor_init">
 
 **Description**
 
-This action runs after rendering no permission view.
+This action runs right after initializing the fluent form editor in the admin panel. If you need to do anything in the background you can use this action.
 
+**Parameters**
+- `$components` (array) Editor Components
 
-**Usage:**
+**Usage**
 
 ```php
-add_action('fluentform/after_no_permission', function() {
+add_action('fluentform/editor_init', function($components) {
    // Do your stuff here
-}, 10, 0);
+}, 10, 1);
 ```
 
 **Reference**
 
-`do_action('fluentform/after_no_permission');`
+`$this->app->doAction('fluentform/editor_init', $components);`
 
-This action is located in `fluentform/app/Views/admin/no_permission.php`
+This hook is located in `fluentform/app/Modules/Component/Component.php`.
 
 </explain-block>

--- a/src/hooks/actions/form-styler.md
+++ b/src/hooks/actions/form-styler.md
@@ -4,32 +4,6 @@
 
 These hooks fire during form styling and visual customization.
 
-<explain-block title="fluentform/form_styler">
-
-**Description**
-
-This action runs before rendering the form styler in preview section.
-
-**parameters**
-- `$formId` (int) Form Id
-
-**Usage:**
-```php 
-add_action('fluentform/form_styler', function($formId) {
-   // Do your stuff
-}, 10, 1);
-```
-
-**Reference**
-
-`do_action('fluentform/form_styler', $form_id);`
-
-This action is located in `fluentform/app/Views/frameless/show_preview.php`
-
-</explain-block>
-
------------------------------------------
-
 <explain-block title="fluentform/after_style_generated">
 
 **Description**
@@ -51,5 +25,29 @@ add_action('fluentform/after_style_generated', function($formId) {
 `do_action('fluentform/after_style_generated', $formId);`
 
 This action is located in `fluentformpro/src/classes/FormStyler.php`
+
+</explain-block>
+
+<explain-block title="fluentform/form_styler">
+
+**Description**
+
+This action runs before rendering the form styler in preview section.
+
+**parameters**
+- `$formId` (int) Form Id
+
+**Usage:**
+```php 
+add_action('fluentform/form_styler', function($formId) {
+   // Do your stuff
+}, 10, 1);
+```
+
+**Reference**
+
+`do_action('fluentform/form_styler', $form_id);`
+
+This action is located in `fluentform/app/Views/frameless/show_preview.php`
 
 </explain-block>

--- a/src/hooks/actions/form.md
+++ b/src/hooks/actions/form.md
@@ -4,188 +4,115 @@
 
 These hooks fire during form lifecycle events — creation, rendering, deletion, and display.
 
-<explain-block title="fluentform/inserted_new_form">
+<explain-block title="fluentform/after_all_forms_render">
 
 **Description**
 
-This action fires after the new form is created. If you want to do certain task after a form creation then you can catch this action hook and do your staff.
+This action fires after all form page was rendered.
 
-**parameters**
-- `$formId` (int) Form Id
-- `$data` (array) Form Data
+**Usage**
 
-**Usage:**
 ```php
-add_action('fluentform/inserted_new_form', function($formId, $data) {
-   // Do your stuff when form is created
-}, 10, 2);
-```
-
-**Reference**
-
-`do_action('fluentform/inserted_new_form', $form->id, $data);`
-
-This action is located in `fluentform/app/Services/Form/FormService.php`
-
-</explain-block>
-
-
-
-<explain-block title="fluentform/form_element_start">
-
-**Description**
-
-This action runs before rendering the input elements of the form. If you need to do anything in the background you can use this action.
-
-**parameters**
-- `$form` (object) Form Object
-
-**Usage:**
-```php
-add_action('fluentform/form_element_start', function($formId, $data) {
-   // Do your stuff when form element start
-}, 10, 1);
-```
-
-**Reference**
-
-`do_action('fluentform/form_element_start', $form);`
-
-This action is located in `fluentform/app/Services/FormBuilder/FormBuilder.php -> build()`
-
-</explain-block>
-
-
-<explain-block title="fluentform/form_duplicated">
-
-**Description**
-
-After a form is duplicated this action is fired.
-
-**parameters**
-- `$newFormId` (int) Form Id
-
-**Usage:**
-```php
-add_action('fluentform/form_duplicated', function($form$newFormId) {
-   // Do your stuff when form is duplicated
-}, 10, 1);
-```
-
-**Reference**
-
-`do_action('fluentform/form_duplicated', $form->id);`
-
-This action is located in `fluentform/app/Services/Form/FormService.php`
-
-</explain-block>
-
-
-<explain-block title="oxygen_add_plus_fluentform_form">
-
-**Description**
-
-This action runs when register Fluent Forms Oxygen widget sections.
-
-**Usage:**
-```php
-add_action('oxygen_add_plus_fluentform_form', function() {
-   // Do your stuff when register oxyget plus widget
+add_action('fluentform/after_all_forms_render', function() {
+   // Do your stuff here
 }, 10, 0);
 ```
 
 **Reference**
 
-`do_action('oxygen_add_plus_fluentform_form');`
+`do_action('fluentform/after_all_forms_render');`
 
-This action is located in `fluentform/app/Modules/Widgets/OxygenWidget.php`
+This hook is located in `fluentform/app/Views/admin/all_forms.php`.
 
 </explain-block>
 
------------------------------------
-
-<explain-block title="fluentform/load_form_assets">
+<explain-block title="fluentform/after_documentation_wrapper">
 
 **Description**
 
-This action fires when loading the form asset.
+This action run after render support page documentation.
+
+**Usage**
+
+```php
+add_action('fluentform/after_documentation_wrapper', function() {
+   // Do your stuff here
+}, 10, 0);
+```
+
+**Reference**
+
+`do_action('fluentform/after_documentation_wrapper');`
+
+This hook is located in `fluentform/app/Views/admin/docs/index.php`.
+
+</explain-block>
+
+<explain-block title="fluentform/after_form_delete">
 
 **Parameters**
-- `$formId`  (int)  Form Id
 
-**Usage:**
+- `$formId` — see source
+
+**Usage**
+
 ```php
-add_action('fluentform/load_form_assets', function($formId) {
-   // Do your stuff when load form assets
+add_action('fluentform/after_form_delete', function ($formId) {
+    // your code
 }, 10, 1);
 ```
 
 **Reference**
 
-`do_action('fluentform/load_form_assets', $formId);`
+`do_action('fluentform/after_form_delete', $formId);`
 
-This action is located in `fluentform/app/Modules/Widgets/OxygenWidget.php`, `fluentformpro/src/classes/SharePage/SharePage.php`, `fluentform/app/Hooks/actions.php`.
+This action is located in `app/Models/Form.php` (line 286).
 
 </explain-block>
 
------------------------------------
-
-<explain-block title="fluentform/init_custom_stylesheet">
-
-**Description**
-
-This action run when a custom style is applied to the form . You can also push your own style using this.
+<explain-block title="fluentform/after_form_entry_app">
 
 **Parameters**
-- `$selectedStyle`  (string)  Selected style type
-- `$formId`         (int)     Form Id
 
-**Usage:**
+- `$form_id` — see source
+
+**Usage**
+
 ```php
-add_action('fluentform/init_custom_stylesheet', function($selectedStyle, $formId) {
-   // Do your stuffs here
-   // enque style
-}, 10, 2);
+add_action('fluentform/after_form_entry_app', function ($form_id) {
+    // your code
+}, 10, 1);
 ```
 
 **Reference**
 
-`do_action('fluentform/init_custom_stylesheet', $selectedStyle, $formId);`
+`do_action('fluentform/after_form_entry_app', $form_id);`
 
-This action is located in `fluentformpro/src/classes/FormStyler.php`, `fluentform/app/Hooks/actions.php`.
+This action is located in `app/Views/admin/form/entries.php` (line 14).
 
 </explain-block>
 
-------------------------------------------------
-
-<explain-block title="fluentform/form_application_view_{$route}">
-
-**Description**
-
-This action runs admin page view. You can hook into it and run your script depending on the current route and form ID.
+<explain-block title="fluentform/after_form_menu">
 
 **Parameters**
 
-- `$form_id` (int) Form ID
+- See source
 
-**Usage:**
+**Usage**
 
 ```php
-add_action('fluentform/form_application_view_{$route}', function($form_id) {
-   // Do your stuff here
-}, 10, 2);
+add_action('fluentform/after_form_menu', function ($value) {
+    // your code
+}, 10, 1);
 ```
-**Note:** `{$route}` is a dynamic route. Replace `{$route}` with Fluent Forms admin route key.
 
 **Reference**
 
-`do_action('fluentform/form_application_view_' . $route, $form_id);`
+`do_action('fluentform/after_form_menu');`
 
-This action is located in `fluentform/app/Views/admin/form/form_wrapper.php`
+This action is located in `app/Views/admin/form/form_wrapper.php` (line 95).
 
 </explain-block>
-
-------------------------------------------------
 
 <explain-block title="fluentform/after_form_navigation">
 
@@ -214,8 +141,6 @@ This action is located in `fluentform/app/Views/admin/form/form_wrapper.php`
 
 </explain-block>
 
-------------------------------------------------
-
 <explain-block title="fluentform/after_form_navigation_{$route}">
 
 **Description**
@@ -243,31 +168,78 @@ This action is located in `fluentform/app/Views/admin/form/form_wrapper.php`
 
 </explain-block>
 
-------------------------------------------------
-
-<explain-block title="fluentform/before_permission_set_assignment">
+<explain-block title="fluentform/after_form_render">
 
 **Description**
 
-This action runs before fluentform is going to assign permission set to a role.
+This action runs after the form rendering is completed. If you need to do anything in the background you can use this action.
+
+**Parameters**
+- `$form` (object) Form Object
 
 **Usage**
 
 ```php
-add_action('fluentform/before_permission_set_assignment', function() {
+add_action('fluentform/after_form_render', function($form) {
    // Do your stuff here
-}, 10, 0);
+}, 10, 1);
 ```
 
 **Reference**
 
-`do_action('fluentform/before_permission_set_assignment');`
+`do_action('fluentform/after_form_render', $form);`
 
-This hook is located in fluentform/app/Modules/Acl/Acl.php
+This hook is located in `fluentform/app/Services/FormBuilder/FormBuilder.php`.
 
 </explain-block>
 
-------------------------------------------------
+<explain-block title="fluentform/after_form_reports_render">
+
+**Parameters**
+
+- See source
+
+**Usage**
+
+```php
+add_action('fluentform/after_form_reports_render', function ($value) {
+    // your code
+}, 10, 1);
+```
+
+**Reference**
+
+`do_action('fluentform/after_form_reports_render');`
+
+This action is located in `app/Views/admin/reports/index.php` (line 20).
+
+</explain-block>
+
+<explain-block title="fluentform/after_form_screen_wrapper">
+
+**Description**
+
+This action runs after the fluent form editor wrapper in the admin panel. If you need to do anything in the background you can use this action.
+
+**Parameters**
+- `$form_id` (int) Form ID
+- `$route` (string) Route
+
+**Usage**
+
+```php
+add_action('fluentform/after_form_screen_wrapper', function($form_id, $route) {
+   // Do your stuff here
+}, 10, 2);
+```
+
+**Reference**
+
+`do_action('fluentform/after_form_screen_wrapper', $form_id, $route);`
+
+This hook is located in `fluentform/app/Views/admin/form/form_wrapper.php`.
+
+</explain-block>
 
 <explain-block title="fluentform/after_permission_set_assignment">
 
@@ -291,37 +263,431 @@ This hook is located in fluentform/app/Modules/Acl/Acl.php
 
 </explain-block>
 
-------------------------------------------------
-
-
-<explain-block title="fluentform/rendering_calculation_form">
+<explain-block title="fluentform/before_all_forms_render">
 
 **Description**
 
-This action runs if the form input has calculation in it and during rendering the input . If you need to do anything in the background you can use this action.
-
-**Parameters**
-- `$form` (object) Form
-- `$field` (array) Input Element
+This action fires before the all form page is rendering.
 
 **Usage**
 
 ```php
-add_action('fluentform/rendering_calculation_form', function($form, $field) {
+add_action('fluentform/before_all_forms_render', function() {
+   // Do your stuff here
+}, 10, 0);
+```
+
+**Reference**
+
+`do_action('fluentform/before_all_forms_render');`
+
+This hook is located in `fluentform/app/Views/admin/all_forms.php`.
+
+</explain-block>
+
+<explain-block title="fluentform/before_documentation_wrapper">
+
+**Description**
+
+This action run before render support page documentation.
+
+**Usage**
+
+```php
+add_action('fluentform/before_documentation_wrapper', function() {
+   // Do your stuff here
+}, 10, 0);
+```
+
+**Reference**
+
+`do_action('fluentform/before_documentation_wrapper');`
+
+This hook is located in `fluentform/app/Views/admin/docs/index.php`.
+
+</explain-block>
+
+<explain-block title="fluentform/before_form_delete">
+
+**Parameters**
+
+- `$formId` — see source
+
+**Usage**
+
+```php
+add_action('fluentform/before_form_delete', function ($formId) {
+    // your code
+}, 10, 1);
+```
+
+**Reference**
+
+`do_action('fluentform/before_form_delete', $formId);`
+
+This action is located in `app/Models/Form.php` (line 263).
+
+</explain-block>
+
+<explain-block title="fluentform/before_form_entry_app">
+
+**Parameters**
+
+- `$form_id` — see source
+
+**Usage**
+
+```php
+add_action('fluentform/before_form_entry_app', function ($form_id) {
+    // your code
+}, 10, 1);
+```
+
+**Reference**
+
+`do_action('fluentform/before_form_entry_app', $form_id);`
+
+This action is located in `app/Views/admin/form/entries.php` (line 5).
+
+</explain-block>
+
+<explain-block title="fluentform/before_form_render">
+
+**Description**
+
+This action fires right before the form is rendered. If you want to do certain task after a form rendering then you can catch this action hook and do your staff.
+
+**Parameters**
+- `$form` (object) Form Object
+
+**Usage**
+
+```php
+add_action('fluentform/before_form_render', function($form) {
+   // Do your stuff here
+}, 10, 1);
+```
+
+**Reference**
+
+`do_action('fluentform/before_form_render', $form);`
+
+This hook is located in `fluentform/app/Services/FormBuilder/FormBuilder.php`.
+
+</explain-block>
+
+<explain-block title="fluentform/before_form_reports_render">
+
+**Parameters**
+
+- See source
+
+**Usage**
+
+```php
+add_action('fluentform/before_form_reports_render', function ($value) {
+    // your code
+}, 10, 1);
+```
+
+**Reference**
+
+`do_action('fluentform/before_form_reports_render');`
+
+This action is located in `app/Views/admin/reports/index.php` (line 11).
+
+</explain-block>
+
+<explain-block title="fluentform/before_form_screen_wrapper">
+
+**Description**
+
+This action runs after the fluent form editor wrapper in the admin panel. If you need to do anything in the background you can use this action.
+
+**Parameters**
+- `$form_id` (int) Form ID
+- `$route` (string) Route
+
+**Usage**
+
+```php
+add_action('fluentform/before_form_screen_wrapper', function($form_id, $route) {
    // Do your stuff here
 }, 10, 2);
 ```
 
 **Reference**
 
-`do_action('fluentform/rendering_calculation_form', $form, $field);`
+`do_action('fluentform/before_form_screen_wrapper', $form_id, $route);`
 
-This hook is located in `fluentform/app/Services/FluentConversational/Classes/Converter/Converter.php`, `fluentfomr/app/Services/FormBuilder/Components/Text.php`.
+This hook is located in `fluentform/app/Views/admin/form/form_wrapper.php`.
 
 </explain-block>
 
-------------------------------------------------
+<explain-block title="fluentform/before_form_validation">
 
+**Parameters**
+
+- `$fields` — see source
+- `$formData` — see source
+
+**Usage**
+
+```php
+add_action('fluentform/before_form_validation', function ($fields, $formData) {
+    // your code
+}, 10, 2);
+```
+
+**Reference**
+
+`do_action('fluentform/before_form_validation', $fields, $formData);`
+
+This action is located in `app/Services/Form/FormValidationService.php` (line 48).
+
+</explain-block>
+
+<explain-block title="fluentform/before_permission_set_assignment">
+
+**Description**
+
+This action runs before fluentform is going to assign permission set to a role.
+
+**Usage**
+
+```php
+add_action('fluentform/before_permission_set_assignment', function() {
+   // Do your stuff here
+}, 10, 0);
+```
+
+**Reference**
+
+`do_action('fluentform/before_permission_set_assignment');`
+
+This hook is located in fluentform/app/Modules/Acl/Acl.php
+
+</explain-block>
+
+<explain-block title="fluentform/before_updating_form">
+
+**Parameters**
+
+- `$form` — see source
+- `$data` — see source
+
+**Usage**
+
+```php
+add_action('fluentform/before_updating_form', function ($form, $data) {
+    // your code
+}, 10, 2);
+```
+
+**Reference**
+
+`do_action('fluentform/before_updating_form', $form, $data);`
+
+This action is located in `app/Services/Form/Updater.php` (line 57).
+
+</explain-block>
+
+<explain-block title="fluentform/editor_script_loaded">
+
+**Parameters**
+
+- `$form` — see source
+
+**Usage**
+
+```php
+add_action('fluentform/editor_script_loaded', function ($form) {
+    // your code
+}, 10, 1);
+```
+
+**Reference**
+
+`do_action('fluentform/editor_script_loaded', $form);`
+
+This action is located in `app/Modules/Registerer/Menu.php` (line 1069).
+
+</explain-block>
+
+<explain-block title="fluentform/form_application_view_{$route}">
+
+**Description**
+
+This action runs admin page view. You can hook into it and run your script depending on the current route and form ID.
+
+**Parameters**
+
+- `$form_id` (int) Form ID
+
+**Usage:**
+
+```php
+add_action('fluentform/form_application_view_{$route}', function($form_id) {
+   // Do your stuff here
+}, 10, 2);
+```
+**Note:** `{$route}` is a dynamic route. Replace `{$route}` with Fluent Forms admin route key.
+
+**Reference**
+
+`do_action('fluentform/form_application_view_' . $route, $form_id);`
+
+This action is located in `fluentform/app/Views/admin/form/form_wrapper.php`
+
+</explain-block>
+
+<explain-block title="fluentform/form_duplicated">
+
+**Description**
+
+After a form is duplicated this action is fired.
+
+**parameters**
+- `$newFormId` (int) Form Id
+
+**Usage:**
+```php
+add_action('fluentform/form_duplicated', function($form$newFormId) {
+   // Do your stuff when form is duplicated
+}, 10, 1);
+```
+
+**Reference**
+
+`do_action('fluentform/form_duplicated', $form->id);`
+
+This action is located in `fluentform/app/Services/Form/FormService.php`
+
+</explain-block>
+
+<explain-block title="fluentform/form_element_start">
+
+**Description**
+
+This action runs before rendering the input elements of the form. If you need to do anything in the background you can use this action.
+
+**parameters**
+- `$form` (object) Form Object
+
+**Usage:**
+```php
+add_action('fluentform/form_element_start', function($formId, $data) {
+   // Do your stuff when form element start
+}, 10, 1);
+```
+
+**Reference**
+
+`do_action('fluentform/form_element_start', $form);`
+
+This action is located in `fluentform/app/Services/FormBuilder/FormBuilder.php -> build()`
+
+</explain-block>
+
+<explain-block title="fluentform/form_imported">
+
+**Description**
+
+This action is fired after a form is imported. So you can use this hook and run your script after a form is imported
+
+**Parameters**
+- `$form_id` (int) Form ID
+
+**Usage**
+
+```php
+add_action('fluentform/form_imported', function($form_id) {
+   // Do your stuff here
+}, 10, 1);
+```
+
+**Reference**
+
+`do_action('fluentform/form_imported', $formId);`
+
+This hook is located in `fluentform/app/Services/Form/FormService.php`.
+
+</explain-block>
+
+<explain-block title="fluentform/init_custom_stylesheet">
+
+**Description**
+
+This action run when a custom style is applied to the form . You can also push your own style using this.
+
+**Parameters**
+- `$selectedStyle`  (string)  Selected style type
+- `$formId`         (int)     Form Id
+
+**Usage:**
+```php
+add_action('fluentform/init_custom_stylesheet', function($selectedStyle, $formId) {
+   // Do your stuffs here
+   // enque style
+}, 10, 2);
+```
+
+**Reference**
+
+`do_action('fluentform/init_custom_stylesheet', $selectedStyle, $formId);`
+
+This action is located in `fluentformpro/src/classes/FormStyler.php`, `fluentform/app/Hooks/actions.php`.
+
+</explain-block>
+
+<explain-block title="fluentform/inserted_new_form">
+
+**Description**
+
+This action fires after the new form is created. If you want to do certain task after a form creation then you can catch this action hook and do your staff.
+
+**parameters**
+- `$formId` (int) Form Id
+- `$data` (array) Form Data
+
+**Usage:**
+```php
+add_action('fluentform/inserted_new_form', function($formId, $data) {
+   // Do your stuff when form is created
+}, 10, 2);
+```
+
+**Reference**
+
+`do_action('fluentform/inserted_new_form', $form->id, $data);`
+
+This action is located in `fluentform/app/Services/Form/FormService.php`
+
+</explain-block>
+
+<explain-block title="fluentform/load_form_assets">
+
+**Description**
+
+This action fires when loading the form asset.
+
+**Parameters**
+- `$formId`  (int)  Form Id
+
+**Usage:**
+```php
+add_action('fluentform/load_form_assets', function($formId) {
+   // Do your stuff when load form assets
+}, 10, 1);
+```
+
+**Reference**
+
+`do_action('fluentform/load_form_assets', $formId);`
+
+This action is located in `fluentform/app/Modules/Widgets/OxygenWidget.php`, `fluentformpro/src/classes/SharePage/SharePage.php`, `fluentform/app/Hooks/actions.php`.
+
+</explain-block>
 
 <explain-block title="fluentform/render_item_{$item_element}">
 
@@ -351,192 +717,51 @@ This hook is located in `fluentform/app/Modules/Component/Component.php`.
 
 </explain-block>
 
-------------------------------------------------
-
-<explain-block title="fluentform/after_form_render">
-
-**Description**
-
-This action runs after the form rendering is completed. If you need to do anything in the background you can use this action.
+<explain-block title="fluentform/render_item_step_end">
 
 **Parameters**
-- `$form` (object) Form Object
+
+- `$form` — see source
+- `$form_2` — see source
 
 **Usage**
 
 ```php
-add_action('fluentform/after_form_render', function($form) {
-   // Do your stuff here
-}, 10, 1);
-```
-
-**Reference**
-
-`do_action('fluentform/after_form_render', $form);`
-
-This hook is located in `fluentform/app/Services/FormBuilder/FormBuilder.php`.
-
-</explain-block>
-
-------------------------------------------------
-
-<explain-block title="fluentform/form_imported">
-
-**Description**
-
-This action is fired after a form is imported. So you can use this hook and run your script after a form is imported
-
-**Parameters**
-- `$form_id` (int) Form ID
-
-**Usage**
-
-```php
-add_action('fluentform/form_imported', function($form_id) {
-   // Do your stuff here
-}, 10, 1);
-```
-
-**Reference**
-
-`do_action('fluentform/form_imported', $formId);`
-
-This hook is located in `fluentform/app/Services/Form/FormService.php`.
-
-</explain-block>
-
-------------------------------------------------
-
-<explain-block title="fluentform/before_form_render">
-
-**Description**
-
-This action fires right before the form is rendered. If you want to do certain task after a form rendering then you can catch this action hook and do your staff.
-
-**Parameters**
-- `$form` (object) Form Object
-
-**Usage**
-
-```php
-add_action('fluentform/before_form_render', function($form) {
-   // Do your stuff here
-}, 10, 1);
-```
-
-**Reference**
-
-`do_action('fluentform/before_form_render', $form);`
-
-This hook is located in `fluentform/app/Services/FormBuilder/FormBuilder.php`.
-
-</explain-block>
-
-------------------------------------------------
-
-<explain-block title="fluentform/before_all_forms_render">
-
-**Description**
-
-This action fires before the all form page is rendering.
-
-**Usage**
-
-```php
-add_action('fluentform/before_all_forms_render', function() {
-   // Do your stuff here
-}, 10, 0);
-```
-
-**Reference**
-
-`do_action('fluentform/before_all_forms_render');`
-
-This hook is located in `fluentform/app/Views/admin/all_forms.php`.
-
-</explain-block>
-
-------------------------------------------------
-
-<explain-block title="fluentform/after_all_forms_render">
-
-**Description**
-
-This action fires after all form page was rendered.
-
-**Usage**
-
-```php
-add_action('fluentform/after_all_forms_render', function() {
-   // Do your stuff here
-}, 10, 0);
-```
-
-**Reference**
-
-`do_action('fluentform/after_all_forms_render');`
-
-This hook is located in `fluentform/app/Views/admin/all_forms.php`.
-
-</explain-block>
-
-------------------------------------------------
-
-<explain-block title="fluentform/before_form_screen_wrapper">
-
-**Description**
-
-This action runs after the fluent form editor wrapper in the admin panel. If you need to do anything in the background you can use this action.
-
-**Parameters**
-- `$form_id` (int) Form ID
-- `$route` (string) Route
-
-**Usage**
-
-```php
-add_action('fluentform/before_form_screen_wrapper', function($form_id, $route) {
-   // Do your stuff here
+add_action('fluentform/render_item_step_end', function ($form, $form_2) {
+    // your code
 }, 10, 2);
 ```
 
 **Reference**
 
-`do_action('fluentform/before_form_screen_wrapper', $form_id, $route);`
+`do_action('fluentform/render_item_step_end', $form->fields['stepsWrapper']['stepEnd'], $form);`
 
-This hook is located in `fluentform/app/Views/admin/form/form_wrapper.php`.
+This action is located in `app/Services/FormBuilder/FormBuilder.php` (line 285).
 
 </explain-block>
 
-
-<explain-block title="fluentform/after_form_screen_wrapper">
-
-**Description**
-
-This action runs after the fluent form editor wrapper in the admin panel. If you need to do anything in the background you can use this action.
+<explain-block title="fluentform/render_item_step_start">
 
 **Parameters**
-- `$form_id` (int) Form ID
-- `$route` (string) Route
+
+- `$startElement` — see source
+- `$form` — see source
 
 **Usage**
 
 ```php
-add_action('fluentform/after_form_screen_wrapper', function($form_id, $route) {
-   // Do your stuff here
+add_action('fluentform/render_item_step_start', function ($startElement, $form) {
+    // your code
 }, 10, 2);
 ```
 
 **Reference**
 
-`do_action('fluentform/after_form_screen_wrapper', $form_id, $route);`
+`do_action('fluentform/render_item_step_start', $startElement, $form);`
 
-This hook is located in `fluentform/app/Views/admin/form/form_wrapper.php`.
+This action is located in `app/Services/FormBuilder/FormBuilder.php` (line 330).
 
 </explain-block>
-
-
-------------------------------------------------
 
 <explain-block title="fluentform/render_item_submit_button">
 
@@ -564,35 +789,87 @@ This hook is located in `fluentform/app/Modules/Component/Component.php`.
 
 </explain-block>
 
-------------------------------------------------
-
-<explain-block title="fluentform/starting_file_upload">
+<explain-block title="fluentform/rendering_address_field">
 
 **Description**
 
-This action run before uploading a file.
+This action run when render address field.
 
 **Parameters**
-- `$files` (array) Files
+- `$field` (array) Field Data
 - `$form` (object) Form Object
 
 **Usage**
 
 ```php
-add_action('fluentform/starting_file_upload', function($files, $form) {
+add_action('fluentform/rendering_address_field', function($field, $form) {
    // Do your stuff here
 }, 10, 2);
 ```
 
 **Reference**
 
-`do_action('fluentform/starting_file_upload', $files, $this->form);`
+`do_action('fluentform/rendering_address_field', $data, $form);`
 
-This hook is located in `fluentformpro/src/Uploader.php -> upload()`.
+This hook is located in `fluentform/app/Services/FormBuilder/Components/Address.php -> compile()`.
 
 </explain-block>
 
-------------------------------------------------
+<explain-block title="fluentform/rendering_calculation_form">
+
+**Description**
+
+This action runs if the form input has calculation in it and during rendering the input . If you need to do anything in the background you can use this action.
+
+**Parameters**
+- `$form` (object) Form
+- `$field` (array) Input Element
+
+**Usage**
+
+```php
+add_action('fluentform/rendering_calculation_form', function($form, $field) {
+   // Do your stuff here
+}, 10, 2);
+```
+
+**Reference**
+
+`do_action('fluentform/rendering_calculation_form', $form, $field);`
+
+This hook is located in `fluentform/app/Services/FluentConversational/Classes/Converter/Converter.php`, `fluentfomr/app/Services/FormBuilder/Components/Text.php`.
+
+</explain-block>
+
+<explain-block title="fluentform/spam_attempt_caught">
+
+**Description**
+
+This action is triggered when a spam attempt is caught. You can use this to log spam attempts, notify administrators, or implement additional security measures.
+
+**Parameters**
+
+`$reason` (string) The reason for the spam detection
+
+**Usage**
+
+```php
+add_action('fluentform/spam_attempt_caught', function ($reason) {
+    // Log spam attempt
+    error_log("Spam attempt caught: " . $reason);
+
+    // Notify admin
+    wp_mail('admin@example.com', 'Spam Attempt Detected', "A spam attempt was caught. Reason: " . $reason);
+}, 10, 1);
+```
+
+**Reference**
+
+`do_action('fluentform/spam_attempt_caught', $reason);`
+
+This action is located in the `FluentForm\App\Modules\Form\TokenBasedSpamProtection -> handleSpam` method.
+
+</explain-block>
 
 <explain-block title="fluentform/starting_file_processing">
 
@@ -622,109 +899,49 @@ This hook is located in `fluentformpro/src/Uploader.php -> processFiles()`.
 
 </explain-block>
 
-
-------------------------------------------------
-
-<explain-block title="fluentform/rendering_address_field">
+<explain-block title="fluentform/starting_file_upload">
 
 **Description**
 
-This action run when render address field.
+This action run before uploading a file.
 
 **Parameters**
-- `$field` (array) Field Data
+- `$files` (array) Files
 - `$form` (object) Form Object
 
 **Usage**
 
 ```php
-add_action('fluentform/rendering_address_field', function($field, $form) {
+add_action('fluentform/starting_file_upload', function($files, $form) {
    // Do your stuff here
 }, 10, 2);
 ```
 
 **Reference**
 
-`do_action('fluentform/rendering_address_field', $data, $form);`
+`do_action('fluentform/starting_file_upload', $files, $this->form);`
 
-This hook is located in `fluentform/app/Services/FormBuilder/Components/Address.php -> compile()`.
+This hook is located in `fluentformpro/src/Uploader.php -> upload()`.
 
 </explain-block>
 
-------------------------------------------------
-
-<explain-block title="fluentform/before_documentation_wrapper">
+<explain-block title="oxygen_add_plus_fluentform_form">
 
 **Description**
 
-This action run before render support page documentation.
+This action runs when register Fluent Forms Oxygen widget sections.
 
-**Usage**
-
+**Usage:**
 ```php
-add_action('fluentform/before_documentation_wrapper', function() {
-   // Do your stuff here
+add_action('oxygen_add_plus_fluentform_form', function() {
+   // Do your stuff when register oxyget plus widget
 }, 10, 0);
 ```
 
 **Reference**
 
-`do_action('fluentform/before_documentation_wrapper');`
+`do_action('oxygen_add_plus_fluentform_form');`
 
-This hook is located in `fluentform/app/Views/admin/docs/index.php`.
-
-</explain-block>
-
-
-<explain-block title="fluentform/after_documentation_wrapper">
-
-**Description**
-
-This action run after render support page documentation.
-
-**Usage**
-
-```php
-add_action('fluentform/after_documentation_wrapper', function() {
-   // Do your stuff here
-}, 10, 0);
-```
-
-**Reference**
-
-`do_action('fluentform/after_documentation_wrapper');`
-
-This hook is located in `fluentform/app/Views/admin/docs/index.php`.
-
-</explain-block>
-
-
-<explain-block title="fluentform/spam_attempt_caught">
-
-**Description**
-
-This action is triggered when a spam attempt is caught. You can use this to log spam attempts, notify administrators, or implement additional security measures.
-
-**Parameters**
-
-`$reason` (string) The reason for the spam detection
-
-**Usage**
-
-```php
-add_action('fluentform/spam_attempt_caught', function ($reason) {
-    // Log spam attempt
-    error_log("Spam attempt caught: " . $reason);
-
-    // Notify admin
-    wp_mail('admin@example.com', 'Spam Attempt Detected', "A spam attempt was caught. Reason: " . $reason);
-}, 10, 1);
-```
-
-**Reference**
-
-`do_action('fluentform/spam_attempt_caught', $reason);`
-
-This action is located in the `FluentForm\App\Modules\Form\TokenBasedSpamProtection -> handleSpam` method.
+This action is located in `fluentform/app/Modules/Widgets/OxygenWidget.php`
 
 </explain-block>

--- a/src/hooks/actions/integration.md
+++ b/src/hooks/actions/integration.md
@@ -4,28 +4,32 @@
 
 These hooks fire during third-party integration processing — scheduled jobs, feed processing, and notifications.
 
-<explain-block title="fluentform/maybe_scheduled_jobs">
+<explain-block title="fluentform/created_user">
 
 **Description**
 
-This is a smart background action to process jobs like integration data pushing by schedule time.
+This action runs after user created. Do your stuff after user is created by fluentform.
+
+**Parameters**
+- `$userId` (int) User ID
+- `$feed` (array) User Feed
+- `$submission` (object) Submission
+- `$form`  (object) Form
 
 **Usage:**
 ```php
-add_action('fluentform/maybe_scheduled_jobs' ,function () {
+add_action('fluentform/created_user', function ($userId, $feed, $submission, $form) {
    // Do your stuff here
-}, 10, 0);
+}, 10, 4);
 ```
 
 **Reference**
 
-`do_action('fluentform/maybe_scheduled_jobs');`
+`do_action('fluentform/created_user', $userId, $feed, $entry, $form);`
 
-This action is located in `fluentform/boot/globals.php`
+This action is located in `fluentformpro/src/Integrations/UserRegistration/UserRegistrationApi.php -> createUser()`
 
 </explain-block>
-
----------------------------------------------------
 
 <explain-block title="fluentform/global_notify_completed">
 
@@ -49,6 +53,53 @@ add_action('fluentform/global_notify_completed' ,function ($insertId, $form) {
 `do_action('fluentform/global_notify_completed', $insertId, $form);`
 
 This action is located in `fluentform/app/Services/Integrations/GlobalNotificationManager.php`, `fluentform/app/Services/WPAsync/FluentFormAsyncRequest.php`
+
+</explain-block>
+
+<explain-block title="fluentform/integration_action_result">
+
+**Description**
+
+This action runs after completing an integration process.
+
+**Parameters**
+- `$feed` (array) Current Feed
+- `$status` (string) Status
+- `$note` (string) Note
+
+**Usage:**
+```php
+add_action('fluentform/integration_action_result', function ($feed, $status, $note) {
+   // Do your stuff here
+}, 10, 3);
+```
+
+**Reference**
+
+`do_action('fluentform/integration_action_result', $feed, $status, $message);`
+
+This action is located in `fluentformpro/src/Integrations/**/Bootstrap.php`
+
+</explain-block>
+
+<explain-block title="fluentform/maybe_scheduled_jobs">
+
+**Description**
+
+This is a smart background action to process jobs like integration data pushing by schedule time.
+
+**Usage:**
+```php
+add_action('fluentform/maybe_scheduled_jobs' ,function () {
+   // Do your stuff here
+}, 10, 0);
+```
+
+**Reference**
+
+`do_action('fluentform/maybe_scheduled_jobs');`
+
+This action is located in `fluentform/boot/globals.php`
 
 </explain-block>
 
@@ -77,35 +128,6 @@ This action is located in `fluentform/app/Http/Controllers/GlobalIntegrationCont
 
 </explain-block>
 
-
-<explain-block title="fluentform/integration_action_result">
-
-**Description**
-
-This action runs after completing an integration process.
-
-**Parameters**
-- `$feed` (array) Current Feed
-- `$status` (string) Status
-- `$note` (string) Note
-
-**Usage:**
-```php
-add_action('fluentform/integration_action_result', function ($feed, $status, $note) {
-   // Do your stuff here
-}, 10, 3);
-```
-
-
-**Reference**
-
-`do_action('fluentform/integration_action_result', $feed, $status, $message);`
-
-This action is located in `fluentformpro/src/Integrations/**/Bootstrap.php`
-
-</explain-block>
-
-
 <explain-block title="fluentform/user_registration_before_start">
 
 **Description**
@@ -124,7 +146,6 @@ add_action('fluentform/user_registration_before_start', function ($feed, $submis
 }, 10, 3);
 ```
 
-
 **Reference**
 
 `do_action('fluentform/user_registration_before_start', $feed, $entry, $form);`
@@ -132,36 +153,6 @@ add_action('fluentform/user_registration_before_start', function ($feed, $submis
 This action is located in `fluentformpro/src/Integrations/UserRegistration/UserRegistrationApi.php -> registerUser()`
 
 </explain-block>
-
-
-<explain-block title="fluentform/created_user">
-
-**Description**
-
-This action runs after user created. Do your stuff after user is created by fluentform.
-
-**Parameters**
-- `$userId` (int) User ID
-- `$feed` (array) User Feed
-- `$submission` (object) Submission
-- `$form`  (object) Form
-
-**Usage:**
-```php
-add_action('fluentform/created_user', function ($userId, $feed, $submission, $form) {
-   // Do your stuff here
-}, 10, 4);
-```
-
-
-**Reference**
-
-`do_action('fluentform/created_user', $userId, $feed, $entry, $form);`
-
-This action is located in `fluentformpro/src/Integrations/UserRegistration/UserRegistrationApi.php -> createUser()`
-
-</explain-block>
-
 
 <explain-block title="fluentform/user_registration_completed">
 
@@ -182,7 +173,6 @@ add_action('fluentform/user_registration_completed', function ($userId, $feed, $
 }, 10, 4);
 ```
 
-
 **Reference**
 
 `do_action('fluentform/user_registration_completed', $userId, $feed, $entry, $form);`
@@ -190,7 +180,6 @@ add_action('fluentform/user_registration_completed', function ($userId, $feed, $
 This action is located in `fluentformpro/src/Integrations/UserRegistration/UserRegistrationApi.php -> createUser()`
 
 </explain-block>
-
 
 <explain-block title="fluentform/user_update_completed">
 
@@ -210,7 +199,6 @@ add_action('fluentform/user_update_completed', function ($userId, $feed, $submis
    // Do your stuff here
 }, 10, 4);
 ```
-
 
 **Reference**
 

--- a/src/hooks/actions/miscellaneous.md
+++ b/src/hooks/actions/miscellaneous.md
@@ -1,0 +1,148 @@
+# Conversational Actions
+
+<Badge type="tip" vertical="top" text="Action Hooks" /> <Badge type="warning" vertical="top" text="1 Actions" />
+
+<explain-block title="fluentform/adding_custom_css_js_">
+
+**Parameters**
+
+- See source
+
+**Usage**
+
+```php
+add_action('fluentform/adding_custom_css_js_', function ($value) {
+    // your code
+}, 10, 1);
+```
+
+**Reference**
+
+`do_action('fluentform/adding_custom_css_js_' . $formId, $formId);`
+
+This action is located in `app/Modules/Form/Settings/FormCssJs.php` (line 30).
+
+</explain-block>
+
+<explain-block title="fluentform/address_map_autocomplete">
+
+**Parameters**
+
+- `$data` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_action('fluentform/address_map_autocomplete', function ($data, $form) {
+    // your code
+}, 10, 2);
+```
+
+**Reference**
+
+`do_action('fluentform/address_map_autocomplete', $data, $form);`
+
+This action is located in `app/Services/FormBuilder/Components/Address.php` (line 65).
+
+</explain-block>
+
+<explain-block title="fluentform/conversational_question">
+
+**Parameters**
+
+- `$question` — see source
+- `$field` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_action('fluentform/conversational_question', function ($question, $field, $form) {
+    // your code
+}, 10, 3);
+```
+
+**Reference**
+
+`do_action('fluentform/conversational_question', $question, $field, $form);`
+
+This action is located in `app/Services/FluentConversational/Classes/Converter/Converter.php` (line 856).
+
+</explain-block>
+
+<explain-block title="fluentform/render_report">
+
+**Parameters**
+
+- See source
+
+**Usage**
+
+```php
+add_action('fluentform/render_report', function ($value) {
+    // your code
+}, 10, 1);
+```
+
+**Reference**
+
+`do_action('fluentform/render_report');`
+
+This action is located in `app/Modules/Registerer/Menu.php` (line 1255).
+
+</explain-block>
+
+<explain-block title="fluentform/temp_files_cleaned">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$tempDir` — see source
+- `$deletedCount` — see source
+- `$maxFileAge` — see source
+- `$maxDeletions` — see source
+
+**Usage**
+
+```php
+add_action('fluentform/temp_files_cleaned', function ($tempDir, $deletedCount, $maxFileAge, $maxDeletions) {
+    // your code
+}, 10, 4);
+```
+
+**Reference**
+
+`do_action('fluentform/temp_files_cleaned', $tempDir, $deletedCount, $maxFileAge, $maxDeletions);`
+
+This action is located in `src/Uploader.php` (line 725).
+
+</explain-block>
+
+<explain-block title="fluentform/upload_to_cloud">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$files` — see source
+- `$uploadLocation` — see source
+- `$formData` — see source
+- `$this` — see source
+
+**Usage**
+
+```php
+add_action('fluentform/upload_to_cloud', function ($files, $uploadLocation, $formData, $this) {
+    // your code
+}, 10, 4);
+```
+
+**Reference**
+
+`do_action('fluentform/upload_to_cloud', $files, $uploadLocation, $formData, $this->form);`
+
+This action is located in `src/Uploader.php` (line 471).
+
+</explain-block>

--- a/src/hooks/actions/partial-submission.md
+++ b/src/hooks/actions/partial-submission.md
@@ -4,6 +4,83 @@
 
 These hooks fire during partial/draft submission handling — step forms, save & resume, and draft entries.
 
+<explain-block title="fluentform/after_partial_entry_deleted">
+
+**Description**
+
+This action runs after partial submission deleted.
+
+**Parameters**
+- `$submissionId`  (int)   Submission ID
+- `$formId`     (int)   Form ID
+
+**Usage:**
+```php 
+add_action('fluentform/after_partial_entry_deleted', function ($submissionId, $formId){
+   // Do your stuff
+}, 10, 2);
+```
+
+**Reference**
+
+`do_action('fluentform/after_partial_entry_deleted', $formData['data'], $formData['active_step'], $insertId, $formId);`
+
+This action is located in `fluentformpro/src/classes/StepFormEntries.php -> deleteEntryById()`.
+
+</explain-block>
+
+<explain-block title="fluentform/before_partial_entry_deleted">
+
+**Description**
+
+This action runs before partial submission deleted.
+
+**Parameters**
+- `$submissionId`  (int)   Submission ID
+- `$formId`     (int)   Form ID
+
+**Usage:**
+```php 
+add_action('fluentform/before_partial_entry_deleted', function ($submissionId, $formId){
+   // Do your stuff
+}, 10, 2);
+```
+
+**Reference**
+
+`do_action('fluentform/before_partial_entry_deleted', $formData['data'], $formData['active_step'], $insertId, $formId);`
+
+This action is located in `fluentformpro/src/classes/StepFormEntries.php -> deleteEntryById()`.
+
+</explain-block>
+
+<explain-block title="fluentform/email_form_resume_link_before_sent">
+
+**Description**
+
+This action fire before sending email resume link for partial submission.
+
+**Parameters**
+- `$emailFormat` (array) Email Format
+- `$submittedData` (array) Partial Submitted Data
+- `$requestData` (array) Request Data
+- `$form` (object) Form
+
+**Usage:**
+```php 
+add_action('fluentform/email_form_resume_link_before_sent', function($emailFormat, $submittedData, $requestData, $form) {
+   // Do your stuff here
+}, 10, 4);
+```
+
+**Reference**
+
+`do_action('fluentform/email_form_resume_link_before_sent', $emailFormat, $submittedData, $requestData, $form);`
+
+This action is located in `fluentformpro/src/classes/DraftSubmissionsManager.php -> emailProgressLink()`
+
+</explain-block>
+
 <explain-block title="fluentform/partial_submission_added">
 
 **Description**
@@ -31,36 +108,30 @@ This action is located in `fluentformpro/src/classes/DraftSubmissionsManager.php
 
 </explain-block>
 
----------------------------------------------------
-
-<explain-block title="fluentform/saved_progress_submission_added">
+<explain-block title="fluentform/partial_submission_deleted">
 
 **Description**
 
-This action runs when partial submission have no steps.
+This action runs after partial state deleted.
 
 **Parameters**
-- `$formData` (array)  Form raw data
-- `$response` (array)  Inserted data
-- `$submissionId`  (int)   Submission ID
+- `$draft` (array)  Form raw data
 - `$formId`     (int)   Form ID
 
 **Usage:**
 ```php 
-add_action('fluentform/saved_progress_submission_added', function ($formData, $response, $submissionId, $formId){
+add_action('fluentform/partial_submission_deleted', function ($draft, $formId){
    // Do your stuff
-}, 10, 4);
+}, 10, 2);
 ```
 
 **Reference**
 
-`do_action('fluentform/saved_progress_submission_added', $formData['data'], $response, $insertId, $formId);`
+`do_action('fluentform/partial_submission_deleted', $draft, $form->id);`
 
-This action is located in `fluentformpro/src/classes/DraftSubmissionsManager.php -> saveState()`.
+This action is located in `fluentformpro/src/classes/DraftSubmissionsManager.php -> deleteSavedStateDraft()`.
 
 </explain-block>
-
----------------------------------------------------
 
 <explain-block title="fluentform/partial_submission_step_completed">
 
@@ -89,8 +160,6 @@ This action is located in `fluentformpro/src/classes/DraftSubmissionsManager.php
 
 </explain-block>
 
----------------------------------------------------
-
 <explain-block title="fluentform/partial_submission_updated">
 
 **Description**
@@ -118,91 +187,32 @@ This action is located in `fluentformpro/src/classes/DraftSubmissionsManager.php
 
 </explain-block>
 
----------------------------------------------------
-
-<explain-block title="fluentform/saved_progress_submission_updated">
+<explain-block title="fluentform/saved_progress_submission_added">
 
 **Description**
 
-This action runs when partial submission has no active step is.
+This action runs when partial submission have no steps.
 
 **Parameters**
 - `$formData` (array)  Form raw data
-- `$activeStep` (array)  Active Step
+- `$response` (array)  Inserted data
 - `$submissionId`  (int)   Submission ID
 - `$formId`     (int)   Form ID
 
 **Usage:**
 ```php 
-add_action('fluentform/saved_progress_submission_updated', function ($formData, $activeStep, $submissionId, $formId){
+add_action('fluentform/saved_progress_submission_added', function ($formData, $response, $submissionId, $formId){
    // Do your stuff
 }, 10, 4);
 ```
 
 **Reference**
 
-`do_action('fluentform/saved_progress_submission_updated', $formData['data'], $formData['active_step'], $insertId, $formId);`
+`do_action('fluentform/saved_progress_submission_added', $formData['data'], $response, $insertId, $formId);`
 
 This action is located in `fluentformpro/src/classes/DraftSubmissionsManager.php -> saveState()`.
 
 </explain-block>
-
-
----------------------------------------------------
-
-<explain-block title="fluentform/before_partial_entry_deleted">
-
-**Description**
-
-This action runs before partial submission deleted.
-
-**Parameters**
-- `$submissionId`  (int)   Submission ID
-- `$formId`     (int)   Form ID
-
-**Usage:**
-```php 
-add_action('fluentform/before_partial_entry_deleted', function ($submissionId, $formId){
-   // Do your stuff
-}, 10, 2);
-```
-
-**Reference**
-
-`do_action('fluentform/before_partial_entry_deleted', $formData['data'], $formData['active_step'], $insertId, $formId);`
-
-This action is located in `fluentformpro/src/classes/StepFormEntries.php -> deleteEntryById()`.
-
-</explain-block>
-
----------------------------------------------------
-
-<explain-block title="fluentform/after_partial_entry_deleted">
-
-**Description**
-
-This action runs after partial submission deleted.
-
-**Parameters**
-- `$submissionId`  (int)   Submission ID
-- `$formId`     (int)   Form ID
-
-**Usage:**
-```php 
-add_action('fluentform/after_partial_entry_deleted', function ($submissionId, $formId){
-   // Do your stuff
-}, 10, 2);
-```
-
-**Reference**
-
-`do_action('fluentform/after_partial_entry_deleted', $formData['data'], $formData['active_step'], $insertId, $formId);`
-
-This action is located in `fluentformpro/src/classes/StepFormEntries.php -> deleteEntryById()`.
-
-</explain-block>
-
----------------------------------------------------
 
 <explain-block title="fluentform/saved_progress_submission_deleted">
 
@@ -229,58 +239,29 @@ This action is located in `fluentformpro/src/classes/DraftSubmissionsManager.php
 
 </explain-block>
 
----------------------------------------------------
-
-<explain-block title="fluentform/partial_submission_deleted">
+<explain-block title="fluentform/saved_progress_submission_updated">
 
 **Description**
 
-This action runs after partial state deleted.
+This action runs when partial submission has no active step is.
 
 **Parameters**
-- `$draft` (array)  Form raw data
+- `$formData` (array)  Form raw data
+- `$activeStep` (array)  Active Step
+- `$submissionId`  (int)   Submission ID
 - `$formId`     (int)   Form ID
 
 **Usage:**
 ```php 
-add_action('fluentform/partial_submission_deleted', function ($draft, $formId){
+add_action('fluentform/saved_progress_submission_updated', function ($formData, $activeStep, $submissionId, $formId){
    // Do your stuff
-}, 10, 2);
-```
-
-**Reference**
-
-`do_action('fluentform/partial_submission_deleted', $draft, $form->id);`
-
-This action is located in `fluentformpro/src/classes/DraftSubmissionsManager.php -> deleteSavedStateDraft()`.
-
-</explain-block>
-
-------------------------------------------
-
-<explain-block title="fluentform/email_form_resume_link_before_sent">
-
-**Description**
-
-This action fire before sending email resume link for partial submission.
-
-**Parameters**
-- `$emailFormat` (array) Email Format
-- `$submittedData` (array) Partial Submitted Data
-- `$requestData` (array) Request Data
-- `$form` (object) Form
-
-**Usage:**
-```php 
-add_action('fluentform/email_form_resume_link_before_sent', function($emailFormat, $submittedData, $requestData, $form) {
-   // Do your stuff here
 }, 10, 4);
 ```
 
 **Reference**
 
-`do_action('fluentform/email_form_resume_link_before_sent', $emailFormat, $submittedData, $requestData, $form);`
+`do_action('fluentform/saved_progress_submission_updated', $formData['data'], $formData['active_step'], $insertId, $formId);`
 
-This action is located in `fluentformpro/src/classes/DraftSubmissionsManager.php -> emailProgressLink()`
+This action is located in `fluentformpro/src/classes/DraftSubmissionsManager.php -> saveState()`.
 
 </explain-block>

--- a/src/hooks/actions/payment.md
+++ b/src/hooks/actions/payment.md
@@ -4,31 +4,111 @@
 
 These hooks fire during payment processing — rendering, status changes, refunds, subscriptions, and webhooks.
 
-<explain-block title="fluentform/rendering_payment_form">
+<explain-block title="fluentform/after_entry_payment_deleted">
 
 **Description**
 
-This action runs when rendering payment form.
+This action runs after payment entries deleted
 
 **Parameters**
-- `$form` (object) Payment Form
+- `$entries` (array) Deleted entries id
+- `$transactions` (array) Transaction entries to delete
 
-**Usage**
+**Usage:**
 ```php 
-add_action('fluentform/rendering_payment_form', function($form) {
-   // Do your stuff when rendering payment form
-}, 10, 1);
+add_action('fluentform/after_entry_payment_deleted', function($entries, $transactions) {
+   // Do your stuff here
+}, 10, 2);
 ```
 
 **Reference**
 
-`do_action('fluentform/rendering_payment_form', $form);`
+`do_action('fluentform/after_entry_payment_deleted', $entries, $transactionData);`
 
-This action is located in `fluentform/app/Modules/Component/Component.php`
+This action is located in `fluentformpro/src/Payments/Classes/PaymentEntries.php`
 
 </explain-block>
 
-------------------------------------------
+<explain-block title="fluentform/after_payment_status_change">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$newStatus` — see source
+- `$this` — see source
+
+**Usage**
+
+```php
+add_action('fluentform/after_payment_status_change', function ($newStatus, $this) {
+    // your code
+}, 10, 2);
+```
+
+**Reference**
+
+`do_action('fluentform/after_payment_status_change', $newStatus, $this->getSubmission());`
+
+This action is located in `src/Payments/PaymentMethods/BaseProcessor.php` (line 263).
+
+</explain-block>
+
+<explain-block title="fluentform/after_transaction_status_change">
+
+**Description**
+
+This action runs when change transaction status.
+
+**Parameters**
+- `$status` (string) Valid Payment Status
+- `$submission` (object) Submission
+- `$transtionId` (int) Transaction ID
+
+**Usage:**
+```php 
+add_action('fluentform/after_transaction_status_change', function($status, $submission, $transtionId) {
+   // Do your stuff here
+}, 10, 3);
+```
+
+**Reference**
+
+`do_action(
+'fluentform/after_transaction_status_change',
+$newStatus,
+$this->getSubmission(),
+$transactionId
+);`
+
+This action is located in `fluentformpro/src/Payments/PaymentMethods/BaseProcessor.php`
+
+</explain-block>
+
+<explain-block title="fluentform/before_entry_payment_deleted">
+
+**Description**
+
+This action runs before payment entries delete
+
+**Parameters**
+- `$entries` (array) Deleted entries id
+- `$transactions` (array) Transaction entries to delete
+
+**Usage:**
+```php 
+add_action('fluentform/before_entry_payment_deleted', function($entries, $transactions) {
+   // Do your stuff here
+}, 10, 2);
+```
+
+**Reference**
+
+`do_action('fluentform/before_entry_payment_deleted', $entries, $transactionData);`
+
+This action is located in `fluentformpro/src/Payments/Classes/PaymentEntries.php`
+
+</explain-block>
 
 <explain-block title="fluentform/before_insert_payment_form">
 
@@ -56,146 +136,178 @@ This action is located in `fluentform/app/Services/Form/SubmissionHandlerService
 
 </explain-block>
 
-------------------------------------------
+<explain-block title="fluentform/before_payment_status_change">
 
-<explain-block title="fluentform/render_payment_entries">
+<Badge type="tip" vertical="top" text="Pro" />
 
-**Description**
+**Parameters**
 
-This action runs before rendering the payment entries.
+- `$newStatus` — see source
+- `$this` — see source
 
-**Usage:**
-```php 
-add_action('fluentform/render_payment_entries', function (){
-   // Do your stuff here
-}, 10, 0);
+**Usage**
+
+```php
+add_action('fluentform/before_payment_status_change', function ($newStatus, $this) {
+    // your code
+}, 10, 2);
 ```
 
 **Reference**
 
-`do_action('fluentform/render_payment_entries');`
+`do_action('fluentform/before_payment_status_change', $newStatus, $this->getSubmission());`
 
-This action is located in `fluentform/app/Modules/Registerer/Menu.php`
+This action is located in `src/Payments/PaymentMethods/BaseProcessor.php` (line 229).
 
 </explain-block>
 
-------------------------------------------
-
-<explain-block title="fluentform/rendering_payment_method_{$methodName}">
+<explain-block title="fluentform/form_payment_success">
 
 **Description**
 
-This action runs when rendering the payment active methods.
+This action runs after PayPal subscription complete
 
 **Parameters**
-- `$paymentMethod` - (string) Current Payment Method
-- `$data` - (array)  Current Payment Element
-- `$form` - (object) Form
+- `$submission` (object) Submission Object
+- `$transaction` (array) Transaction Data
+- `$formId` (int) Form ID
+- `$ipnVerified` (boolean) Ipn Verification
 
 **Usage:**
 ```php 
-add_action('fluentform/rendering_payment_method_{$methodName}', function ($paymentMethod, $data, $form){
+add_action('fluentform/form_payment_success', function($submission, $transaction, $formId, $ipnVerified) {
    // Do your stuff here
-}, 10, 3);
+}, 10, 4);
 ```
-
-**Note:** `{$methodName}` is dynamic method name. Replace `{$methodName}` with Fluent Forms payment methods name.
 
 **Reference**
 
-`do_action('fluentform/rendering_payment_method_' . $methodName, $activatedMethod, $data, $form);`
+`do_action('fluentform/form_payment_success', $submission, $transaction, $formId, false);`
 
-This action is located in `fluentformpro/src/Payments/Components/PaymentMethods.php`, `fluentform/app/Services/FluentConversational/Classes/Converter/Converter.php`
+This action is located in `fluentformpro/src/Payments/PaymentMethods/PayPal/API/IPN.php`
 
 </explain-block>
 
-------------------------------------------
-
-<explain-block title="fluentform/payment_frameless_{$paymentMethod}">
+<explain-block title="fluentform/form_submission_activity_start">
 
 **Description**
 
-This action runs before rendering the payment redirect handler page.
+This action runs when PayPal INP process subscription payment or Stripe handle cancelled subscription.
 
 **Parameters**
-- `$data` - (array) Payment Data
+- `$formId` (ing) Form Id
 
 **Usage:**
 ```php 
-add_action('fluentform/payment_frameless_{$paymentMethod}', function ($data){
+add_action('fluentform/form_submission_activity_start', function($formId) {
    // Do your stuff here
 }, 10, 1);
 ```
 
-**Note:** `{$paymentMethod}` is dynamic method name. Replace `{$paymentMethod}` with Fluent Forms payment methods name.
+**Reference**
+
+`do_action('fluentform/form_submission_activity_start', $submission->form_id);`
+
+This action is located in `fluentformpro/src/Payments/PaymentMethods/PayPal/API/IPN.php -> processSubscriptionPayment()`
+This action is located in `fluentformpro/src/Payments/PaymentMethods/Stripe/API/StripeListener.php -> handleSubscriptionCancelled()`
+
+</explain-block>
+
+<explain-block title="fluentform/handle_authorizenet_">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- See source
+
+**Usage**
+
+```php
+add_action('fluentform/handle_authorizenet_', function ($value) {
+    // your code
+}, 10, 1);
+```
 
 **Reference**
 
-`do_action('fluentform/payment_frameless_' . $paymentMethod, $data);`
+`do_action('fluentform/handle_authorizenet_' . $entityName . '_ipn', $data);`
+
+This action is located in `src/Payments/PaymentMethods/AuthorizeNet/API/IPN.php` (line 115).
+
+</explain-block>
+
+<explain-block title="fluentform/handle_payment_ajax_endpoint">
+
+**Parameters**
+
+- `$route` — see source
+
+**Usage**
+
+```php
+add_action('fluentform/handle_payment_ajax_endpoint', function ($route) {
+    // your code
+}, 10, 1);
+```
+
+**Reference**
+
+`do_action('fluentform/handle_payment_ajax_endpoint', $route);`
+
+This action is located in `app/Modules/Payments/AjaxEndpoints.php` (line 43).
+
+</explain-block>
+
+<explain-block title="fluentform/ipn_endpoint_{$paymentMethod}">
+
+**Description**
+
+This action runs when payment handler api notify.
+
+**Usage:**
+```php 
+add_action('fluentform/ipn_endpoint_{$paymentMethod}', function() {
+   // Do your stuff here
+}, 10, 0);
+```
+
+**Note:** `{$paymentMethod}` is dynamic value. Replace `{$paymentMethod}` with valid payment method.
+
+**Reference**
+
+`do_action('fluentform/ipn_endpoint_' . $paymentMethod);`
 
 This action is located in `fluentformpro/src/Payments/PaymentHandler.php`
 
 </explain-block>
 
-------------------------------------------
-
-<explain-block title="fluentform/payment_method_render_{$paymentMethod}">
+<explain-block title="fluentform/ipn_mollie_action_refunded">
 
 **Description**
 
-This action runs if the form has single payment method, then the payment method is rendered using this method.
+This action runs when  Mollie ipn verification response with refund.
 
 **Parameters**
-- `$methodElement` (array) Payment Method Data
-- `$form` (object) Form Object
+- `$amount` (int) Refund Amount
+- `$submission` (object) Submission Object
+- `$vendorData` - (array) Transaction vendor data
+- `$data` (array) Encoded vendor data
 
 **Usage:**
 ```php 
-add_action('fluentform/payment_method_render_{$paymentMethod}', function ($methodElement, $data){
+add_action('fluentform/ipn_mollie_action_refunded', function($amount, $submission, $vendorData, $data) {
    // Do your stuff here
-}, 10, 2);
+}, 10, 4);
 ```
-
-**Note:** `{$paymentMethod}` is dynamic method name. Replace `{$paymentMethod}` with Fluent Forms payment methods name.
 
 **Reference**
 
-`do_action('fluentform/payment_method_render_' . $paymentMethod, $methodElement, $data);`
+`do_action('fluentform/ipn_mollie_action_refunded', $refundAmount, $submission, $vendorTransaction, $data);`
 
-This action is located in `fluentformpro/src/Payments/Components/PaymentMethods.php`
-
-</explain-block>
-
-------------------------------------------
-
-<explain-block title="fluentform/payment_refunded">
-
-**Description**
-
-This action runs after a successful refund on every payment method. You can hook into this and get the refund data.
-
-**Parameters**
-- `$refund` (array)  Refund Data
-- `$form_id` (int) Form ID
-
-**Usage:**
-```php 
-add_action('fluentform/payment_refunded', function($refund, $form_id) {
-   // Do your stuff here
-}, 10, 2);
-```
-
-**Note:** `{$paymentMethod}` is dynamic method name. Replace `{$paymentMethod}` with Fluent Forms payment methods name.
-
-**Reference**
-
-`do_action('fluentform/payment_refunded', $refund, $refund->form_id);`
-
-This action is located in `fluentformpro/src/Payments/PaymentMethods/BaseProcessor.php`
+This action is located in `fluentformpro/src/Payments/PaymentMethods/Mollie/API/IPN.php`
 
 </explain-block>
-
-------------------------------------------
 
 <explain-block title="fluentform/ipn_mollie_action_{$status}">
 
@@ -225,13 +337,67 @@ This action is located in `fluentformpro/src/Payments/PaymentMethods/Mollie/API/
 
 </explain-block>
 
-------------------------------------------
-
-<explain-block title="fluentform/ipn_mollie_action_refunded">
+<explain-block title="fluentform/ipn_paypal_action_web_accept">
 
 **Description**
 
-This action runs when  Mollie ipn verification response with refund.
+This action runs during the web accept PayPal ipn.
+
+**Parameters**
+- `$encoded_data_array` (array) Encoded Data
+- `$submissionId` (int) Submission ID
+- `$submission` (object) Submission Object
+- `$ipnVerified` (boolean) Ipn Verification
+
+**Usage:**
+```php 
+add_action('fluentform/ipn_paypal_action_web_accept', function($encoded_data_array, $submissionId, $submission, $ipnVerified) {
+   // Do your stuff here
+}, 10, 4);
+```
+
+**Reference**
+
+`do_action('fluentform/ipn_paypal_action_web_accept', $encoded_data_array, $submissionId, $submission, $ipnVerified);`
+
+This action is located in `fluentformpro/src/Payments/PaymentMethods/PayPal/API/IPN.php`
+
+</explain-block>
+
+<explain-block title="fluentform/ipn_paypal_action_{$txn_type}">
+
+**Description**
+
+This action runs when  PayPal ipn verification response. You can use to specify transaction type processing you want to perform.
+
+**Parameters**
+- `$encoded_data_array` (array) Encoded Data
+- `$submissionId` (int) Submission ID
+- `$submission` (object) Submission Object
+- `$ipnVerified` (boolean) Ipn Verification
+
+**Usage:**
+```php 
+add_action('fluentform/ipn_paypal_action_{$txn_type}', function($encoded_data_array, $submissionId, $submission, $ipnVerified) {
+   // Do your stuff here
+}, 10, 4);
+```
+
+**Note:** `{$txn_type}` is dynamic [IPN transaction types](https://developer.paypal.com/api/nvp-soap/ipn/IPNandPDTVariables/#link-ipntransactiontypes). Replace `{$txn_type}` with INP transaction type.
+
+**Reference**
+
+`do_action('fluentform/ipn_paypal_action_' . $encoded_data_array['txn_type'], $encoded_data_array, $submissionId, $submission, $ipnVerified);`
+
+This action is located in `fluentformpro/src/Payments/PaymentMethods/PayPal/API/IPN.php`
+
+</explain-block>
+
+<explain-block title="fluentform/ipn_razorpay_action_refunded">
+
+**Description**
+
+This action runs when  Razorpay ipn verification response with refund.
 
 **Parameters**
 - `$amount` (int) Refund Amount
@@ -241,20 +407,18 @@ This action runs when  Mollie ipn verification response with refund.
 
 **Usage:**
 ```php 
-add_action('fluentform/ipn_mollie_action_refunded', function($amount, $submission, $vendorData, $data) {
+add_action('fluentform/ipn_razorpay_action_refunded', function($amount, $submission, $vendorData, $data) {
    // Do your stuff here
 }, 10, 4);
 ```
 
 **Reference**
 
-`do_action('fluentform/ipn_mollie_action_refunded', $refundAmount, $submission, $vendorTransaction, $data);`
+`do_action('fluentform/ipn_razorpay_action_refunded', $refundAmount, $submission, $vendorTransaction, $data);`
 
-This action is located in `fluentformpro/src/Payments/PaymentMethods/Mollie/API/IPN.php`
+This action is located in `fluentformpro/src/Payments/PaymentMethods/RazorPay/API.php`
 
 </explain-block>
-
-------------------------------------------
 
 <explain-block title="fluentform/ipn_razorpay_action_{$status}">
 
@@ -284,98 +448,29 @@ This action is located in `fluentformpro/src/Payments/PaymentMethods/RazorPay/AP
 
 </explain-block>
 
-------------------------------------------
+<explain-block title="fluentform/payment_">
 
-<explain-block title="fluentform/ipn_razorpay_action_refunded">
-
-**Description**
-
-This action runs when  Razorpay ipn verification response with refund.
+<Badge type="tip" vertical="top" text="Pro" />
 
 **Parameters**
-- `$amount` (int) Refund Amount
-- `$submission` (object) Submission Object
-- `$vendorData` - (array) Transaction vendor data
-- `$data` (array) Encoded vendor data
 
-**Usage:**
-```php 
-add_action('fluentform/ipn_razorpay_action_refunded', function($amount, $submission, $vendorData, $data) {
-   // Do your stuff here
-}, 10, 4);
+- See source
+
+**Usage**
+
+```php
+add_action('fluentform/payment_', function ($value) {
+    // your code
+}, 10, 1);
 ```
 
 **Reference**
 
-`do_action('fluentform/ipn_razorpay_action_refunded', $refundAmount, $submission, $vendorTransaction, $data);`
+`do_action('fluentform/payment_' . $status . '_' . $method, $refund, $transaction, $submission);`
 
-This action is located in `fluentformpro/src/Payments/PaymentMethods/RazorPay/API.php`
-
-</explain-block>
-
-------------------------------------------
-
-<explain-block title="fluentform/stripe_customer_created">
-
-**Description**
-
-This action runs after created Stripe customer.
-
-**Parameters**
-- `$data` (array) Customer API response
-- `$customerArgs` (array) Customer Args
-
-**Usage:**
-```php 
-add_action('fluentform/stripe_customer_created', function($data, $customerArgs) {
-   // Do your stuff here
-}, 10, 2);
-```
-
-**Reference**
-
-`do_action('fluentform/stripe_customer_created', $response, $customerArgs);`
-
-This action is located in `fluentformpro/src/Payments/PaymentMethods/Stripe/API/Customer.php`
+This action is located in `src/Payments/PaymentMethods/BaseProcessor.php` (line 655).
 
 </explain-block>
-
-------------------------------------------
-
-<explain-block title="fluentform/payment_stripe_failed">
-
-**Description**
-
-This action runs when handle payment charge error.
-
-**Parameters**
-- `$submission` (object) Submission
-- `$transaction` (object) Transaction
-- `$formId` (int) Form Id
-- `$charge` (bool) Charged or not
-- `$type` (string) Type
-  - `customer`
-  - `subscription`
-  - `invoice`
-  - `payment_intent`
-  - `payment_error`
-
-**Usage:**
-```php 
-add_action('fluentform/payment_stripe_failed', function($submission, $transaction, $formId, $charge, $type) {
-   // Do your stuff here
-}, 10, 5);
-```
-
-**Reference**
-
-`do_action('fluentform/payment_stripe_failed', $submission, $transaction, $this->form->id, $charge, $type);`
-
-This action is located in `fluentformpro/src/Payments/PaymentMethods/Stripe/StripeProcessor.php -> handlePaymentChargeError()`
-
-</explain-block>
-
-------------------------------------------
 
 <explain-block title="fluentform/payment_failed">
 
@@ -410,259 +505,323 @@ This action is located in `fluentformpro/src/Payments/PaymentMethods/Stripe/Stri
 
 </explain-block>
 
-
-------------------------------------------
-
-<explain-block title="fluentform/transactions_before_table">
+<explain-block title="fluentform/payment_frameless_{$paymentMethod}">
 
 **Description**
 
-This action runs before creating transactions receipt table.
+This action runs before rendering the payment redirect handler page.
 
 **Parameters**
-- `$transaction` (array) Transactions
+- `$data` - (array) Payment Data
 
 **Usage:**
 ```php 
-add_action('fluentform/transactions_before_table', function($transactions) {
+add_action('fluentform/payment_frameless_{$paymentMethod}', function ($data){
+   // Do your stuff here
+}, 10, 1);
+```
+
+**Note:** `{$paymentMethod}` is dynamic method name. Replace `{$paymentMethod}` with Fluent Forms payment methods name.
+
+**Reference**
+
+`do_action('fluentform/payment_frameless_' . $paymentMethod, $data);`
+
+This action is located in `fluentformpro/src/Payments/PaymentHandler.php`
+
+</explain-block>
+
+<explain-block title="fluentform/payment_method_render_{$paymentMethod}">
+
+**Description**
+
+This action runs if the form has single payment method, then the payment method is rendered using this method.
+
+**Parameters**
+- `$methodElement` (array) Payment Method Data
+- `$form` (object) Form Object
+
+**Usage:**
+```php 
+add_action('fluentform/payment_method_render_{$paymentMethod}', function ($methodElement, $data){
+   // Do your stuff here
+}, 10, 2);
+```
+
+**Note:** `{$paymentMethod}` is dynamic method name. Replace `{$paymentMethod}` with Fluent Forms payment methods name.
+
+**Reference**
+
+`do_action('fluentform/payment_method_render_' . $paymentMethod, $methodElement, $data);`
+
+This action is located in `fluentformpro/src/Payments/Components/PaymentMethods.php`
+
+</explain-block>
+
+<explain-block title="fluentform/payment_receipt_after_content">
+
+**Description**
+
+This action runs after rendered payment receipt
+
+**Parameters**
+- `$submission` (object) Submission data
+
+**Usage:**
+```php 
+add_action('fluentform/payment_receipt_after_content', function($submission) {
    // Do your stuff here
 }, 10, 1);
 ```
 
 **Reference**
 
-`do_action('fluentform/transactions_before_table', $transactions);`
+`do_action('fluentform/payment_receipt_after_content', $this->entry);`
 
-This action is located in `fluentformpro/src/views/receipt/transactions_table.php`
+This action is located in `fluentformpro/src/Payments/Classes/PaymentReceipt.php`
 
 </explain-block>
 
-------------------------------------------
-
-<explain-block title="fluentform/transaction_table_thead_row">
+<explain-block title="fluentform/payment_receipt_before_content">
 
 **Description**
 
-This action runs after creating transactions receipt table head (th).
+This action runs before rendering payment receipt
 
 **Parameters**
-- `$transactions` (array) Transactions
+- `$submission` (object) Submission data
 
 **Usage:**
 ```php 
-add_action('fluentform/transaction_table_thead_row', function($transactions) {
+add_action('fluentform/payment_receipt_before_content', function($submission) {
    // Do your stuff here
 }, 10, 1);
 ```
 
 **Reference**
 
-`do_action('fluentform/transaction_table_thead_row', $transactions);`
+`do_action('fluentform/payment_receipt_before_content', $this->entry);`
 
-This action is located in `fluentformpro/src/views/receipt/transactions_table.php`
-
-</explain-block>
-
-------------------------------------------
-
-<explain-block title="fluentform/transactions_actions">
-
-**Description**
-
-This action runs when render transaction receipt table body actions.
-
-**Parameters**
-- `$transaction` (object) Transaction
-
-**Usage:**
-```php 
-add_action('fluentform/transactions_actions', function($transaction) {
-   // Do your stuff here
-}, 10, 1);
-```
-
-**Reference**
-
-`do_action('fluentform/transactions_actions', $transaction);`
-
-This action is located in `fluentformpro/src/views/receipt/transactions_table.php`
+This action is located in `fluentformpro/src/Payments/Classes/PaymentReceipt.php`
 
 </explain-block>
 
-------------------------------------------
+<explain-block title="fluentform/payment_refund_updated">
 
-<explain-block title="fluentform/transaction_table_tbody_row">
-
-**Description**
-
-This action runs after render transaction receipt table body td.
+<Badge type="tip" vertical="top" text="Pro" />
 
 **Parameters**
-- `$transaction` (object) Transaction
-- `$transactions` (array) Transactions
 
-**Usage:**
-```php 
-add_action('fluentform/transaction_table_tbody_row', function($transaction, $transactions) {
-   // Do your stuff here
+- `$existingRefund` — see source
+- `$existingRefund_2` — see source
+
+**Usage**
+
+```php
+add_action('fluentform/payment_refund_updated', function ($existingRefund, $existingRefund_2) {
+    // your code
 }, 10, 2);
 ```
 
 **Reference**
 
-`do_action('fluentform/transaction_table_tbody_row', $transaction, $transactions);`
+`do_action('fluentform/payment_refund_updated', $existingRefund, $existingRefund->form_id);`
 
-This action is located in `fluentformpro/src/views/receipt/transactions_table.php`
+This action is located in `src/Payments/PaymentMethods/BaseProcessor.php` (line 743).
 
 </explain-block>
 
-------------------------------------------
+<explain-block title="fluentform/payment_refund_updated_">
 
-<explain-block title="fluentform/transactions_before_table_close">
-
-**Description**
-
-This action runs before closing transactions receipt table.
+<Badge type="tip" vertical="top" text="Pro" />
 
 **Parameters**
-- `$transactions` (array) Transactions
 
-**Usage:**
-```php 
-add_action('fluentform/transactions_before_table_close', function($transactions) {
-   // Do your stuff here
+- See source
+
+**Usage**
+
+```php
+add_action('fluentform/payment_refund_updated_', function ($value) {
+    // your code
 }, 10, 1);
 ```
 
 **Reference**
 
-`do_action('fluentform/transactions_before_table_close', $transactions);`
+`do_action('fluentform/payment_refund_updated_' . $method, $existingRefund, $existingRefund->form_id);`
 
-This action is located in `fluentformpro/src/views/receipt/transactions_table.php`
+This action is located in `src/Payments/PaymentMethods/BaseProcessor.php` (line 730).
 
 </explain-block>
 
-------------------------------------------
-
-<explain-block title="fluentform/transactions_after_table">
+<explain-block title="fluentform/payment_refunded">
 
 **Description**
 
-This action runs after created transaction receipt table.
+This action runs after a successful refund on every payment method. You can hook into this and get the refund data.
 
 **Parameters**
-- `$transactions` (array) Transactions
+- `$refund` (array)  Refund Data
+- `$form_id` (int) Form ID
 
 **Usage:**
 ```php 
-add_action('fluentform/transactions_after_table', function($transactions) {
+add_action('fluentform/payment_refunded', function($refund, $form_id) {
    // Do your stuff here
-}, 10, 1);
+}, 10, 2);
+```
+
+**Note:** `{$paymentMethod}` is dynamic method name. Replace `{$paymentMethod}` with Fluent Forms payment methods name.
+
+**Reference**
+
+`do_action('fluentform/payment_refunded', $refund, $refund->form_id);`
+
+This action is located in `fluentformpro/src/Payments/PaymentMethods/BaseProcessor.php`
+
+</explain-block>
+
+<explain-block title="fluentform/payment_square_inline_failed">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$submission` — see source
+- `$transaction` — see source
+- `$this` — see source
+- `$charge` — see source
+- `$type` — see source
+
+**Usage**
+
+```php
+add_action('fluentform/payment_square_inline_failed', function ($submission, $transaction, $this, $charge, $type) {
+    // your code
+}, 10, 5);
 ```
 
 **Reference**
 
-`do_action('fluentform/transactions_after_table', $transactions);`
+`do_action('fluentform/payment_square_inline_failed', $submission, $transaction, $this->form->id, $charge, $type);`
 
-This action is located in `fluentformpro/src/views/receipt/transactions_table.php`
+This action is located in `src/Payments/PaymentMethods/Square/SquareInlineProcessor.php` (line 217).
 
 </explain-block>
 
-
-------------------------------------------
-
-<explain-block title="fluentform/after_transaction_status_change">
+<explain-block title="fluentform/payment_stripe_failed">
 
 **Description**
 
-This action runs when change transaction status.
+This action runs when handle payment charge error.
 
 **Parameters**
-- `$status` (string) Valid Payment Status
 - `$submission` (object) Submission
-- `$transtionId` (int) Transaction ID
+- `$transaction` (object) Transaction
+- `$formId` (int) Form Id
+- `$charge` (bool) Charged or not
+- `$type` (string) Type
+  - `customer`
+  - `subscription`
+  - `invoice`
+  - `payment_intent`
+  - `payment_error`
 
 **Usage:**
 ```php 
-add_action('fluentform/after_transaction_status_change', function($status, $submission, $transtionId) {
+add_action('fluentform/payment_stripe_failed', function($submission, $transaction, $formId, $charge, $type) {
+   // Do your stuff here
+}, 10, 5);
+```
+
+**Reference**
+
+`do_action('fluentform/payment_stripe_failed', $submission, $transaction, $this->form->id, $charge, $type);`
+
+This action is located in `fluentformpro/src/Payments/PaymentMethods/Stripe/StripeProcessor.php -> handlePaymentChargeError()`
+
+</explain-block>
+
+<explain-block title="fluentform/payment_subscription_status_to_cancelled">
+
+**Description**
+
+This action runs when subscription payment status change to cancelled
+
+**Parameters**
+- `$subscription` (object) Subscription data
+- `$submission` (object) Submission data
+- `$oldStatus` (string) Subscription old status
+
+**Usage:**
+```php 
+add_action('fluentform/payment_subscription_status_to_cancelled', function($subscription, $submission, $oldStatus) {
    // Do your stuff here
 }, 10, 3);
 ```
 
 **Reference**
 
-`do_action(
-'fluentform/after_transaction_status_change',
-$newStatus,
-$this->getSubmission(),
-$transactionId
-);`
+`do_action('fluentform/payment_subscription_status_to_cancelled', $subscription, $submission, $oldStatus);`
 
-This action is located in `fluentformpro/src/Payments/PaymentMethods/BaseProcessor.php`
+This action is located in `fluentformpro/src/Payments/Classes/PaymentManagement.php`
 
 </explain-block>
 
-------------------------------------------
-
-<explain-block title="fluentform/ipn_paypal_action_{$txn_type}">
+<explain-block title="fluentform/payment_subscription_status_{$payment_method}_to_{$newStatus}">
 
 **Description**
 
-This action runs when  PayPal ipn verification response. You can use to specify transaction type processing you want to perform.
+This action runs when subscription payment status change to cancelled
 
 **Parameters**
-- `$encoded_data_array` (array) Encoded Data
-- `$submissionId` (int) Submission ID
-- `$submission` (object) Submission Object
-- `$ipnVerified` (boolean) Ipn Verification
+- `$subscription` (object) Subscription data
+- `$submission` (object) Submission data
+- `$oldStatus` (string) Subscription old status
 
 **Usage:**
 ```php 
-add_action('fluentform/ipn_paypal_action_{$txn_type}', function($encoded_data_array, $submissionId, $submission, $ipnVerified) {
+add_action('fluentform/payment_subscription_status_{$payment_method}_to_{$newStatus}', function($subscription, $submission, $oldStatus) {
    // Do your stuff here
-}, 10, 4);
+}, 10, 3);
 ```
 
-**Note:** `{$txn_type}` is dynamic [IPN transaction types](https://developer.paypal.com/api/nvp-soap/ipn/IPNandPDTVariables/#link-ipntransactiontypes). Replace `{$txn_type}` with INP transaction type.
+**Note:** `{$payment_method}` and `{$newSatus}` is dynamic value. Replace `{$payment_method}` with fluentform valid payment method and `{$newSatus}` with valid subscription payment status for responsible payment method.
 
 **Reference**
 
-`do_action('fluentform/ipn_paypal_action_' . $encoded_data_array['txn_type'], $encoded_data_array, $submissionId, $submission, $ipnVerified);`
+`do_action('fluentform/payment_subscription_status_' . $submission->payment_method . '_to_' . $newStatus, $subscription, $submission, $oldStatus);`
 
-This action is located in `fluentformpro/src/Payments/PaymentMethods/PayPal/API/IPN.php`
+This action is located in `fluentformpro/src/Payments/Classes/PaymentManagement.php`
 
 </explain-block>
 
-------------------------------------------
-
-<explain-block title="fluentform/ipn_paypal_action_web_accept">
+<explain-block title="fluentform/payment_view_{$route}">
 
 **Description**
 
-This action runs during the web accept PayPal ipn.
+This action runs before rendering the payment handler view.
 
 **Parameters**
-- `$encoded_data_array` (array) Encoded Data
-- `$submissionId` (int) Submission ID
-- `$submission` (object) Submission Object
-- `$ipnVerified` (boolean) Ipn Verification
+- `$data` - (array) Payment Data
 
 **Usage:**
 ```php 
-add_action('fluentform/ipn_paypal_action_web_accept', function($encoded_data_array, $submissionId, $submission, $ipnVerified) {
+add_action('fluentform/payment_view_{$route}', function($data) {
    // Do your stuff here
-}, 10, 4);
+}, 10, 1);
 ```
+
+**Note:** `{$route}` is dynamic value. Replace `{$route}` with valid payment view route.
 
 **Reference**
 
-`do_action('fluentform/ipn_paypal_action_web_accept', $encoded_data_array, $submissionId, $submission, $ipnVerified);`
+`do_action('fluentform/payment_view_' . $route, $data);`
 
-This action is located in `fluentformpro/src/Payments/PaymentMethods/PayPal/API/IPN.php`
+This action is located in `fluentformpro/src/Payments/PaymentHandler.php`
 
 </explain-block>
-
-------------------------------------------
 
 <explain-block title="fluentform/process_payment">
 
@@ -694,7 +853,53 @@ This action is located in `fluentformpro/src/Payments/Classes/PaymentAction.php`
 
 </explain-block>
 
-------------------------------------------
+<explain-block title="fluentform/process_payment_square_">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- See source
+
+**Usage**
+
+```php
+add_action('fluentform/process_payment_square_', function ($value) {
+    // your code
+}, 10, 1);
+```
+
+**Reference**
+
+`do_action('fluentform/process_payment_square_' . $processor, $submissionId, $submissionData, $form, $methodSettings, $hasSubscriptions, $totalPayable);`
+
+This action is located in `src/Payments/PaymentMethods/Square/SquareHandler.php` (line 248).
+
+</explain-block>
+
+<explain-block title="fluentform/process_payment_stripe_">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- See source
+
+**Usage**
+
+```php
+add_action('fluentform/process_payment_stripe_', function ($value) {
+    // your code
+}, 10, 1);
+```
+
+**Reference**
+
+`do_action('fluentform/process_payment_stripe_' . $processor, $submissionId, $submissionData, $form, $methodSettings, $hasSubscriptions, $totalPayable);`
+
+This action is located in `src/Payments/PaymentMethods/Stripe/StripeHandler.php` (line 82).
+
+</explain-block>
 
 <explain-block title="fluentform/process_payment_{$method_name}">
 
@@ -727,342 +932,127 @@ This action is located in `fluentformpro/src/Payments/Classes/PaymentAction.php`
 
 </explain-block>
 
-------------------------------------------
-
-<explain-block title="fluentform/form_payment_success">
+<explain-block title="fluentform/render_payment_entries">
 
 **Description**
 
-This action runs after PayPal subscription complete
-
-**Parameters**
-- `$submission` (object) Submission Object
-- `$transaction` (array) Transaction Data
-- `$formId` (int) Form ID
-- `$ipnVerified` (boolean) Ipn Verification
+This action runs before rendering the payment entries.
 
 **Usage:**
 ```php 
-add_action('fluentform/form_payment_success', function($submission, $transaction, $formId, $ipnVerified) {
-   // Do your stuff here
-}, 10, 4);
-```
-
-**Reference**
-
-`do_action('fluentform/form_payment_success', $submission, $transaction, $formId, false);`
-
-This action is located in `fluentformpro/src/Payments/PaymentMethods/PayPal/API/IPN.php`
-
-</explain-block>
-
-------------------------------------------
-
-<explain-block title="fluentform/before_entry_payment_deleted">
-
-**Description**
-
-This action runs before payment entries delete
-
-**Parameters**
-- `$entries` (array) Deleted entries id
-- `$transactions` (array) Transaction entries to delete
-
-**Usage:**
-```php 
-add_action('fluentform/before_entry_payment_deleted', function($entries, $transactions) {
-   // Do your stuff here
-}, 10, 2);
-```
-
-**Reference**
-
-`do_action('fluentform/before_entry_payment_deleted', $entries, $transactionData);`
-
-This action is located in `fluentformpro/src/Payments/Classes/PaymentEntries.php`
-
-</explain-block>
-
-------------------------------------------
-
-<explain-block title="fluentform/after_entry_payment_deleted">
-
-**Description**
-
-This action runs after payment entries deleted
-
-**Parameters**
-- `$entries` (array) Deleted entries id
-- `$transactions` (array) Transaction entries to delete
-
-**Usage:**
-```php 
-add_action('fluentform/after_entry_payment_deleted', function($entries, $transactions) {
-   // Do your stuff here
-}, 10, 2);
-```
-
-**Reference**
-
-`do_action('fluentform/after_entry_payment_deleted', $entries, $transactionData);`
-
-This action is located in `fluentformpro/src/Payments/Classes/PaymentEntries.php`
-
-</explain-block>
-
-------------------------------------------
-
-<explain-block title="fluentform/form_submission_activity_start">
-
-**Description**
-
-This action runs when PayPal INP process subscription payment or Stripe handle cancelled subscription.
-
-**Parameters**
-- `$formId` (ing) Form Id
-
-**Usage:**
-```php 
-add_action('fluentform/form_submission_activity_start', function($formId) {
-   // Do your stuff here
-}, 10, 1);
-```
-
-**Reference**
-
-`do_action('fluentform/form_submission_activity_start', $submission->form_id);`
-
-This action is located in `fluentformpro/src/Payments/PaymentMethods/PayPal/API/IPN.php -> processSubscriptionPayment()`
-This action is located in `fluentformpro/src/Payments/PaymentMethods/Stripe/API/StripeListener.php -> handleSubscriptionCancelled()`
-
-</explain-block>
-
-------------------------------------------
-
-<explain-block title="fluentform/payment_subscription_status_to_cancelled">
-
-**Description**
-
-This action runs when subscription payment status change to cancelled
-
-**Parameters**
-- `$subscription` (object) Subscription data
-- `$submission` (object) Submission data
-- `$oldStatus` (string) Subscription old status
-
-**Usage:**
-```php 
-add_action('fluentform/payment_subscription_status_to_cancelled', function($subscription, $submission, $oldStatus) {
-   // Do your stuff here
-}, 10, 3);
-```
-
-**Reference**
-
-`do_action('fluentform/payment_subscription_status_to_cancelled', $subscription, $submission, $oldStatus);`
-
-This action is located in `fluentformpro/src/Payments/Classes/PaymentManagement.php`
-
-</explain-block>
-
-
-------------------------------------------
-
-<explain-block title="fluentform/payment_subscription_status_{$payment_method}_to_{$newStatus}">
-
-**Description**
-
-This action runs when subscription payment status change to cancelled
-
-**Parameters**
-- `$subscription` (object) Subscription data
-- `$submission` (object) Submission data
-- `$oldStatus` (string) Subscription old status
-
-**Usage:**
-```php 
-add_action('fluentform/payment_subscription_status_{$payment_method}_to_{$newStatus}', function($subscription, $submission, $oldStatus) {
-   // Do your stuff here
-}, 10, 3);
-```
-
-**Note:** `{$payment_method}` and `{$newSatus}` is dynamic value. Replace `{$payment_method}` with fluentform valid payment method and `{$newSatus}` with valid subscription payment status for responsible payment method.
-
-**Reference**
-
-`do_action('fluentform/payment_subscription_status_' . $submission->payment_method . '_to_' . $newStatus, $subscription, $submission, $oldStatus);`
-
-This action is located in `fluentformpro/src/Payments/Classes/PaymentManagement.php`
-
-</explain-block>
-
-------------------------------------------
-
-<explain-block title="fluentform/payment_receipt_before_content">
-
-**Description**
-
-This action runs before rendering payment receipt
-
-**Parameters**
-- `$submission` (object) Submission data
-
-**Usage:**
-```php 
-add_action('fluentform/payment_receipt_before_content', function($submission) {
-   // Do your stuff here
-}, 10, 1);
-```
-
-**Reference**
-
-`do_action('fluentform/payment_receipt_before_content', $this->entry);`
-
-This action is located in `fluentformpro/src/Payments/Classes/PaymentReceipt.php`
-
-</explain-block>
-
-------------------------------------------------
-
-<explain-block title="fluentform/payment_receipt_after_content">
-
-**Description**
-
-This action runs after rendered payment receipt
-
-**Parameters**
-- `$submission` (object) Submission data
-
-**Usage:**
-```php 
-add_action('fluentform/payment_receipt_after_content', function($submission) {
-   // Do your stuff here
-}, 10, 1);
-```
-
-**Reference**
-
-`do_action('fluentform/payment_receipt_after_content', $this->entry);`
-
-This action is located in `fluentformpro/src/Payments/Classes/PaymentReceipt.php`
-
-</explain-block>
-
--------------------------------------------
-
-<explain-block title="fluentform/payment_view_{$route}">
-
-**Description**
-
-This action runs before rendering the payment handler view.
-
-**Parameters**
-- `$data` - (array) Payment Data
-
-**Usage:**
-```php 
-add_action('fluentform/payment_view_{$route}', function($data) {
-   // Do your stuff here
-}, 10, 1);
-```
-
-**Note:** `{$route}` is dynamic value. Replace `{$route}` with valid payment view route.
-
-**Reference**
-
-`do_action('fluentform/payment_view_' . $route, $data);`
-
-This action is located in `fluentformpro/src/Payments/PaymentHandler.php`
-
-</explain-block>
-
--------------------------------------------
-
-<explain-block title="fluentform/ipn_endpoint_{$paymentMethod}">
-
-**Description**
-
-This action runs when payment handler api notify.
-
-
-**Usage:**
-```php 
-add_action('fluentform/ipn_endpoint_{$paymentMethod}', function() {
+add_action('fluentform/render_payment_entries', function (){
    // Do your stuff here
 }, 10, 0);
 ```
 
-**Note:** `{$paymentMethod}` is dynamic value. Replace `{$paymentMethod}` with valid payment method.
-
 **Reference**
 
-`do_action('fluentform/ipn_endpoint_' . $paymentMethod);`
+`do_action('fluentform/render_payment_entries');`
 
-This action is located in `fluentformpro/src/Payments/PaymentHandler.php`
+This action is located in `fluentform/app/Modules/Registerer/Menu.php`
 
 </explain-block>
 
--------------------------------------------
-
-<explain-block title="fluentform/subscription_payment_received">
+<explain-block title="fluentform/rendering_payment_form">
 
 **Description**
 
-This action runs when PayPal new subscription received.
+This action runs when rendering payment form.
 
 **Parameters**
-- `$submission` - (object) Submission data
-- `$updatedSubscription` - (array) Subscription updated data
-- `$formId` - (int) Form Id
-- `$subscription` - (object) Subscription data
+- `$form` (object) Payment Form
 
-**Usage:**
+**Usage**
 ```php 
-add_action('fluentform/subscription_payment_received', function($subscription, $submission, $vendorData) {
-   // Do your stuff here
-}, 10, 4);
+add_action('fluentform/rendering_payment_form', function($form) {
+   // Do your stuff when rendering payment form
+}, 10, 1);
 ```
-
 
 **Reference**
 
-`do_action('fluentform/subscription_payment_received', $subscription, $submission, $vendorData);`
+`do_action('fluentform/rendering_payment_form', $form);`
 
-This action is located in `fluentformpro/src/Payments/PaymentMethods/PayPal/API/IPN.php`
+This action is located in `fluentform/app/Modules/Component/Component.php`
 
 </explain-block>
 
--------------------------------------------
-
-<explain-block title="fluentform/subscription_payment_received_paypal">
+<explain-block title="fluentform/rendering_payment_method_{$methodName}">
 
 **Description**
 
-This action runs when PayPal new subscription received.
+This action runs when rendering the payment active methods.
 
 **Parameters**
-- `$submission` - (object) Submission data
-- `$updatedSubscription` - (array) Subscription updated data
-- `$formId` - (int) Form Id
-- `$subscription` - (object) Subscription data
+- `$paymentMethod` - (string) Current Payment Method
+- `$data` - (array)  Current Payment Element
+- `$form` - (object) Form
 
 **Usage:**
 ```php 
-add_action('fluentform/subscription_payment_received_paypal', function($subscription, $submission, $vendorData) {
+add_action('fluentform/rendering_payment_method_{$methodName}', function ($paymentMethod, $data, $form){
    // Do your stuff here
-}, 10, 4);
+}, 10, 3);
 ```
 
+**Note:** `{$methodName}` is dynamic method name. Replace `{$methodName}` with Fluent Forms payment methods name.
 
 **Reference**
 
-`do_action('fluentform/subscription_payment_received_paypal', $subscription, $submission, $vendorData);`
+`do_action('fluentform/rendering_payment_method_' . $methodName, $activatedMethod, $data, $form);`
 
-This action is located in `fluentformpro/src/Payments/PaymentMethods/PayPal/API/IPN.php`
+This action is located in `fluentformpro/src/Payments/Components/PaymentMethods.php`, `fluentform/app/Services/FluentConversational/Classes/Converter/Converter.php`
 
 </explain-block>
 
--------------------------------------------
+<explain-block title="fluentform/stripe_customer_created">
+
+**Description**
+
+This action runs after created Stripe customer.
+
+**Parameters**
+- `$data` (array) Customer API response
+- `$customerArgs` (array) Customer Args
+
+**Usage:**
+```php 
+add_action('fluentform/stripe_customer_created', function($data, $customerArgs) {
+   // Do your stuff here
+}, 10, 2);
+```
+
+**Reference**
+
+`do_action('fluentform/stripe_customer_created', $response, $customerArgs);`
+
+This action is located in `fluentformpro/src/Payments/PaymentMethods/Stripe/API/Customer.php`
+
+</explain-block>
+
+<explain-block title="fluentform/subscription_payment_">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- See source
+
+**Usage**
+
+```php
+add_action('fluentform/subscription_payment_', function ($value) {
+    // your code
+}, 10, 1);
+```
+
+**Reference**
+
+`do_action('fluentform/subscription_payment_' . $newStatus, $subscription, $submission, false);`
+
+This action is located in `src/Payments/PaymentMethods/BaseProcessor.php` (line 1191).
+
+</explain-block>
 
 <explain-block title="fluentform/subscription_payment_canceled">
 
@@ -1082,7 +1072,6 @@ add_action('fluentform/subscription_payment_canceled', function($subscription, $
 }, 10, 3);
 ```
 
-
 **Reference**
 
 `do_action('fluentform/subscription_payment_canceled', $subscription, $submission, $vendorData);`
@@ -1090,8 +1079,6 @@ add_action('fluentform/subscription_payment_canceled', function($subscription, $
 This action is located in `fluentformpro/src/Payments/PaymentHelper.php`
 
 </explain-block>
-
--------------------------------------------
 
 <explain-block title="fluentform/subscription_payment_canceled_{$payment_method}">
 
@@ -1113,7 +1100,6 @@ add_action('fluentform/subscription_payment_canceled_{$payment_method}', functio
 
 **Note:** `{$payment_method}` is dynamic value. Replace `{$payment_method}` with valid fluentform payment method name.
 
-
 **Reference**
 
 `do_action('fluentform/subscription_payment_canceled_' . $submission->payment_method, $subscription, $submission, $vendorData);`
@@ -1122,8 +1108,250 @@ This action is located in `fluentformpro/src/Payments/PaymentHelper.php`
 
 </explain-block>
 
+<explain-block title="fluentform/subscription_payment_received">
 
+**Description**
 
+This action runs when PayPal new subscription received.
 
+**Parameters**
+- `$submission` - (object) Submission data
+- `$updatedSubscription` - (array) Subscription updated data
+- `$formId` - (int) Form Id
+- `$subscription` - (object) Subscription data
 
+**Usage:**
+```php 
+add_action('fluentform/subscription_payment_received', function($subscription, $submission, $vendorData) {
+   // Do your stuff here
+}, 10, 4);
+```
 
+**Reference**
+
+`do_action('fluentform/subscription_payment_received', $subscription, $submission, $vendorData);`
+
+This action is located in `fluentformpro/src/Payments/PaymentMethods/PayPal/API/IPN.php`
+
+</explain-block>
+
+<explain-block title="fluentform/subscription_payment_received_paypal">
+
+**Description**
+
+This action runs when PayPal new subscription received.
+
+**Parameters**
+- `$submission` - (object) Submission data
+- `$updatedSubscription` - (array) Subscription updated data
+- `$formId` - (int) Form Id
+- `$subscription` - (object) Subscription data
+
+**Usage:**
+```php 
+add_action('fluentform/subscription_payment_received_paypal', function($subscription, $submission, $vendorData) {
+   // Do your stuff here
+}, 10, 4);
+```
+
+**Reference**
+
+`do_action('fluentform/subscription_payment_received_paypal', $subscription, $submission, $vendorData);`
+
+This action is located in `fluentformpro/src/Payments/PaymentMethods/PayPal/API/IPN.php`
+
+</explain-block>
+
+<explain-block title="fluentform/subscription_received_payment">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$subscription` — see source
+- `$submission` — see source
+
+**Usage**
+
+```php
+add_action('fluentform/subscription_received_payment', function ($subscription, $submission) {
+    // your code
+}, 10, 2);
+```
+
+**Reference**
+
+`do_action('fluentform/subscription_received_payment', $subscription, $submission);`
+
+This action is located in `src/Payments/PaymentMethods/BaseProcessor.php` (line 930).
+
+</explain-block>
+
+<explain-block title="fluentform/subscription_received_payment_">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- See source
+
+**Usage**
+
+```php
+add_action('fluentform/subscription_received_payment_', function ($value) {
+    // your code
+}, 10, 1);
+```
+
+**Reference**
+
+`do_action('fluentform/subscription_received_payment_' . $submission->payment_method, $subscription, $submission);`
+
+This action is located in `src/Payments/PaymentMethods/BaseProcessor.php` (line 942).
+
+</explain-block>
+
+<explain-block title="fluentform/transaction_table_tbody_row">
+
+**Description**
+
+This action runs after render transaction receipt table body td.
+
+**Parameters**
+- `$transaction` (object) Transaction
+- `$transactions` (array) Transactions
+
+**Usage:**
+```php 
+add_action('fluentform/transaction_table_tbody_row', function($transaction, $transactions) {
+   // Do your stuff here
+}, 10, 2);
+```
+
+**Reference**
+
+`do_action('fluentform/transaction_table_tbody_row', $transaction, $transactions);`
+
+This action is located in `fluentformpro/src/views/receipt/transactions_table.php`
+
+</explain-block>
+
+<explain-block title="fluentform/transaction_table_thead_row">
+
+**Description**
+
+This action runs after creating transactions receipt table head (th).
+
+**Parameters**
+- `$transactions` (array) Transactions
+
+**Usage:**
+```php 
+add_action('fluentform/transaction_table_thead_row', function($transactions) {
+   // Do your stuff here
+}, 10, 1);
+```
+
+**Reference**
+
+`do_action('fluentform/transaction_table_thead_row', $transactions);`
+
+This action is located in `fluentformpro/src/views/receipt/transactions_table.php`
+
+</explain-block>
+
+<explain-block title="fluentform/transactions_actions">
+
+**Description**
+
+This action runs when render transaction receipt table body actions.
+
+**Parameters**
+- `$transaction` (object) Transaction
+
+**Usage:**
+```php 
+add_action('fluentform/transactions_actions', function($transaction) {
+   // Do your stuff here
+}, 10, 1);
+```
+
+**Reference**
+
+`do_action('fluentform/transactions_actions', $transaction);`
+
+This action is located in `fluentformpro/src/views/receipt/transactions_table.php`
+
+</explain-block>
+
+<explain-block title="fluentform/transactions_after_table">
+
+**Description**
+
+This action runs after created transaction receipt table.
+
+**Parameters**
+- `$transactions` (array) Transactions
+
+**Usage:**
+```php 
+add_action('fluentform/transactions_after_table', function($transactions) {
+   // Do your stuff here
+}, 10, 1);
+```
+
+**Reference**
+
+`do_action('fluentform/transactions_after_table', $transactions);`
+
+This action is located in `fluentformpro/src/views/receipt/transactions_table.php`
+
+</explain-block>
+
+<explain-block title="fluentform/transactions_before_table">
+
+**Description**
+
+This action runs before creating transactions receipt table.
+
+**Parameters**
+- `$transaction` (array) Transactions
+
+**Usage:**
+```php 
+add_action('fluentform/transactions_before_table', function($transactions) {
+   // Do your stuff here
+}, 10, 1);
+```
+
+**Reference**
+
+`do_action('fluentform/transactions_before_table', $transactions);`
+
+This action is located in `fluentformpro/src/views/receipt/transactions_table.php`
+
+</explain-block>
+
+<explain-block title="fluentform/transactions_before_table_close">
+
+**Description**
+
+This action runs before closing transactions receipt table.
+
+**Parameters**
+- `$transactions` (array) Transactions
+
+**Usage:**
+```php 
+add_action('fluentform/transactions_before_table_close', function($transactions) {
+   // Do your stuff here
+}, 10, 1);
+```
+
+**Reference**
+
+`do_action('fluentform/transactions_before_table_close', $transactions);`
+
+This action is located in `fluentformpro/src/views/receipt/transactions_table.php`
+
+</explain-block>

--- a/src/hooks/actions/plugin-init.md
+++ b/src/hooks/actions/plugin-init.md
@@ -4,6 +4,28 @@
 
 These hooks fire during Fluent Forms plugin initialization and loading.
 
+<explain-block title="fluentform/global_menu">
+
+**Description**
+
+This action runs before rendering the admin menu.
+
+**Usage**
+
+```php
+add_action('fluentform/global_menu', function() {
+   // Do your stuff here
+}, 10, 0);
+```
+
+**Reference**
+
+`do_action('fluentform/global_menu');`
+
+This hook is located in `app/Views/admin/**/*.php`.
+
+</explain-block>
+
 <explain-block title="fluentform/loaded">
 
 **Description**
@@ -30,7 +52,30 @@ This hook is located in fluentform/boot/app.php
 
 </explain-block>
 
-------------------------------------------------
+<explain-block title="fluentform/loading_editor_assets">
+
+**Description**
+
+This action runs during asset loading for the editor. You can hook into this action and load your custom scripts or do other tasks.
+
+**Parameters**
+- `$form` (object) Form
+
+**Usage**
+
+```php
+add_action('fluentform/loading_editor_assets', function($form) {
+   // Do your stuff here
+}, 10, 1);
+```
+
+**Reference**
+
+`do_action('fluentform/loading_editor_assets', $form);`
+
+This hook is located in `fluentform/app/Modules/Registerer/Menu.php`.
+
+</explain-block>
 
 <explain-block title="fluentform/pre_load_scripts">
 
@@ -58,8 +103,6 @@ This hook is located in fluentform/app/Modules/Component/Component.php
 
 </explain-block>
 
-------------------------------------------------
-
 <explain-block title="fluentform/scripts_registered">
 
 **Description**
@@ -79,58 +122,5 @@ add_action('fluentform/scripts_registered', function() {
 `do_action('fluentform/scripts_registered');`
 
 This hook is located in fluentform/app/Modules/Component/Component.php
-
-</explain-block>
-
-
-------------------------------------------------
-
-<explain-block title="fluentform/loading_editor_assets">
-
-**Description**
-
-This action runs during asset loading for the editor. You can hook into this action and load your custom scripts or do other tasks.
-
-**Parameters**
-- `$form` (object) Form
-
-**Usage**
-
-```php
-add_action('fluentform/loading_editor_assets', function($form) {
-   // Do your stuff here
-}, 10, 1);
-```
-
-**Reference**
-
-`do_action('fluentform/loading_editor_assets', $form);`
-
-This hook is located in `fluentform/app/Modules/Registerer/Menu.php`.
-
-</explain-block>
-
-------------------------------------------------
-
-<explain-block title="fluentform/global_menu">
-
-**Description**
-
-This action runs before rendering the admin menu.
-
-
-**Usage**
-
-```php
-add_action('fluentform/global_menu', function() {
-   // Do your stuff here
-}, 10, 0);
-```
-
-**Reference**
-
-`do_action('fluentform/global_menu');`
-
-This hook is located in `app/Views/admin/**/*.php`.
 
 </explain-block>

--- a/src/hooks/actions/post-creation.md
+++ b/src/hooks/actions/post-creation.md
@@ -1,0 +1,57 @@
+# Post Creation Actions
+
+<Badge type="tip" vertical="top" text="Action Hooks" /> <Badge type="warning" vertical="top" text="2 Actions" />
+
+<explain-block title="fluentform/populate_post_form_values">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$form` — see source
+- `$feed` — see source
+- `$postType` — see source
+
+**Usage**
+
+```php
+add_action('fluentform/populate_post_form_values', function ($form, $feed, $postType) {
+    // your code
+}, 10, 3);
+```
+
+**Reference**
+
+`do_action('fluentform/populate_post_form_values', $form, $feed->value, $postType);`
+
+This action is located in `src/Components/Post/PostFormHandler.php` (line 60).
+
+</explain-block>
+
+<explain-block title="fluentform/post_integration_success">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$postId` — see source
+- `$postData` — see source
+- `$entryId` — see source
+- `$form` — see source
+- `$feed` — see source
+
+**Usage**
+
+```php
+add_action('fluentform/post_integration_success', function ($postId, $postData, $entryId, $form, $feed) {
+    // your code
+}, 10, 5);
+```
+
+**Reference**
+
+`do_action('fluentform/post_integration_success', $postId, $postData, $entryId, $form, $feed);`
+
+This action is located in `src/Components/Post/PostFormHandler.php` (line 451).
+
+</explain-block>

--- a/src/hooks/actions/settings.md
+++ b/src/hooks/actions/settings.md
@@ -27,7 +27,115 @@ This action is located in `fluentform/app/Modules/Registerer/AdminBar.php`
 
 </explain-block>
 
-------------------------------------------------
+<explain-block title="fluentform/after_form_settings_app">
+
+**Description**
+
+This action fires after fluentform plugin is loaded.
+
+**Parameters**
+- `$form_id` (int) Form ID
+
+**Usage:**
+```php
+add_action('fluentform/after_form_settings_app', function($form_id) {
+   // Do your stuff when
+}, 10, 1);
+```
+
+**Reference**
+
+`do_action('fluentform/after_form_settings_app', $form_id);`
+
+This action is located in `fluentform/app/Views/admin/form/settings.php`
+
+</explain-block>
+
+<explain-block title="fluentform/after_global_menu">
+
+**Parameters**
+
+- See source
+
+**Usage**
+
+```php
+add_action('fluentform/after_global_menu', function ($value) {
+    // your code
+}, 10, 1);
+```
+
+**Reference**
+
+`do_action('fluentform/after_global_menu');`
+
+This action is located in `app/Views/admin/global_menu.php` (line 116).
+
+</explain-block>
+
+<explain-block title="fluentform/after_global_menu_render">
+
+**Parameters**
+
+- `$page` — see source
+
+**Usage**
+
+```php
+add_action('fluentform/after_global_menu_render', function ($page) {
+    // your code
+}, 10, 1);
+```
+
+**Reference**
+
+`do_action('fluentform/after_global_menu_render',$page);`
+
+This action is located in `app/Views/admin/global_menu.php` (line 187).
+
+</explain-block>
+
+<explain-block title="fluentform/after_global_settings_option_render">
+
+**Description**
+
+This hook is available before rendering the global settings option page. Fore example Custom CSS/JS page.
+
+**Usage:**
+```php
+add_action('fluentform/after_global_settings_option_render', function() {
+   // Do your stuff when
+}, 10, 0);
+```
+
+**Reference**
+
+`do_action('fluentform/after_global_settings_option_render');`
+
+This action is located in `fluentform/app/Views/admin/settings/settings.php`
+
+</explain-block>
+
+<explain-block title="fluentform/after_global_settings_wrapper">
+
+**Description**
+
+After rendering the form settings page this hook is available.
+
+**Usage:**
+```php
+add_action('fluentform/after_global_settings_wrapper', function() {
+   // Do your stuff when
+}, 10, 0);
+```
+
+**Reference**
+
+`do_action('fluentform/after_global_settings_wrapper');`
+
+This action is located in `fluentform/app/Views/admin/settings/index.php`
+
+</explain-block>
 
 <explain-block title="fluentform/after_save_form_settings">
 
@@ -54,53 +162,47 @@ This action is located in `fluentform/app/Services/Settings/SettingsService.php`
 
 </explain-block>
 
-------------------------------------------------
-
-<explain-block title="fluentform/before_global_settings_wrapper">
+<explain-block title="fluentform/after_tools_container">
 
 **Description**
 
-Before rendering the form global settings page this hook is available.
+This action fires after tool settings body render. Do your stuff after tool settings body rendered.
 
 **Usage:**
 ```php
-add_action('fluentform/before_global_settings_wrapper', function() {
-   // Do your stuff when
+add_action('fluentform/after_tools_container', function() {
+   // Do your stuff here
 }, 10, 0);
 ```
 
 **Reference**
 
-`do_action('fluentform/before_global_settings_wrapper');`
+`do_action('fluentform/after_tools_container');`
 
-This action is located in `fluentform/app/Views/admin/settings/index.php`
+This action is located in `fluentform/app/Views/admin/tools/index.php`
 
 </explain-block>
 
-------------------------------------------------
-
-<explain-block title="fluentform/after_global_settings_wrapper">
+<explain-block title="fluentform/after_tools_wrapper">
 
 **Description**
 
-After rendering the form settings page this hook is available.
+This action fires after tool settings render. Do your stuff after tool settings rendered.
 
 **Usage:**
 ```php
-add_action('fluentform/after_global_settings_wrapper', function() {
-   // Do your stuff when
+add_action('fluentform/after_tools_wrapper', function() {
+   // Do your stuff here
 }, 10, 0);
 ```
 
 **Reference**
 
-`do_action('fluentform/after_global_settings_wrapper');`
+`do_action('fluentform/after_tools_wrapper');`
 
-This action is located in `fluentform/app/Views/admin/settings/index.php`
+This action is located in `fluentform/app/Views/admin/tools/index.php`
 
 </explain-block>
-
-------------------------------------------------
 
 <explain-block title="fluentform/before_form_settings_app">
 
@@ -126,35 +228,6 @@ This action is located in `fluentform/app/Views/admin/form/settings.php`
 
 </explain-block>
 
-------------------------------------------------
-
-<explain-block title="fluentform/after_form_settings_app">
-
-**Description**
-
-This action fires after fluentform plugin is loaded.
-
-
-**Parameters**
-- `$form_id` (int) Form ID
-
-**Usage:**
-```php
-add_action('fluentform/after_form_settings_app', function($form_id) {
-   // Do your stuff when
-}, 10, 1);
-```
-
-**Reference**
-
-`do_action('fluentform/after_form_settings_app', $form_id);`
-
-This action is located in `fluentform/app/Views/admin/form/settings.php`
-
-</explain-block>
-
------------------------------------------
-
 <explain-block title="fluentform/before_global_settings_option_render">
 
 **Description**
@@ -176,128 +249,52 @@ This action is located in `fluentform/app/Views/admin/settings/settings.php`
 
 </explain-block>
 
------------------------------------------
-
-<explain-block title="fluentform/after_global_settings_option_render">
+<explain-block title="fluentform/before_global_settings_wrapper">
 
 **Description**
 
-This hook is available before rendering the global settings option page. Fore example Custom CSS/JS page.
+Before rendering the form global settings page this hook is available.
 
 **Usage:**
 ```php
-add_action('fluentform/after_global_settings_option_render', function() {
+add_action('fluentform/before_global_settings_wrapper', function() {
    // Do your stuff when
 }, 10, 0);
 ```
 
 **Reference**
 
-`do_action('fluentform/after_global_settings_option_render');`
-
-This action is located in `fluentform/app/Views/admin/settings/settings.php`
-
-</explain-block>
-
-------------------------------------------
-
-<explain-block title="fluentform/form_settings_container_{$current_route}">
-
-**Description**
-
-This hook runs before rendering the settings page container.
-
-**Parameters**
-- `$form_id` (int) Form ID
-
-**Usage:**
-```php
-add_action('fluentform/form_settings_container_{$current_route}', function($form_id) {
-   // Do your stuff when add fluentform admin menu
-}, 10, 1);
-```
-
-**Note:** `{$current_route}` is a dynamic settings route. Replace `{$current_route}` with Fluent Forms settings route.
-
-**Reference**
-
-`do_action('fluentform/form_settings_container_' . $current_sub_route, $form_id);`
-
-This action is located in `fluentform/app/Views/admin/form/settings_wrapper.php`
-
-</explain-block>
-
-
-<explain-block title="fluentform/global_settings_component_{$current_component}">
-
-**Description**
-
-This action fires on each global settings component. For example reCaptcha
-
-**Usage:**
-```php
-add_action('fluentform/global_settings_component_{$current_component}', function() {
-   // Do your stuff when add fluentform admin menu
-}, 10, 0);
-```
-
-**Note:** `{$current_component}` is a dynamic component name. Replace `{$current_component}` with Fluent Forms component name.
-
-**Reference**
-
-`do_action('fluentform/global_settings_component_' . $currentComponent);`
+`do_action('fluentform/before_global_settings_wrapper');`
 
 This action is located in `fluentform/app/Views/admin/settings/index.php`
 
 </explain-block>
 
-------------------------------------------
+<explain-block title="fluentform/before_partial_entry_admin_email">
 
-<explain-block title="fluentform/before_tools_wrapper">
+<Badge type="tip" vertical="top" text="Pro" />
 
-**Description**
+**Parameters**
 
-This action fires before tool settings render. Do your stuff before tool settings rendered.
+- `$emailFormat` — see source
+- `$entry` — see source
+- `$form` — see source
 
-**Usage:**
+**Usage**
+
 ```php
-add_action('fluentform/before_tools_wrapper', function() {
-   // Do your stuff here
-}, 10, 0);
+add_action('fluentform/before_partial_entry_admin_email', function ($emailFormat, $entry, $form) {
+    // your code
+}, 10, 3);
 ```
 
 **Reference**
 
-`do_action('fluentform/before_tools_wrapper');`
+`do_action('fluentform/before_partial_entry_admin_email', $emailFormat, $entry, $form);`
 
-This action is located in `fluentform/app/Views/admin/tools/index.php`
-
-</explain-block>
-
-------------------------------------------
-
-<explain-block title="fluentform/after_tools_wrapper">
-
-**Description**
-
-This action fires after tool settings render. Do your stuff after tool settings rendered.
-
-**Usage:**
-```php
-add_action('fluentform/after_tools_wrapper', function() {
-   // Do your stuff here
-}, 10, 0);
-```
-
-**Reference**
-
-`do_action('fluentform/after_tools_wrapper');`
-
-This action is located in `fluentform/app/Views/admin/tools/index.php`
+This action is located in `src/classes/DraftSubmissionsManager.php` (line 108).
 
 </explain-block>
-
-------------------------------------------
 
 <explain-block title="fluentform/before_tools_container">
 
@@ -320,80 +317,26 @@ This action is located in `fluentform/app/Views/admin/tools/index.php`
 
 </explain-block>
 
-------------------------------------------
-
-<explain-block title="fluentform/after_tools_container">
+<explain-block title="fluentform/before_tools_wrapper">
 
 **Description**
 
-This action fires after tool settings body render. Do your stuff after tool settings body rendered.
+This action fires before tool settings render. Do your stuff before tool settings rendered.
 
 **Usage:**
 ```php
-add_action('fluentform/after_tools_container', function() {
+add_action('fluentform/before_tools_wrapper', function() {
    // Do your stuff here
 }, 10, 0);
 ```
 
 **Reference**
 
-`do_action('fluentform/after_tools_container');`
+`do_action('fluentform/before_tools_wrapper');`
 
 This action is located in `fluentform/app/Views/admin/tools/index.php`
 
 </explain-block>
-
-
-<explain-block title="fluentform/email_template_after_footer">
-
-**Description**
-
-This action fire after email template footer rendered.
-
-
-**Parameters**
-- `$form` (object) Form Object
-- `$notification` (array) Email Notification
-
-**Usage:**
-```php
-add_action('fluentform/email_template_after_footer', function($form, $notification) {
-   // Do your stuff here
-}, 10, 2);
-```
-
-**Reference**
-
-`do_action( 'fluentform/email_template_after_footer', $form, $notification );`
-
-This action is located in `fluentform/app/Views/email/template/footer.php`
-
-</explain-block>
-
-------------------------------------------
-
-<explain-block title="fluentform/do_scheduled_tasks">
-
-**Description**
-
-This action fire when register schedule task event.
-
-**Usage:**
-```php
-add_action('fluentform/do_scheduled_tasks', function() {
-   // Do your stuff here
-}, 10, 0);
-```
-
-**Reference**
-
-`do_action( 'fluentform/do_scheduled_tasks');`
-
-This action is located in `fluentform/app/Hooks/Handlers/ActivationHandler.php -> setCronSchedule()`, `fluentform/app/Hooks/actions.php`
-
-</explain-block>
-
-------------------------------------------
 
 <explain-block title="fluentform/do_email_report_scheduled_tasks">
 
@@ -416,7 +359,26 @@ This action is located in `fluentform/app/Hooks/Handlers/ActivationHandler.php -
 
 </explain-block>
 
-------------------------------------------
+<explain-block title="fluentform/do_scheduled_tasks">
+
+**Description**
+
+This action fire when register schedule task event.
+
+**Usage:**
+```php
+add_action('fluentform/do_scheduled_tasks', function() {
+   // Do your stuff here
+}, 10, 0);
+```
+
+**Reference**
+
+`do_action( 'fluentform/do_scheduled_tasks');`
+
+This action is located in `fluentform/app/Hooks/Handlers/ActivationHandler.php -> setCronSchedule()`, `fluentform/app/Hooks/actions.php`
+
+</explain-block>
 
 <explain-block title="fluentform/email_summary_details">
 
@@ -450,7 +412,123 @@ This action is located in `fluentform/app/Services/Scheduler/Scheduler.php -> pr
 
 </explain-block>
 
-------------------------------------------
+<explain-block title="fluentform/email_template_after_footer">
+
+**Description**
+
+This action fire after email template footer rendered.
+
+**Parameters**
+- `$form` (object) Form Object
+- `$notification` (array) Email Notification
+
+**Usage:**
+```php
+add_action('fluentform/email_template_after_footer', function($form, $notification) {
+   // Do your stuff here
+}, 10, 2);
+```
+
+**Reference**
+
+`do_action( 'fluentform/email_template_after_footer', $form, $notification );`
+
+This action is located in `fluentform/app/Views/email/template/footer.php`
+
+</explain-block>
+
+<explain-block title="fluentform/form_settings_container_{$current_route}">
+
+**Description**
+
+This hook runs before rendering the settings page container.
+
+**Parameters**
+- `$form_id` (int) Form ID
+
+**Usage:**
+```php
+add_action('fluentform/form_settings_container_{$current_route}', function($form_id) {
+   // Do your stuff when add fluentform admin menu
+}, 10, 1);
+```
+
+**Note:** `{$current_route}` is a dynamic settings route. Replace `{$current_route}` with Fluent Forms settings route.
+
+**Reference**
+
+`do_action('fluentform/form_settings_container_' . $current_sub_route, $form_id);`
+
+This action is located in `fluentform/app/Views/admin/form/settings_wrapper.php`
+
+</explain-block>
+
+<explain-block title="fluentform/global_settings_component_{$current_component}">
+
+**Description**
+
+This action fires on each global settings component. For example reCaptcha
+
+**Usage:**
+```php
+add_action('fluentform/global_settings_component_{$current_component}', function() {
+   // Do your stuff when add fluentform admin menu
+}, 10, 0);
+```
+
+**Note:** `{$current_component}` is a dynamic component name. Replace `{$current_component}` with Fluent Forms component name.
+
+**Reference**
+
+`do_action('fluentform/global_settings_component_' . $currentComponent);`
+
+This action is located in `fluentform/app/Views/admin/settings/index.php`
+
+</explain-block>
+
+<explain-block title="fluentform/global_settings_custom_component">
+
+**Parameters**
+
+- See source
+
+**Usage**
+
+```php
+add_action('fluentform/global_settings_custom_component', function ($value) {
+    // your code
+}, 10, 1);
+```
+
+**Reference**
+
+`<?php do_action('fluentform/global_settings_custom_component'); ?>`
+
+This action is located in `app/Views/admin/globalSettings/menu.php` (line 387).
+
+</explain-block>
+
+<explain-block title="fluentform/loading_settings_assets">
+
+**Parameters**
+
+- `$formId` — see source
+
+**Usage**
+
+```php
+add_action('fluentform/loading_settings_assets', function ($formId) {
+    // your code
+}, 10, 1);
+```
+
+**Reference**
+
+`do_action('fluentform/loading_settings_assets', $formId);`
+
+This action is located in `app/Modules/Registerer/Menu.php` (line 348).
+
+</explain-block>
 
 <explain-block title="fluentform/saving_global_settings_with_key_method">
 

--- a/src/hooks/actions/submission.md
+++ b/src/hooks/actions/submission.md
@@ -4,114 +4,78 @@
 
 These hooks fire during form submission processing — before, during, and after a submission is saved.
 
-<explain-block title="fluentform/before_insert_submission">
+<explain-block title="fluentform/after_deleting_submissions">
 
 **Description**
 
-This action runs before a submission is inserting
+This action runs after deleting a submission.
 
 **Parameters**
-- `$insertData` Insert Model
-- `$data` Form Data
-- `$form` Form Object
+- `$submissionId`  (int)   Submission ID
+- `$formId`     (int)   Form ID
 
 **Usage:**
 ```php
-add_action('fluentform/before_insert_submission', function($insertData, $data, $form) {
-   // Do whatever you want before inserting a submission
-}, 10, 3);
+add_action('fluentform/after_deleting_submissions', function ($submissionIds, $formId){
+   // Do your stuff
+}, 10, 2);
 ```
 
 **Reference**
 
-`do_action('fluentform/before_insert_submission', $insertData, $formDataRaw, $this->form);`
+`do_action('fluentform/after_deleting_submissions', $submissionIds, $formId);`
 
-This action is located in `fluentform/app/Services/Form/SubmissionHandlerService.php`
+This action is located in `fluentform/app/Services/Submission/SubmissionService.php -> deleteEntries()`.
 
 </explain-block>
 
-
-<explain-block title="fluentform/submission_inserted">
-
-**Description**
-
-This action runs after a submission was inserted
+<explain-block title="fluentform/after_submission_status_update">
 
 **Parameters**
-- `$submissionId` Submission ID
-- `$formData` Form Data
-- `$form` Form Object
 
-**Usage:**
+- `$submissionId` — see source
+- `$status` — see source
+
+**Usage**
+
 ```php
-add_action('fluentform/submission_inserted', function($submissionId, $formData, $form) {
-   // Do whatever you want with the new submission
-}, 10, 3);
+add_action('fluentform/after_submission_status_update', function ($submissionId, $status) {
+    // your code
+}, 10, 2);
 ```
 
 **Reference**
 
-`$this->app->doAction('fluentform/submission_inserted', $insertId, $formData, $form);`
+`do_action('fluentform/after_submission_status_update', $submissionId, $status);`
 
-This action is located in `fluentform/app/Services/Form/SubmissionHandlerService.php`
+This action is located in `app/Services/Submission/SubmissionService.php` (line 284).
 
 </explain-block>
 
-------------------------------------------------
-
-<explain-block title="fluentform/before_submission_confirmation">
+<explain-block title="fluentform/before_deleting_entries">
 
 **Description**
 
-This action runs after all the actions are completed regarding the form submission and before the submission confirmation message.
+This action runs before deleting a submission.
 
 **Parameters**
-- `$submissionId` Submission ID
-- `$formData` Form  Data
-- `$form` Form Object
+- `$submissionId`  (int)   Submission ID
+- `$formId`     (int)   Form ID
 
 **Usage:**
 ```php
-add_action('fluentform/before_submission_confirmation', function($submissionId, $formData, $form) {
-   // Do whatever you want here
-}, 10, 3);
+add_action('fluentform/before_deleting_entries', function ($submissionIds, $formId){
+   // Do your stuff
+}, 10, 2);
 ```
 
 **Reference**
 
-`do_action('fluentform/before_submission_confirmation', $insertId, $formData, $form);`
+`do_action('fluentform/before_deleting_entries', $submissionIds, $formId);`
 
-This action is located in `fluentform/app/Services/Form/SubmissionHandlerService.php`
-
-</explain-block>
-
-------------------------------------------------
-
-<explain-block title="fluentform/entry_confirmation">
-
-**Description**
-
-This action runs during the confirmation process of double opt-in. Using this action fluent form confirms the subscription of double optin. You can also use this to run your script during the confirmation process.
-
-**Parameters**
-- `$_REQUEST` (array)  Global PHP Request
-
-**Usage:**
-```php
-add_action('fluentform/entry_confirmation', function($_REQUEST) {
-   // Do whatever you want here
-}, 10);
-```
-
-**Reference**
-
-`do_action('fluentform/entry_confirmation', $_REQUEST);`
-
-This action is located in `fluentformpor/src/classes/SharePage/SharePage.php`
+This action is located in `fluentform/app/Services/Submission/SubmissionService.php -> deleteEntries()`.
 
 </explain-block>
-
-------------------------------------------------
 
 <explain-block title="fluentform/before_form_actions_processing">
 
@@ -139,7 +103,6 @@ This action is located in `fluentform/app/Services/Form/SubmissionHandlerService
 
 </explain-block>
 
-
 <explain-block title="fluentform/before_insert_payment_form">
 
 **Description**
@@ -166,171 +129,81 @@ This action is located in `fluentform/app/Services/Form/SubmissionHandlerService
 
 </explain-block>
 
----------------------------------------------------
-
-<explain-block title="fluentform/submission_inserted_{$form_type}_form">
+<explain-block title="fluentform/before_insert_submission">
 
 **Description**
 
-This action runs after a submission was inserted
+This action runs before a submission is inserting
 
 **Parameters**
-- `$submissionId`  (int)    Submission Id
-- `$formData` (array)  Form Raw Data
-- `$form`     (object) Form Object
+- `$insertData` Insert Model
+- `$data` Form Data
+- `$form` Form Object
 
 **Usage:**
 ```php
-add_action('fluentform/submission_inserted_{$form_type}_form', function ($submissionId, $formData, $form){
-   // Do whatever you want with the new submission base on specifiy form type
+add_action('fluentform/before_insert_submission', function($insertData, $data, $form) {
+   // Do whatever you want before inserting a submission
 }, 10, 3);
 ```
-**Note:** `{$form_type}` is dynamic value. Replace `{$form_type}` with your form type.
 
 **Reference**
 
-`$this->app->doAction('fluentform/submission_inserted', $insertId, $formData, $form);`
+`do_action('fluentform/before_insert_submission', $insertData, $formDataRaw, $this->form);`
 
 This action is located in `fluentform/app/Services/Form/SubmissionHandlerService.php`
 
 </explain-block>
 
-
-<explain-block title="fluentform/notify_on_form_submit">
+<explain-block title="fluentform/before_submission_confirmation">
 
 **Description**
 
-This action runs after a submission was inserted
+This action runs after all the actions are completed regarding the form submission and before the submission confirmation message.
 
 **Parameters**
-- `$submissionId`  (int)    Submission Id
-- `$formData` (array)  Form Raw Data
-- `$form`     (object) Form Object
+- `$submissionId` Submission ID
+- `$formData` Form  Data
+- `$form` Form Object
 
 **Usage:**
 ```php
-add_action('fluentform/notify_on_form_submit', function ($submissionId, $formData, $form){
-   // Do whatever you want with the new submission base on specifiy form type
+add_action('fluentform/before_submission_confirmation', function($submissionId, $formData, $form) {
+   // Do whatever you want here
 }, 10, 3);
 ```
 
 **Reference**
 
-`do_action('fluentform/notify_on_form_submit', $insertId, $this->formData, $this->form);`
+`do_action('fluentform/before_submission_confirmation', $insertId, $formData, $form);`
 
-This action is located in `fluentform/app/Services/Form/SubmissionHandlerService.php`, `fluentfomrpro/src/Payments/Classes/PaymentAction.php`.
+This action is located in `fluentform/app/Services/Form/SubmissionHandlerService.php`
 
 </explain-block>
 
----------------------------------------------------
-
-<explain-block title="fluentform/submission_user_changed">
+<explain-block title="fluentform/entry_confirmation">
 
 **Description**
 
-This action runs after a submission user changed
+This action runs during the confirmation process of double opt-in. Using this action fluent form confirms the subscription of double optin. You can also use this to run your script during the confirmation process.
 
 **Parameters**
-- `$submission`  (object)   Submission
-- `$user`     (object)   User
+- `$_REQUEST` (array)  Global PHP Request
 
 **Usage:**
 ```php
-add_action('fluentform/submission_user_changed', function ($submission, $user){
-   // Do your stuff
-}, 10, 2);
+add_action('fluentform/entry_confirmation', function($_REQUEST) {
+   // Do whatever you want here
+}, 10);
 ```
 
 **Reference**
 
-`do_action('fluentform/submission_user_changed', $submission, $user);`
+`do_action('fluentform/entry_confirmation', $_REQUEST);`
 
-This action is located in `fluentform/app/Services/Submission/SubmissionService.php -> updateSubmissionUser()`.
-
-</explain-block>
-
----------------------------------------------------
-
-<explain-block title="fluentform/before_deleting_entries">
-
-**Description**
-
-This action runs before deleting a submission.
-
-**Parameters**
-- `$submissionId`  (int)   Submission ID
-- `$formId`     (int)   Form ID
-
-**Usage:**
-```php
-add_action('fluentform/before_deleting_entries', function ($submissionIds, $formId){
-   // Do your stuff
-}, 10, 2);
-```
-
-**Reference**
-
-`do_action('fluentform/before_deleting_entries', $submissionIds, $formId);`
-
-This action is located in `fluentform/app/Services/Submission/SubmissionService.php -> deleteEntries()`.
+This action is located in `fluentformpor/src/classes/SharePage/SharePage.php`
 
 </explain-block>
-
----------------------------------------------------
-
-<explain-block title="fluentform/after_deleting_submissions">
-
-**Description**
-
-This action runs after deleting a submission.
-
-**Parameters**
-- `$submissionId`  (int)   Submission ID
-- `$formId`     (int)   Form ID
-
-**Usage:**
-```php
-add_action('fluentform/after_deleting_submissions', function ($submissionIds, $formId){
-   // Do your stuff
-}, 10, 2);
-```
-
-**Reference**
-
-`do_action('fluentform/after_deleting_submissions', $submissionIds, $formId);`
-
-This action is located in `fluentform/app/Services/Submission/SubmissionService.php -> deleteEntries()`.
-
-</explain-block>
-
----------------------------------------------------
-
-<explain-block title="fluentform/submission_note_stored">
-
-**Description**
-
-This action runs after submission note saved.
-
-**Parameters**
-- `$submissionMetaId`  (int)   Submission meta ID
-- `$submissionMeta`     (object)   Submission meta
-
-**Usage:**
-```php
-add_action('fluentform/submission_note_stored', function ($submissionMetaId, $submissionMeta){
-   // Do your stuff
-}, 10, 2);
-```
-
-**Reference**
-
-`do_action('fluentform/submission_note_stored', $submissionMeta->id, $submissionMeta);`
-
-This action is located in `fluentform/app/Services/Submission/SubmissionService.php -> storeNote()`.
-
-</explain-block>
-
----------------------------------------------------
 
 <explain-block title="fluentform/log_data">
 
@@ -369,4 +242,153 @@ This action is added in `fluentform/app/Hooks/actions.php`.
 
 </explain-block>
 
+<explain-block title="fluentform/notify_on_form_submit">
 
+**Description**
+
+This action runs after a submission was inserted
+
+**Parameters**
+- `$submissionId`  (int)    Submission Id
+- `$formData` (array)  Form Raw Data
+- `$form`     (object) Form Object
+
+**Usage:**
+```php
+add_action('fluentform/notify_on_form_submit', function ($submissionId, $formData, $form){
+   // Do whatever you want with the new submission base on specifiy form type
+}, 10, 3);
+```
+
+**Reference**
+
+`do_action('fluentform/notify_on_form_submit', $insertId, $this->formData, $this->form);`
+
+This action is located in `fluentform/app/Services/Form/SubmissionHandlerService.php`, `fluentfomrpro/src/Payments/Classes/PaymentAction.php`.
+
+</explain-block>
+
+<explain-block title="fluentform/submission_deleted">
+
+**Parameters**
+
+- `$submissionId` — see source
+
+**Usage**
+
+```php
+add_action('fluentform/submission_deleted', function ($submissionId) {
+    // your code
+}, 10, 1);
+```
+
+**Reference**
+
+`do_action('fluentform/submission_deleted', $submissionId);`
+
+This action is located in `app/Http/Controllers/SubmissionController.php` (line 115).
+
+</explain-block>
+
+<explain-block title="fluentform/submission_inserted">
+
+**Description**
+
+This action runs after a submission was inserted
+
+**Parameters**
+- `$submissionId` Submission ID
+- `$formData` Form Data
+- `$form` Form Object
+
+**Usage:**
+```php
+add_action('fluentform/submission_inserted', function($submissionId, $formData, $form) {
+   // Do whatever you want with the new submission
+}, 10, 3);
+```
+
+**Reference**
+
+`$this->app->doAction('fluentform/submission_inserted', $insertId, $formData, $form);`
+
+This action is located in `fluentform/app/Services/Form/SubmissionHandlerService.php`
+
+</explain-block>
+
+<explain-block title="fluentform/submission_inserted_{$form_type}_form">
+
+**Description**
+
+This action runs after a submission was inserted
+
+**Parameters**
+- `$submissionId`  (int)    Submission Id
+- `$formData` (array)  Form Raw Data
+- `$form`     (object) Form Object
+
+**Usage:**
+```php
+add_action('fluentform/submission_inserted_{$form_type}_form', function ($submissionId, $formData, $form){
+   // Do whatever you want with the new submission base on specifiy form type
+}, 10, 3);
+```
+**Note:** `{$form_type}` is dynamic value. Replace `{$form_type}` with your form type.
+
+**Reference**
+
+`$this->app->doAction('fluentform/submission_inserted', $insertId, $formData, $form);`
+
+This action is located in `fluentform/app/Services/Form/SubmissionHandlerService.php`
+
+</explain-block>
+
+<explain-block title="fluentform/submission_note_stored">
+
+**Description**
+
+This action runs after submission note saved.
+
+**Parameters**
+- `$submissionMetaId`  (int)   Submission meta ID
+- `$submissionMeta`     (object)   Submission meta
+
+**Usage:**
+```php
+add_action('fluentform/submission_note_stored', function ($submissionMetaId, $submissionMeta){
+   // Do your stuff
+}, 10, 2);
+```
+
+**Reference**
+
+`do_action('fluentform/submission_note_stored', $submissionMeta->id, $submissionMeta);`
+
+This action is located in `fluentform/app/Services/Submission/SubmissionService.php -> storeNote()`.
+
+</explain-block>
+
+<explain-block title="fluentform/submission_user_changed">
+
+**Description**
+
+This action runs after a submission user changed
+
+**Parameters**
+- `$submission`  (object)   Submission
+- `$user`     (object)   User
+
+**Usage:**
+```php
+add_action('fluentform/submission_user_changed', function ($submission, $user){
+   // Do your stuff
+}, 10, 2);
+```
+
+**Reference**
+
+`do_action('fluentform/submission_user_changed', $submission, $user);`
+
+This action is located in `fluentform/app/Services/Submission/SubmissionService.php -> updateSubmissionUser()`.
+
+</explain-block>

--- a/src/hooks/filters/conversational.md
+++ b/src/hooks/filters/conversational.md
@@ -1,0 +1,70 @@
+# Conversational Filters
+
+<Badge type="tip" vertical="top" text="Filter Hooks" /> <Badge type="warning" vertical="top" text="3 Filters" />
+
+<explain-block title="fluentform/conversational_extra_inputs">
+
+**Parameters**
+
+- `$inputs` — see source
+- `$formId` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/conversational_extra_inputs', function ($inputs, $formId) {
+    return $inputs;
+}, 10, 2);
+```
+
+**Reference**
+
+`return apply_filters('fluentform/conversational_extra_inputs', $inputs, $formId);`
+
+This filter is located in `app/Services/FluentConversational/Classes/Form.php` (line 685).
+
+</explain-block>
+
+<explain-block title="fluentform/conversational_field_types">
+
+**Parameters**
+
+- `$fieldTypes` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/conversational_field_types', function ($fieldTypes) {
+    return $fieldTypes;
+}, 10, 1);
+```
+
+**Reference**
+
+`return apply_filters('fluentform/conversational_field_types', $fieldTypes);`
+
+This filter is located in `app/Services/FluentConversational/Classes/Converter/Converter.php` (line 990).
+
+</explain-block>
+
+<explain-block title="fluentform/conversational_form_address_gmap_api_key">
+
+**Parameters**
+
+- `$value` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/conversational_form_address_gmap_api_key', function ($value) {
+    return $value;
+}, 10, 1);
+```
+
+**Reference**
+
+`$question['GmapApiKey'] = apply_filters('fluentform/conversational_form_address_gmap_api_key', '');`
+
+This filter is located in `app/Services/FluentConversational/Classes/Converter/Converter.php` (line 137).
+
+</explain-block>

--- a/src/hooks/filters/dynamic-fields.md
+++ b/src/hooks/filters/dynamic-fields.md
@@ -1,0 +1,219 @@
+# Dynamic Fields Filters
+
+<Badge type="tip" vertical="top" text="Filter Hooks" /> <Badge type="warning" vertical="top" text="9 Filters" />
+
+<explain-block title="fluentform/chat_field_before_render">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$data` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/chat_field_before_render', function ($data, $form) {
+    return $data;
+}, 10, 2);
+```
+
+**Reference**
+
+`return apply_filters('fluentform/chat_field_before_render', $data, $form);`
+
+This filter is located in `src/classes/Chat/ChatField.php` (line 239).
+
+</explain-block>
+
+<explain-block title="fluentform/chat_field_send_icon">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$sendSvgIcon` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/chat_field_send_icon', function ($sendSvgIcon) {
+    return $sendSvgIcon;
+}, 10, 1);
+```
+
+**Reference**
+
+`$chatSvgIcon = apply_filters('fluentform/chat_field_send_icon', $sendSvgIcon);`
+
+This filter is located in `src/classes/Chat/ChatField.php` (line 211).
+
+</explain-block>
+
+<explain-block title="fluentform/chat_gpt_waiting_message">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$value` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/chat_gpt_waiting_message', function ($value, $form) {
+    return $value;
+}, 10, 2);
+```
+
+**Reference**
+
+`$message = apply_filters('fluentform/chat_gpt_waiting_message','', $form);`
+
+This filter is located in `src/classes/Chat/ChatFieldController.php` (line 113).
+
+</explain-block>
+
+<explain-block title="fluentform/dynamic_field_filter_default_config">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- See source
+
+**Usage**
+
+```php
+add_filter('fluentform/dynamic_field_filter_default_config', function ($value) {
+    return $value;
+}, 10, 1);
+```
+
+**Reference**
+
+`$defaultConfig = apply_filters('fluentform/dynamic_field_filter_default_config' . $source, []);`
+
+This filter is located in `src/Components/DynamicField/DynamicField.php` (line 322).
+
+</explain-block>
+
+<explain-block title="fluentform/dynamic_field_filter_fields">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$fields` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/dynamic_field_filter_fields', function ($fields) {
+    return $fields;
+}, 10, 1);
+```
+
+**Reference**
+
+`return apply_filters("fluentform/dynamic_field_filter_fields", $fields);`
+
+This filter is located in `src/Components/DynamicField/DynamicField.php` (line 731).
+
+</explain-block>
+
+<explain-block title="fluentform/dynamic_field_filter_get_result">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- See source
+
+**Usage**
+
+```php
+add_filter('fluentform/dynamic_field_filter_get_result', function ($value) {
+    return $value;
+}, 10, 1);
+```
+
+**Reference**
+
+`return apply_filters('fluentform/dynamic_field_filter_get_result' . $source, [], $config);`
+
+This filter is located in `src/Components/DynamicField/DynamicField.php` (line 412).
+
+</explain-block>
+
+<explain-block title="fluentform/dynamic_field_filter_value_options">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- See source
+
+**Usage**
+
+```php
+add_filter('fluentform/dynamic_field_filter_value_options', function ($value) {
+    return $value;
+}, 10, 1);
+```
+
+**Reference**
+
+`$options = apply_filters('fluentform/dynamic_field_filter_value_options' . $source, []);`
+
+This filter is located in `src/Components/DynamicField/DynamicField.php` (line 321).
+
+</explain-block>
+
+<explain-block title="fluentform/dynamic_field_re_fetch_result_and_resolve_value">
+
+**Parameters**
+
+- `$field` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/dynamic_field_re_fetch_result_and_resolve_value', function ($field) {
+    return $field;
+}, 10, 1);
+```
+
+**Reference**
+
+`$field = apply_filters('fluentform/dynamic_field_re_fetch_result_and_resolve_value', $field);`
+
+This filter is located in `app/Hooks/filters.php` (line 176).
+
+</explain-block>
+
+<explain-block title="fluentform/dynamic_field_sources">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$sources` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/dynamic_field_sources', function ($sources) {
+    return $sources;
+}, 10, 1);
+```
+
+**Reference**
+
+`return apply_filters('fluentform/dynamic_field_sources', $sources);`
+
+This filter is located in `src/Components/DynamicField/DynamicField.php` (line 303).
+
+</explain-block>

--- a/src/hooks/filters/email.md
+++ b/src/hooks/filters/email.md
@@ -4,30 +4,294 @@
 
 These filters let you modify email notifications, templates, headers, and delivery settings.
 
-<explain-block title="fluentform/email_summary_config">
+<explain-block title="fluentform/email_attachments">
 
-You can use this filter to modify email summary configuration.
+You can modify email attachments by using this filter.
 
 **Parameters**
 
-- `$config` (array) Email Summary Configuration
+- `$attachments` (array) Email Attachment
+- `$processedValues` (array) Shortcode Parsed Value
+- `$formData` (array) Form Data
+- `$entry` (array) Submission Data
+- `$form` (object) Form Object
 
 **Usage**
 
 ```php
-add_filter('fluentform/email_summary_config', function ($config) {
+add_filter('fluentform/email_attachments', function ($attachments, $processedValues, $formData, $entry, $form) {
     // Do your stuff here
     
-    return $config;
+    return $attachments;
+}, 10, 5);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/email_attachments', $attachments, $processedValues, $formData, $entry, $form);`
+
+This filter is located in FluentFormPro\src\classes\ResendNotificationHandler -> resendEntryEmail($entryId, $feed, $sendToType, $customRecipient, $form)
+
+</explain-block>
+
+<explain-block title="fluentform/email_body">
+
+You can hook into this filter and modify the email body.
+
+**Parameters**
+
+- `$emailBody` (string) Email Body
+- `$notification` (array) Notification Data
+- `$submittedData` (array) Submitted Data
+- `$form` (object) Form Object
+
+**Usage**
+
+```php
+add_filter('fluentform/email_body', function ($emailBody, $notification, $submittedData, $form) {
+    // Do your stuff here
+
+    return $emailBody;
+}, 10, 4);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/email_body', $emailBody, $notification, $submittedData, $form);`
+
+This filter is located in FluentForm\app\Services\FormBuilder\Notifications\EmailNotifications -> notify($notification, $submittedData, $form, $entryId = false)
+
+</explain-block>
+
+<explain-block title="fluentform/email_content_type_header">
+
+You can use this filter to add email content type to header.
+
+**Parameters**
+
+- `$contentType` (string) Email Header Content Type By Default, text/html; charset=UTF-8
+
+**Usage**
+
+```php
+add_filter('fluentform/email_content_type_header', function ($contentType) {
+    // Do your stuff here
+    
+    return $contentType;
 }, 10, 1);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/email_summary_config', $config);`
+`apply_filters('fluentform/email_content_type_header', false, $form, $notification);`
 
-This filter is located in FluentForm\App\Services\Scheduler\Scheduler -> processEmailReport()
+This filter is located in FluentForm\app\views\email\template\header.php
+
+</explain-block>
+
+<explain-block title="fluentform/email_footer">
+
+You can hook into this filter and modify the email footer.
+
+**Parameters**
+
+- `$emailFooter` (string) Email Footer
+- `$form` (object) Form Object
+- `$notification` (array) Notification Data
+
+**Usage**
+
+```php
+add_filter('fluentform/email_footer', function ($emailFooter, $form, $notification) {
+    // Do your stuff here
+
+    return $emailFooter;
+}, 10, 3);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/email_footer', $emailFooter, $form, $notification);`
+
+This filter is located in FluentForm\app\Services\FormBuilder\Notifications\EmailNotifications -> getEmailWithTemplate($emailBody, $form, $notification)
+
+</explain-block>
+
+<explain-block title="fluentform/email_form_resume_link_config">
+
+You can change form resume link for partial submission of forms by using this filter.
+
+**Parameters**
+
+- `$emailFormat` (array) Email Format
+- `$submittedData` (array) Partial Submitted Data
+- `$requestData` (array) Request Data
+- `$form` (object) Form
+
+**Usage**
+
+```php
+add_filter('fluentform/email_form_resume_link_config', function ($emailFormat, $submittedData, $requestData, $form) {
+    // Do your stuff here
+    
+    return $emailFormat;
+}, 10, 4);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/email_form_resume_link_config', $emailFormat, $submittedData, $requestData, $form));`
+
+This filter is located in FluentFormPro\src\classes\DraftSubmissionsManager -> emailProgressLink()
+
+</explain-block>
+
+<explain-block title="fluentform/email_header">
+
+You can hook into this filter and modify the email header.
+
+**Parameters**
+
+- `$emailHeader` (string) Email Header
+- `$form` (object) Form Object
+- `$notification` (array) Notification Data
+
+**Usage**
+
+```php
+add_filter('fluentform/email_header', function ($emailHeader, $form, $notification) {
+    // Do your stuff here
+
+    return $emailHeader;
+}, 10, 3);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/email_header', $emailHeader, $form, $notification);`
+
+This filter is located in FluentForm\app\Services\FormBuilder\Notifications\EmailNotifications -> getEmailWithTemplate($emailBody, $form, $notification)
+
+</explain-block>
+
+<explain-block title="fluentform/email_resume_link_body">
+
+You can modify email body of resume link for partial submission by using this filter.
+
+**Parameters**
+
+- `$emailBody` (string) Email Body
+- `$form` (object) Form Object
+- `$link` (string) Email Resume Link
+
+**Usage**
+
+```php
+add_filter('fluentform/email_resume_link_body', function ($emailBody, $form, $link) {
+    // Do your stuff here
+    
+    return $emailBody;
+}, 10, 3);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/email_resume_link_body', $emailBody, $form, $link);`
+
+This filter is located in FluentFormPro\src\classes\DraftSubmissionsManager -> processEmail($settings, $form, $link, $toEmail)
+
+</explain-block>
+
+<explain-block title="fluentform/email_resume_link_response">
+
+You can modify email resume link confirmation message by using this filter.
+
+**Parameters**
+
+- `$message` (string) Email Confirmation Message
+
+**Usage**
+
+```php
+add_filter('fluentform/email_resume_link_response', function ($message) {
+    // Do your stuff here
+    
+    return $message;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/email_resume_link_response', $message);`
+
+This filter is located in FluentFormPro\src\classes\DraftSubmissionsManager -> emailProgressLink()
+
+</explain-block>
+
+<explain-block title="fluentform/email_styles">
+
+You can hook into this filter and modify the email styles using css.
+
+**Parameters**
+
+- `$css` (string) Styles for the email
+- `$form` (object) Form Object
+- `$notification` (array) Notification Data
+
+**Usage**
+
+```php
+add_filter('fluentform/email_styles', function ($css, $form, $notification) {
+    // Do your stuff here
+
+    return $css;
+}, 10, 3);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/email_styles', $css, $form, $notification);`
+
+This filter is located in FluentForm\app\Services\FormBuilder\Notifications\EmailNotifications -> getEmailWithTemplate($emailBody, $form, $notification)
+
+</explain-block>
+
+<explain-block title="fluentform/email_subject">
+
+You can hook into this filter and modify the email subject.
+
+**Parameters**
+
+- `$subject` (string) Email Subject
+- `$notification` (array) Notification Data
+- `$submittedData` (array) Submitted Data
+- `$form` (object) Form Object
+
+**Usage**
+
+```php
+add_filter('fluentform/email_subject', function ($subject, $notification, $submittedData, $form) {
+    // Do your stuff here
+
+    return $subject;
+}, 10, 4);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/email_subject', $notification['subject'], $notification, $submittedData, $form);`
+
+This filter is located in FluentForm\app\Services\FormBuilder\Notifications\EmailNotifications -> notify($notification, $submittedData, $form, $entryId = false)
 
 </explain-block>
 
@@ -54,33 +318,6 @@ add_filter('fluentform/email_summary_body', function ($emailBody, $data) {
 **Reference**
 
 `apply_filters('fluentform/email_summary_body', $emailBody, $data);`
-
-This filter is located in FluentForm\App\Services\Scheduler\Scheduler -> processEmailReport()
-
-</explain-block>
-
-<explain-block title="fluentform/email_summary_subject">
-
-You can use this filter to modify email subject.
-
-**Parameters**
-
-- `$emailSubject` (string) Email Subject
-
-**Usage**
-
-```php
-add_filter('fluentform/email_summary_subject', function ($$emailSubject) {
-    // Do your stuff here
-    
-    return $emailSubject;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/email_summary_subject', $emailSubject);`
 
 This filter is located in FluentForm\App\Services\Scheduler\Scheduler -> processEmailReport()
 
@@ -114,6 +351,33 @@ This filter is located in FluentForm\app\views\email\report\body.php
 
 </explain-block>
 
+<explain-block title="fluentform/email_summary_config">
+
+You can use this filter to modify email summary configuration.
+
+**Parameters**
+
+- `$config` (array) Email Summary Configuration
+
+**Usage**
+
+```php
+add_filter('fluentform/email_summary_config', function ($config) {
+    // Do your stuff here
+    
+    return $config;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/email_summary_config', $config);`
+
+This filter is located in FluentForm\App\Services\Scheduler\Scheduler -> processEmailReport()
+
+</explain-block>
+
 <explain-block title="fluentform/email_summary_footer_text">
 
 You can use this filter to modify email summary footer.
@@ -141,117 +405,30 @@ This filter is located in FluentForm\app\views\email\report\body.php
 
 </explain-block>
 
-<explain-block title="fluentform/email_template_footer_credit">
+<explain-block title="fluentform/email_summary_subject">
 
-You can use this filter to modify email template footer credit text.
+You can use this filter to modify email subject.
 
 **Parameters**
 
-- `$poweredBy` (string) Credit Text By Default Powered by FluentForm
-- `$form` (object) Form Object
-- `$notification` (array) Email Notification
+- `$emailSubject` (string) Email Subject
 
 **Usage**
 
 ```php
-add_filter('fluentform/email_template_footer_credit', function ($poweredBy, $form, $notification) {
+add_filter('fluentform/email_summary_subject', function ($$emailSubject) {
     // Do your stuff here
     
-    return $footerText;
+    return $emailSubject;
 }, 10, 1);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/email_template_footer_credit', $poweredBy, $form, $notification);`
+`apply_filters('fluentform/email_summary_subject', $emailSubject);`
 
-This filter is located in FluentForm\app\views\email\template\footer.php
-
-</explain-block>
-
-<explain-block title="fluentform/email_template_email_heading">
-
-You can use this filter to toggle email template header.
-
-**Parameters**
-
-- `$status` (boolean) Whether the email heading is enabled
-- `$form` (object) Form Object
-- `$notification` (array) Email Notification
-
-**Usage**
-
-```php
-add_filter('fluentform/email_template_email_heading', function ($status, $form, $notification) {
-    // Do your stuff here
-    
-    return $status;
-}, 10, 3);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/email_template_email_heading', false, $form, $notification);`
-
-This filter is located in FluentForm\app\views\email\template\header.php
-
-</explain-block>
-
-<explain-block title="fluentform/email_template_header_image">
-
-You can use this filter to toggle email header image.
-
-**Parameters**
-
-- `$status` (boolean) Whether the email header image is enabled
-- `$form` (object) Form Object
-- `$notification` (array) Email Notification
-
-**Usage**
-
-```php
-add_filter('fluentform/email_template_header_image', function ($status, $form, $notification) {
-    // Do your stuff here
-    
-    return $status;
-}, 10, 3);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/email_template_header_image', false, $form, $notification);`
-
-This filter is located in FluentForm\app\views\email\template\header.php
-
-</explain-block>
-
-<explain-block title="fluentform/email_content_type_header">
-
-You can use this filter to add email content type to header.
-
-**Parameters**
-
-- `$contentType` (string) Email Header Content Type By Default, text/html; charset=UTF-8
-
-**Usage**
-
-```php
-add_filter('fluentform/email_content_type_header', function ($contentType) {
-    // Do your stuff here
-    
-    return $contentType;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/email_content_type_header', false, $form, $notification);`
-
-This filter is located in FluentForm\app\views\email\template\header.php
+This filter is located in FluentForm\App\Services\Scheduler\Scheduler -> processEmailReport()
 
 </explain-block>
 
@@ -291,89 +468,177 @@ This filter is located in FluentForm\app\views\email\template\styles.php
 
 </explain-block>
 
-<explain-block title="fluentform/email_form_resume_link_config">
+<explain-block title="fluentform/email_template_email_heading">
 
-You can change form resume link for partial submission of forms by using this filter.
-
-**Parameters**
-
-- `$emailFormat` (array) Email Format
-- `$submittedData` (array) Partial Submitted Data
-- `$requestData` (array) Request Data
-- `$form` (object) Form
-
-**Usage**
-
-```php
-add_filter('fluentform/email_form_resume_link_config', function ($emailFormat, $submittedData, $requestData, $form) {
-    // Do your stuff here
-    
-    return $emailFormat;
-}, 10, 4);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/email_form_resume_link_config', $emailFormat, $submittedData, $requestData, $form));`
-
-This filter is located in FluentFormPro\src\classes\DraftSubmissionsManager -> emailProgressLink()
-
-</explain-block>
-
-<explain-block title="fluentform/email_resume_link_response">
-
-You can modify email resume link confirmation message by using this filter.
+You can use this filter to toggle email template header.
 
 **Parameters**
 
-- `$message` (string) Email Confirmation Message
-
-**Usage**
-
-```php
-add_filter('fluentform/email_resume_link_response', function ($message) {
-    // Do your stuff here
-    
-    return $message;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/email_resume_link_response', $message);`
-
-This filter is located in FluentFormPro\src\classes\DraftSubmissionsManager -> emailProgressLink()
-
-</explain-block>
-
-<explain-block title="fluentform/email_resume_link_body">
-
-You can modify email body of resume link for partial submission by using this filter.
-
-**Parameters**
-
-- `$emailBody` (string) Email Body
+- `$status` (boolean) Whether the email heading is enabled
 - `$form` (object) Form Object
-- `$link` (string) Email Resume Link
+- `$notification` (array) Email Notification
 
 **Usage**
 
 ```php
-add_filter('fluentform/email_resume_link_body', function ($emailBody, $form, $link) {
+add_filter('fluentform/email_template_email_heading', function ($status, $form, $notification) {
     // Do your stuff here
     
-    return $emailBody;
+    return $status;
 }, 10, 3);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/email_resume_link_body', $emailBody, $form, $link);`
+`apply_filters('fluentform/email_template_email_heading', false, $form, $notification);`
 
-This filter is located in FluentFormPro\src\classes\DraftSubmissionsManager -> processEmail($settings, $form, $link, $toEmail)
+This filter is located in FluentForm\app\views\email\template\header.php
+
+</explain-block>
+
+<explain-block title="fluentform/email_template_footer_credit">
+
+You can use this filter to modify email template footer credit text.
+
+**Parameters**
+
+- `$poweredBy` (string) Credit Text By Default Powered by FluentForm
+- `$form` (object) Form Object
+- `$notification` (array) Email Notification
+
+**Usage**
+
+```php
+add_filter('fluentform/email_template_footer_credit', function ($poweredBy, $form, $notification) {
+    // Do your stuff here
+    
+    return $footerText;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/email_template_footer_credit', $poweredBy, $form, $notification);`
+
+This filter is located in FluentForm\app\views\email\template\footer.php
+
+</explain-block>
+
+<explain-block title="fluentform/email_template_footer_text">
+
+You can hook into this filter and modify the email template footer text.
+
+**Parameters**
+
+- `$footerText` (string) Email Template Footer Text
+- `$form` (object) Form Object
+- `$notification` (array) Notification Data
+
+**Usage**
+
+```php
+add_filter('fluentform/email_template_footer_text', function ($footerText, $form, $notification) {
+    // Do your stuff here
+
+    return $footerText;
+}, 10, 3);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/email_template_footer_text', $footerText, $form, $notification);`
+
+This filter is located in FluentForm\app\Services\FormBuilder\Notifications\EmailNotifications -> getFooterText($form, $notification)
+
+</explain-block>
+
+<explain-block title="fluentform/email_template_header">
+
+You can hook into this filter and modify the email template header array.
+
+**Parameters**
+
+- `$headers` (array) Email Template Header Data
+- `$notification` (array) Notification Data
+
+**Usage**
+
+```php
+add_filter('fluentform/email_template_header', function ($headers, $notification) {
+    // Do your stuff here
+
+    return $headers;
+}, 10, 2);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/email_template_header', $headers, $notification);`
+
+This filter is located in FluentForm\app\Services\FormBuilder\Notifications\EmailNotifications -> getHeaders($notification, $isSendAsPlain = false)
+
+</explain-block>
+
+<explain-block title="fluentform/email_template_header_image">
+
+You can use this filter to toggle email header image.
+
+**Parameters**
+
+- `$status` (boolean) Whether the email header image is enabled
+- `$form` (object) Form Object
+- `$notification` (array) Email Notification
+
+**Usage**
+
+```php
+add_filter('fluentform/email_template_header_image', function ($status, $form, $notification) {
+    // Do your stuff here
+    
+    return $status;
+}, 10, 3);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/email_template_header_image', false, $form, $notification);`
+
+This filter is located in FluentForm\app\views\email\template\header.php
+
+</explain-block>
+
+<explain-block title="fluentform/email_to">
+
+This filter returns the destination email for emails. Multiple emails can be added by (,) comma separator.
+
+**Parameters**
+
+- `$address` (string) Email Address
+- `$notification` (array) Notification Data
+- `$submittedData` (array) Submitted Data
+- `$form` (object) Form Object
+
+**Usage**
+
+```php
+add_filter('fluentform/email_to', function ($address, $notification, $submittedData, $form) {
+    // Do your stuff here
+
+    return $address;
+}, 10, 4);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/email_to', $address, $notification, $submittedData, $form);`
+
+This filter is located in FluentForm\app\Services\FormBuilder\Notifications\EmailNotifications -> notify($notification, $submittedData, $form, $entryId = false)
 
 </explain-block>
 
@@ -404,62 +669,31 @@ This filter is located in FluentFormPro\src\classes\FailedIntegrationNotificatio
 
 </explain-block>
 
-<explain-block title="fluentform/email_attachments">
+<explain-block title="fluentform/filter_email_attachments">
 
-You can modify email attachments by using this filter.
-
-**Parameters**
-
-- `$attachments` (array) Email Attachment
-- `$processedValues` (array) Shortcode Parsed Value
-- `$formData` (array) Form Data
-- `$entry` (array) Submission Data
-- `$form` (object) Form Object
-
-**Usage**
-
-```php
-add_filter('fluentform/email_attachments', function ($attachments, $processedValues, $formData, $entry, $form) {
-    // Do your stuff here
-    
-    return $attachments;
-}, 10, 5);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/email_attachments', $attachments, $processedValues, $formData, $entry, $form);`
-
-This filter is located in FluentFormPro\src\classes\ResendNotificationHandler -> resendEntryEmail($entryId, $feed, $sendToType, $customRecipient, $form)
-
-</explain-block>
-
-<explain-block title="fluentform/email_to">
-
-This filter returns the destination email for emails. Multiple emails can be added by (,) comma separator.
+You can hook into this filter and modify the email attachments.
 
 **Parameters**
 
-- `$address` (string) Email Address
+- `$notificationAttachments` (string) Email Attachments
 - `$notification` (array) Notification Data
-- `$submittedData` (array) Submitted Data
 - `$form` (object) Form Object
+- `$submittedData` (array) Submitted Data
 
 **Usage**
 
 ```php
-add_filter('fluentform/email_to', function ($address, $notification, $submittedData, $form) {
+add_filter('fluentform/filter_email_attachments', function ($notificationAttachments, $notification, $form, $submittedData) {
     // Do your stuff here
 
-    return $address;
+    return $notificationAttachments;
 }, 10, 4);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/email_to', $address, $notification, $submittedData, $form);`
+`apply_filters('fluentform/filter_email_attachments', $notificationAttachments, $notification, $form, $submittedData);`
 
 This filter is located in FluentForm\app\Services\FormBuilder\Notifications\EmailNotifications -> notify($notification, $submittedData, $form, $entryId = false)
 
@@ -521,239 +755,5 @@ add_filter('fluentform/submission_message_parse', function ($emailBody, $entryId
 `apply_filters('fluentform/submission_message_parse', $emailBody, $entryId, $submittedData, $form);`
 
 This filter is located in FluentForm\app\Services\FormBuilder\Notifications\EmailNotifications -> notify($notification, $submittedData, $form, $entryId = false)
-
-</explain-block>
-
-<explain-block title="fluentform/email_subject">
-
-You can hook into this filter and modify the email subject.
-
-**Parameters**
-
-- `$subject` (string) Email Subject
-- `$notification` (array) Notification Data
-- `$submittedData` (array) Submitted Data
-- `$form` (object) Form Object
-
-**Usage**
-
-```php
-add_filter('fluentform/email_subject', function ($subject, $notification, $submittedData, $form) {
-    // Do your stuff here
-
-    return $subject;
-}, 10, 4);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/email_subject', $notification['subject'], $notification, $submittedData, $form);`
-
-This filter is located in FluentForm\app\Services\FormBuilder\Notifications\EmailNotifications -> notify($notification, $submittedData, $form, $entryId = false)
-
-</explain-block>
-
-<explain-block title="fluentform/filter_email_attachments">
-
-You can hook into this filter and modify the email attachments.
-
-**Parameters**
-
-- `$notificationAttachments` (string) Email Attachments
-- `$notification` (array) Notification Data
-- `$form` (object) Form Object
-- `$submittedData` (array) Submitted Data
-
-**Usage**
-
-```php
-add_filter('fluentform/filter_email_attachments', function ($notificationAttachments, $notification, $form, $submittedData) {
-    // Do your stuff here
-
-    return $notificationAttachments;
-}, 10, 4);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/filter_email_attachments', $notificationAttachments, $notification, $form, $submittedData);`
-
-This filter is located in FluentForm\app\Services\FormBuilder\Notifications\EmailNotifications -> notify($notification, $submittedData, $form, $entryId = false)
-
-</explain-block>
-
-<explain-block title="fluentform/email_body">
-
-You can hook into this filter and modify the email body.
-
-**Parameters**
-
-- `$emailBody` (string) Email Body
-- `$notification` (array) Notification Data
-- `$submittedData` (array) Submitted Data
-- `$form` (object) Form Object
-
-**Usage**
-
-```php
-add_filter('fluentform/email_body', function ($emailBody, $notification, $submittedData, $form) {
-    // Do your stuff here
-
-    return $emailBody;
-}, 10, 4);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/email_body', $emailBody, $notification, $submittedData, $form);`
-
-This filter is located in FluentForm\app\Services\FormBuilder\Notifications\EmailNotifications -> notify($notification, $submittedData, $form, $entryId = false)
-
-</explain-block>
-
-<explain-block title="fluentform/email_header">
-
-You can hook into this filter and modify the email header.
-
-**Parameters**
-
-- `$emailHeader` (string) Email Header
-- `$form` (object) Form Object
-- `$notification` (array) Notification Data
-
-**Usage**
-
-```php
-add_filter('fluentform/email_header', function ($emailHeader, $form, $notification) {
-    // Do your stuff here
-
-    return $emailHeader;
-}, 10, 3);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/email_header', $emailHeader, $form, $notification);`
-
-This filter is located in FluentForm\app\Services\FormBuilder\Notifications\EmailNotifications -> getEmailWithTemplate($emailBody, $form, $notification)
-
-</explain-block>
-
-<explain-block title="fluentform/email_footer">
-
-You can hook into this filter and modify the email footer.
-
-**Parameters**
-
-- `$emailFooter` (string) Email Footer
-- `$form` (object) Form Object
-- `$notification` (array) Notification Data
-
-**Usage**
-
-```php
-add_filter('fluentform/email_footer', function ($emailFooter, $form, $notification) {
-    // Do your stuff here
-
-    return $emailFooter;
-}, 10, 3);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/email_footer', $emailFooter, $form, $notification);`
-
-This filter is located in FluentForm\app\Services\FormBuilder\Notifications\EmailNotifications -> getEmailWithTemplate($emailBody, $form, $notification)
-
-</explain-block>
-
-<explain-block title="fluentform/email_styles">
-
-You can hook into this filter and modify the email styles using css.
-
-**Parameters**
-
-- `$css` (string) Styles for the email
-- `$form` (object) Form Object
-- `$notification` (array) Notification Data
-
-**Usage**
-
-```php
-add_filter('fluentform/email_styles', function ($css, $form, $notification) {
-    // Do your stuff here
-
-    return $css;
-}, 10, 3);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/email_styles', $css, $form, $notification);`
-
-This filter is located in FluentForm\app\Services\FormBuilder\Notifications\EmailNotifications -> getEmailWithTemplate($emailBody, $form, $notification)
-
-</explain-block>
-
-<explain-block title="fluentform/email_template_footer_text">
-
-You can hook into this filter and modify the email template footer text.
-
-**Parameters**
-
-- `$footerText` (string) Email Template Footer Text
-- `$form` (object) Form Object
-- `$notification` (array) Notification Data
-
-**Usage**
-
-```php
-add_filter('fluentform/email_template_footer_text', function ($footerText, $form, $notification) {
-    // Do your stuff here
-
-    return $footerText;
-}, 10, 3);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/email_template_footer_text', $footerText, $form, $notification);`
-
-This filter is located in FluentForm\app\Services\FormBuilder\Notifications\EmailNotifications -> getFooterText($form, $notification)
-
-</explain-block>
-
-<explain-block title="fluentform/email_template_header">
-
-You can hook into this filter and modify the email template header array.
-
-**Parameters**
-
-- `$headers` (array) Email Template Header Data
-- `$notification` (array) Notification Data
-
-**Usage**
-
-```php
-add_filter('fluentform/email_template_header', function ($headers, $notification) {
-    // Do your stuff here
-
-    return $headers;
-}, 10, 2);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/email_template_header', $headers, $notification);`
-
-This filter is located in FluentForm\app\Services\FormBuilder\Notifications\EmailNotifications -> getHeaders($notification, $isSendAsPlain = false)
 
 </explain-block>

--- a/src/hooks/filters/entries-export.md
+++ b/src/hooks/filters/entries-export.md
@@ -1,0 +1,353 @@
+# Entries Export Filters
+
+<Badge type="tip" vertical="top" text="Filter Hooks" /> <Badge type="warning" vertical="top" text="15 Filters" />
+
+<explain-block title="fluentform/apply_entries_advance_filter">
+
+**Parameters**
+
+- `$query` — see source
+- `$attributes` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/apply_entries_advance_filter', function ($query, $attributes) {
+    return $query;
+}, 10, 2);
+```
+
+**Reference**
+
+`$query = apply_filters('fluentform/apply_entries_advance_filter', $query, $attributes);`
+
+This filter is located in `app/Models/Submission.php` (line 218).
+
+</explain-block>
+
+<explain-block title="fluentform/bulk_entries_print_start_on_new_page">
+
+**Parameters**
+
+- `$value` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/bulk_entries_print_start_on_new_page', function ($value) {
+    return $value;
+}, 10, 1);
+```
+
+**Reference**
+
+`if ($index !== 0 && apply_filters('fluentform/bulk_entries_print_start_on_new_page', __return_true(),`
+
+This filter is located in `app/Services/Submission/SubmissionPrint.php` (line 42).
+
+</explain-block>
+
+<explain-block title="fluentform/csv_sanitize_formulas">
+
+**Parameters**
+
+- `$formulas` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/csv_sanitize_formulas', function ($formulas) {
+    return $formulas;
+}, 10, 1);
+```
+
+**Reference**
+
+`$formulas = apply_filters('fluentform/csv_sanitize_formulas', $formulas);`
+
+This filter is located in `app/Helpers/Helper.php` (line 946).
+
+</explain-block>
+
+<explain-block title="fluentform/entries_human_date">
+
+**Parameters**
+
+- `$value` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/entries_human_date', function ($value) {
+    return $value;
+}, 10, 1);
+```
+
+**Reference**
+
+`$useHumanDate = apply_filters('fluentform/entries_human_date', false);`
+
+This filter is located in `app/Models/Submission.php` (line 372).
+
+</explain-block>
+
+<explain-block title="fluentform/entries_print_body">
+
+**Parameters**
+
+- `$pdfBody` — see source
+- `$submissions` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/entries_print_body', function ($pdfBody, $submissions, $form) {
+    return $pdfBody;
+}, 10, 3);
+```
+
+**Reference**
+
+`return apply_filters('fluentform/entries_print_body', $pdfBody, $submissions, $form);`
+
+This filter is located in `app/Services/Submission/SubmissionPrint.php` (line 51).
+
+</explain-block>
+
+<explain-block title="fluentform/entries_print_css">
+
+**Parameters**
+
+- `$value` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/entries_print_css', function ($value) {
+    return $value;
+}, 10, 1);
+```
+
+**Reference**
+
+`return apply_filters('fluentform/entries_print_css', ob_get_clean());`
+
+This filter is located in `app/Services/Submission/SubmissionPrint.php` (line 148).
+
+</explain-block>
+
+<explain-block title="fluentform/entry_limit_reached_message">
+
+**Parameters**
+
+- `$restrictions` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/entry_limit_reached_message', function ($restrictions, $form) {
+    return $restrictions;
+}, 10, 2);
+```
+
+**Reference**
+
+`$isRenderable['message'] = apply_filters('fluentform/entry_limit_reached_message', $restrictions['limitReachedMsg'], $form);`
+
+This filter is located in `app/Modules/Component/Component.php` (line 1064).
+
+</explain-block>
+
+<explain-block title="fluentform/entry_notes">
+
+**Parameters**
+
+- `$notes` — see source
+- `$submissionId` — see source
+- `$formId` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/entry_notes', function ($notes, $submissionId, $formId) {
+    return $notes;
+}, 10, 3);
+```
+
+**Reference**
+
+`$notes = apply_filters('fluentform/entry_notes', $notes, $submissionId, $formId);`
+
+This filter is located in `app/Services/Submission/SubmissionService.php` (line 543).
+
+</explain-block>
+
+<explain-block title="fluentform/entry_print_body">
+
+**Parameters**
+
+- `$htmlBody` — see source
+- `$submission` — see source
+- `$form` — see source
+- `$formData` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/entry_print_body', function ($htmlBody, $submission, $form, $formData) {
+    return $htmlBody;
+}, 10, 4);
+```
+
+**Reference**
+
+`$pdfBody .= apply_filters('fluentform/entry_print_body', $htmlBody, $submission, $form, $formData);`
+
+This filter is located in `app/Services/Submission/SubmissionPrint.php` (line 49).
+
+</explain-block>
+
+<explain-block title="fluentform/entry_print_with_notes">
+
+**Parameters**
+
+- `$value` — see source
+- `$form` — see source
+- `$submission` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/entry_print_with_notes', function ($value, $form, $submission) {
+    return $value;
+}, 10, 3);
+```
+
+**Reference**
+
+`if (apply_filters('fluentform/entry_print_with_notes', __return_true(), $form, $submission)) {`
+
+This filter is located in `app/Services/Submission/SubmissionPrint.php` (line 46).
+
+</explain-block>
+
+<explain-block title="fluentform/export_entry_metadata">
+
+**Parameters**
+
+- `$temp` — see source
+- `$submission` — see source
+- `$form` — see source
+- `$args` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/export_entry_metadata', function ($temp, $submission, $form, $args) {
+    return $temp;
+}, 10, 4);
+```
+
+**Reference**
+
+`$temp = apply_filters('fluentform/export_entry_metadata', $temp, $submission, $form, $args);`
+
+This filter is located in `app/Services/Transfer/TransferService.php` (line 304).
+
+</explain-block>
+
+<explain-block title="fluentform/export_entry_metadata_labels">
+
+**Parameters**
+
+- `$inputLabels` — see source
+- `$form` — see source
+- `$args` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/export_entry_metadata_labels', function ($inputLabels, $form, $args) {
+    return $inputLabels;
+}, 10, 3);
+```
+
+**Reference**
+
+`$inputLabels = apply_filters('fluentform/export_entry_metadata_labels', $inputLabels, $form, $args);`
+
+This filter is located in `app/Services/Transfer/TransferService.php` (line 321).
+
+</explain-block>
+
+<explain-block title="fluentform/front_end_entry_view_status">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$status` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/front_end_entry_view_status', function ($status) {
+    return $status;
+}, 10, 1);
+```
+
+**Reference**
+
+`return apply_filters('fluentform/front_end_entry_view_status', $status);`
+
+This filter is located in `src/classes/FrontEndEntryView.php` (line 87).
+
+</explain-block>
+
+<explain-block title="fluentform/store_submission_note">
+
+**Parameters**
+
+- `$note` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/store_submission_note', function ($note) {
+    return $note;
+}, 10, 1);
+```
+
+**Reference**
+
+`$note = apply_filters('fluentform/store_submission_note', $note);`
+
+This filter is located in `app/Services/Submission/SubmissionService.php` (line 576).
+
+</explain-block>
+
+<explain-block title="fluentform/submission_notes">
+
+**Parameters**
+
+- `$notes` — see source
+- `$submissionId` — see source
+- `$formId` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/submission_notes', function ($notes, $submissionId, $formId) {
+    return $notes;
+}, 10, 3);
+```
+
+**Reference**
+
+`return apply_filters('fluentform/submission_notes', $notes, $submissionId, $formId);`
+
+This filter is located in `app/Services/Submission/SubmissionService.php` (line 545).
+
+</explain-block>

--- a/src/hooks/filters/file-uploader.md
+++ b/src/hooks/filters/file-uploader.md
@@ -4,31 +4,184 @@
 
 These filters let you modify file upload validation, paths, and processing.
 
-<explain-block title="fluentform/file_upload_validations">
+<explain-block title="fluentform/change_file_upload_location">
 
-You can modify file upload validation rules and message using the filter.
+<Badge type="tip" vertical="top" text="Pro" />
 
 **Parameters**
 
-- `$delegateValidations` (array) Rules and Message Set
+- `$location` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/change_file_upload_location', function ($location) {
+    return $location;
+}, 10, 1);
+```
+
+**Reference**
+
+`$location = apply_filters('fluentform/change_file_upload_location', $location);`
+
+This filter is located in `src/Uploader.php` (line 869).
+
+</explain-block>
+
+<explain-block title="fluentform/default_file_upload_url">
+
+You can modify default file upload path using the filter.
+
+**Parameters**
+
+- `$filePath` (string) File Location Path
 - `$form` (object) Form Object
 
 **Usage**
 
 ```php
-add_filter('fluentform/file_upload_validations', function ($delegateValidations, $form) {
+add_filter('fluentform/default_file_upload_url', function ($filePath, $form) {
     // Do your stuff here
     
-    return $delegateValidations; 
+    return $filePath;
 }, 10, 2);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/file_upload_validations', $delegateValidations, $this->form);`
+`apply_filters('fluentform/default_file_upload_url', $filePath, $form);`
+
+This filter is located in FluentFormPro\src\Uploader -> getProcessedUrl($file, $location)
+
+</explain-block>
+
+<explain-block title="fluentform/default_upload_path">
+
+You can modify uploaded file default path using the filter.
+
+**Parameters**
+
+- `$filePath` (array) File Default Path
+- `$form` (object) Form Object
+
+**Usage**
+
+```php
+add_filter('fluentform/default_upload_path', function ($filePath, $form) {
+    // Do your stuff here
+    
+    return $filePath;
+}, 10, 2);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/default_upload_path', $filePath, $this->form);`
+
+This filter is located in FluentFormPro\src\Uploader -> copyToDefault($files)
+
+</explain-block>
+
+<explain-block title="fluentform/file_upload_button_text">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$btnText` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/file_upload_button_text', function ($btnText, $form) {
+    return $btnText;
+}, 10, 2);
+```
+
+**Reference**
+
+`$btnText = apply_filters('fluentform/file_upload_button_text', $btnText, $form);`
+
+This filter is located in `src/Components/Uploader.php` (line 52).
+
+</explain-block>
+
+<explain-block title="fluentform/file_upload_messages">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$args` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/file_upload_messages', function ($args) {
+    return $args;
+}, 10, 1);
+```
+
+**Reference**
+
+`$uploadMessages = apply_filters('fluentform/file_upload_messages', [`
+
+This filter is located in `src/Components/Uploader.php` (line 55).
+
+</explain-block>
+
+<explain-block title="fluentform/file_upload_params">
+
+You can modify file upload location using the filter.
+
+**Parameters**
+
+- `$param` (array) File Upload Location URL and Path
+- `$formData` (array) Form Data
+- `$form` (object) Form Object
+
+**Usage**
+
+```php
+add_filter('fluentform/file_upload_params', function ($param, $formData, $form) {
+    // Do your stuff here
+    
+    return $param;
+}, 10, 3);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/file_upload_params', $param, $this->formData, $this->form);`
 
 This filter is located in FluentFormPro\src\Uploader -> upload()
+
+</explain-block>
+
+<explain-block title="fluentform/file_upload_settings_for_js">
+
+**Parameters**
+
+- `$args` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/file_upload_settings_for_js', function ($args, $form) {
+    return $args;
+}, 10, 2);
+```
+
+**Reference**
+
+`$fileUploadSettings = apply_filters('fluentform/file_upload_settings_for_js', [], $form);`
+
+This filter is located in `app/Services/FluentConversational/Classes/Form.php` (line 558).
 
 </explain-block>
 
@@ -60,32 +213,135 @@ This filter is located in FluentFormPro\src\Uploader -> upload()
 
 </explain-block>
 
-<explain-block title="fluentform/file_upload_params">
+<explain-block title="fluentform/file_upload_validations">
 
-You can modify file upload location using the filter.
+You can modify file upload validation rules and message using the filter.
 
 **Parameters**
 
-- `$param` (array) File Upload Location URL and Path
+- `$delegateValidations` (array) Rules and Message Set
+- `$form` (object) Form Object
+
+**Usage**
+
+```php
+add_filter('fluentform/file_upload_validations', function ($delegateValidations, $form) {
+    // Do your stuff here
+    
+    return $delegateValidations; 
+}, 10, 2);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/file_upload_validations', $delegateValidations, $this->form);`
+
+This filter is located in FluentFormPro\src\Uploader -> upload()
+
+</explain-block>
+
+<explain-block title="fluentform/file_uploaded">
+
+You can modify uploaded file using the filter.
+
+**Parameters**
+
+- `$uploadFile` (array) Uploaded File
 - `$formData` (array) Form Data
 - `$form` (object) Form Object
 
 **Usage**
 
 ```php
-add_filter('fluentform/file_upload_params', function ($param, $formData, $form) {
+add_filter('fluentform/file_uploaded', function ($uploadFile, $formData, $form) {
     // Do your stuff here
     
-    return $param;
+    return $uploadFile;
 }, 10, 3);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/file_upload_params', $param, $this->formData, $this->form);`
+`apply_filters('fluentform/file_uploaded', $uploadFile, $formData, $form);`
 
-This filter is located in FluentFormPro\src\Uploader -> upload()
+This filter is located in FluentFormPro\src\Uploader -> uploadToTemp($files, $field)
+
+</explain-block>
+
+<explain-block title="fluentform/skip_cloud_file_decryption">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$value` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/skip_cloud_file_decryption', function ($value) {
+    return $value;
+}, 10, 1);
+```
+
+**Reference**
+
+`$isSkip = apply_filters('fluentform/skip_cloud_file_decryption', false);`
+
+This filter is located in `src/Uploader.php` (line 162).
+
+</explain-block>
+
+<explain-block title="fluentform/temp_file_cleanup_batch_size">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$value` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/temp_file_cleanup_batch_size', function ($value) {
+    return $value;
+}, 10, 1);
+```
+
+**Reference**
+
+`$maxDeletions = apply_filters('fluentform/temp_file_cleanup_batch_size', 50);`
+
+This filter is located in `src/Uploader.php` (line 703).
+
+</explain-block>
+
+<explain-block title="fluentform/temp_file_delete_time">
+
+You can modify temporary file delete time using the filter.
+
+**Parameters**
+
+- `$time` (string) Temp File Delete Time (milliseconds)
+
+**Usage**
+
+```php
+add_filter('fluentform/temp_file_delete_time', function ($time) {
+    // Do your stuff here
+    
+    return $time;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/temp_file_delete_time',  2 * 3600);`
+
+This filter is located in FluentFormPro\src\Uploader -> removeOldTempFiles()
 
 </explain-block>
 
@@ -119,34 +375,6 @@ This filter is located in FluentFormPro\src\Uploader -> renameFileName($file)
 
 </explain-block>
 
-<explain-block title="fluentform/default_upload_path">
-
-You can modify uploaded file default path using the filter.
-
-**Parameters**
-
-- `$filePath` (array) File Default Path
-- `$form` (object) Form Object
-
-**Usage**
-
-```php
-add_filter('fluentform/default_upload_path', function ($filePath, $form) {
-    // Do your stuff here
-    
-    return $filePath;
-}, 10, 2);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/default_upload_path', $filePath, $this->form);`
-
-This filter is located in FluentFormPro\src\Uploader -> copyToDefault($files)
-
-</explain-block>
-
 <explain-block title="fluentform/uploader_args">
 
 You can modify uploaded file args using the filter.
@@ -173,89 +401,5 @@ add_filter('fluentform/uploader_args', function ($args, $filesArray, $form) {
 `apply_filters('fluentform/uploader_args', $args, $filesArray, $this->form);`
 
 This filter is located in FluentFormPro\src\Uploader -> uploadToTemp($files, $field)
-
-</explain-block>
-
-<explain-block title="fluentform/file_uploaded">
-
-You can modify uploaded file using the filter.
-
-**Parameters**
-
-- `$uploadFile` (array) Uploaded File
-- `$formData` (array) Form Data
-- `$form` (object) Form Object
-
-**Usage**
-
-```php
-add_filter('fluentform/file_uploaded', function ($uploadFile, $formData, $form) {
-    // Do your stuff here
-    
-    return $uploadFile;
-}, 10, 3);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/file_uploaded', $uploadFile, $formData, $form);`
-
-This filter is located in FluentFormPro\src\Uploader -> uploadToTemp($files, $field)
-
-</explain-block>
-
-<explain-block title="fluentform/default_file_upload_url">
-
-You can modify default file upload path using the filter.
-
-**Parameters**
-
-- `$filePath` (string) File Location Path
-- `$form` (object) Form Object
-
-**Usage**
-
-```php
-add_filter('fluentform/default_file_upload_url', function ($filePath, $form) {
-    // Do your stuff here
-    
-    return $filePath;
-}, 10, 2);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/default_file_upload_url', $filePath, $form);`
-
-This filter is located in FluentFormPro\src\Uploader -> getProcessedUrl($file, $location)
-
-</explain-block>
-
-<explain-block title="fluentform/temp_file_delete_time">
-
-You can modify temporary file delete time using the filter.
-
-**Parameters**
-
-- `$time` (string) Temp File Delete Time (milliseconds)
-
-**Usage**
-
-```php
-add_filter('fluentform/temp_file_delete_time', function ($time) {
-    // Do your stuff here
-    
-    return $time;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/temp_file_delete_time',  2 * 3600);`
-
-This filter is located in FluentFormPro\src\Uploader -> removeOldTempFiles()
 
 </explain-block>

--- a/src/hooks/filters/form.md
+++ b/src/hooks/filters/form.md
@@ -4,30 +4,57 @@
 
 These filters let you modify form rendering, validation, fields, and form-level settings.
 
-<explain-block title="fluentform/is_form_renderable">
+<explain-block title="fluentform/before_render_item">
 
-You can check if the form is renderable using this filter.
+You can use this filter to modify the form inputs before form render.
 
 **Parameters**
 
-- `$isAllowed` (array) Form Status
+- `$item` (array) Input Item
 - `$form` (object) Form Object
 
 **Usage**
 
 ```php
-add_filter('fluentform/is_form_renderable', function ($isAllowed, $form){
-   // Do your stuff here
-   
-   return $isAllowed;
+add_filter('fluentform/before_render_item', function ($item, $form) {
+    // Do your stuff here
+    
+    return $item;
 }, 10, 2);
-```
 
+```
 **Reference**
 
-`apply_filters('fluentform/is_form_renderable', $isAllowed, $this->form);`
+`apply_filters('fluentform/before_render_item',  $item, $form);`
 
-This filter is located in FluentForm\App\Services\Form\FormValidationService -> validateRestrictions(&$fields)
+This filter is located in FluentForm\App\Services\FormBuilder -> buildFormBody($form)
+
+</explain-block>
+
+<explain-block title="fluentform/conversational_editor_elements">
+
+You can modify conversational editor elements using this filter.
+
+**Parameters**
+
+- `$elements` (array) Conversational Editor Elements
+- `$formId` (int) Form ID
+
+**Usage**
+
+```php
+add_filter('fluentform/conversational_editor_elements', function ($elements, $formId) {
+    // Do your stuff here
+    
+    return $elements;
+}, 10, 1);
+
+```
+**Reference**
+
+`apply_filters('fluentform/conversational_editor_elements', $elements, $formId);`
+
+This filter is located in FluentForm\App\Modules\Widgets\EditorButtonModule -> pageSupportedMediaButtons()
 
 </explain-block>
 
@@ -127,85 +154,6 @@ customFfLandingPageSlug('my-forms'); // you may change the "my-forms" for your o
 
 </explain-block>
 
-<explain-block title="fluentform/numeric_styles">
-
-You can modify or add more numeric formatters to number inputs using this filter.
-
-**Parameters**
-
-- `$numericFormatters` (array) all numeric formats
-
-**Usage**
-
-```php
-add_filter('fluentform/numeric_styles', function($numericFormatters) {
-   // Do your stuff here
-
-  return $staus;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/numeric_styles', $numericFormatters);`
-
-This filter is located in FluentForm\App\Helpers\Helper -> getNumericFormatters()
-
-</explain-block>
-
-<explain-block title="fluentform/form_store_attributes">
-
-You can modify Form attributes just Before storing the Form to the Database.
-
-**Parameters**
-
-- `$storeAttributes` (array) Form default attributes
-
-**Usage**
-
-```php
-add_filter('fluentform/form_store_attributes', function ($storeAttributes) {
-   // Do your stuff here
-
-   return $storeAttributes;
-}, 10, 1);
-
-```
-**Reference**
-
-`apply_filters('fluentform/form_store_attributes', array_filter($storeAttributes));`
-
-This filter is located in FluentForm\App\Models\Form -> prepare($attributes = [])
-
-</explain-block>
-
-<explain-block title="fluentform/forms_default_settings">
-
-You can modify Form Default Settings using this filter.
-
-**Parameters**
-
-- `$defaultSettings` (array) Form default Settings
-
-**Usage**
-
-```php
-add_filter('fluentform/forms_default_settings', function ($defaultSettings) {
-   // Do your stuff here
-
-   return $defaultSettings;
-}, 10, 1);
-
-```
-**Reference**
-
-`apply_filters('fluentform/forms_default_settings', array_filter($data));`
-
-This filter is located in FluentForm\App\Models\Form -> getFormsDefaultSettings($formId = false)
-
-</explain-block>
-
 <explain-block title="fluentform/create_default_settings">
 
 You can modify Form Default Settings while creating a new form using this filter.
@@ -229,6 +177,114 @@ add_filter('fluentform/create_default_settings', function($defaultSettings) {
 `apply_filters('fluentform/create_default_settings', array_filter($defaultSettings));`
 
 This filter is located in FluentForm\App\Models\Form -> getFormsDefaultSettings($formId = false)
+
+</explain-block>
+
+<explain-block title="fluentform/date_i18n">
+
+This filter returns date fields internationalized strings.
+
+**Parameters**
+
+- `$i18n` (array) Internationalized Strings
+
+**Usage**
+
+```php
+add_filter('fluentform/date_i18n', function ($i18n) {
+   // Do your stuff here
+
+   return $i18n;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/date_i18n', $i18n);`
+
+This filter is located in FluentForm\App\Modules\Component\Component -> getDatei18n()
+
+</explain-block>
+
+<explain-block title="fluentform/disable_accessibility_fieldset">
+
+You can use this filter to toggle form accessibility status and fieldset.
+
+**Parameters**
+
+- `$status` (boolean) Whether the accessibility status is enabled
+- `$form` (object) Form Object
+
+**Usage**
+
+```php
+add_filter('fluentform/disable_accessibility_fieldset', function ($status, $form) {
+    // Do your stuff here
+    
+    return $status;
+}, 10, 2);
+
+```
+**Reference**
+
+`apply_filters('fluentform/disable_accessibility_fieldset', true, $form);`
+
+This filter is located in FluentForm\App\Services\FormBuilder\FormBuilder -> build($form, $extraCssClass = '', $instanceCssClass = '', $atts = [])
+
+</explain-block>
+
+<explain-block title="fluentform/disable_inputmode">
+
+You can disable text input field using the filter.
+
+**Parameters**
+
+- `$status` (boolean) Whether text input is disabled
+
+**Usage**
+
+```php
+add_filter('fluentform/disable_inputmode', function ($status) {
+   // Do your stuff here
+
+   return $status;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/disable_inputmode', $status);`
+
+This filter is located in FluentForm\App\Services\FormBuilder\Components\Text -> compile($data, $form)
+
+</explain-block>
+
+<explain-block title="fluentform/disabled_analytics">
+
+Using this filter you can toggle the form analytics.
+
+**Parameters**
+
+- `$status` (boolean) whether form analytics is enabled
+
+**Usage**
+
+```php
+add_filter('fluentform/disabled_analytics', function($status) {
+   // Do your stuff here
+
+   return $status;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/disabled_analytics', $disableAnalytics);`
+
+This filter is located in FluentForm\App\Modules\Component\Component -> renderForm($atts)
 
 </explain-block>
 
@@ -263,6 +319,792 @@ add_filter('fluentform/editor_components', function($editorComponents, $formId) 
 `apply_filters('fluentform/editor_components', $editorComponents, $formId);`
 
 This filter is located in FluentForm\App\Modules\Component\Component -> index()
+
+</explain-block>
+
+<explain-block title="fluentform/editor_element_search_tags">
+
+You can modify editor element search tags using this filter.
+
+**Parameters**
+
+- `$searchTags` (array) Editor Fields
+- `$form` (object) Form Object
+
+**Usage**
+
+```php
+add_filter('fluentform/editor_element_search_tags', function ($searchTags, $form) {
+   // Do your stuff here
+
+   return $searchTags;
+}, 10, 2);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/editor_element_search_tags', $searchTags, $form);`
+
+This filter is located in FluentForm\App\Modules\Registerer\Menu -> enqueueEditorAssets()
+
+</explain-block>
+
+<explain-block title="fluentform/editor_element_settings_placement">
+
+Using this filter you can insert more editor settings for input in the editor.
+
+**Parameters**
+
+- `$placements` (array) Editor Fields
+- `$form` (object) Form Object
+
+**Usage**
+
+```php
+add_filter('fluentform/editor_element_settings_placement', function ($placements, $form) {
+   // Do your stuff here
+
+   return $placements;
+}, 10, 2);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/editor_element_settings_placement', $elementPlacements, $form);`
+
+This filter is located in FluentForm\App\Modules\Registerer\Menu -> enqueueEditorAssets()
+
+</explain-block>
+
+<explain-block title="'fluentform/editor_init_element_' . $formField['element']">
+
+Rendered form fields can be modified using this filter.
+
+**Parameters**
+
+- `$formField` (array) Form Field
+- `$form` (object) Form Object
+
+**Usage**
+
+```php
+add_filter('fluentform/editor_init_element_input_text', function ($element) {
+    if (!isset($element['attributes']['maxlength'])) {
+        $element['attributes']['maxlength'] = '';
+    }
+    
+    return $element;
+});
+```
+```php
+add_filter('fluentform/editor_init_element_input_number', function ($item) {
+    if (!isset($item['settings']['number_step'])) {
+        $item['settings']['number_step'] = '';
+    }
+    if (!isset($item['settings']['numeric_formatter'])) {
+        $item['settings']['numeric_formatter'] = '';
+    }
+    if (!isset($item['settings']['prefix_label'])) {
+        $item['settings']['prefix_label'] = '';
+    }
+    if (!isset($item['settings']['suffix_label'])) {
+        $item['settings']['suffix_label'] = '';
+    }
+
+    return $item;
+});
+```
+
+**Reference**
+
+`apply_filters('fluentform/editor_init_element_' . $formField['element'], $formField, $form);`
+
+This filter is located in FluentForm\App\Modules\Registerer\Menu -> enqueueEditorAssets()
+
+::: tip New core registrations in 6.2.3
+Fluent Forms 6.2.3 added two new core uses of this dynamic filter. These are NOT new hook names — they're additional registrations on the same `fluentform/editor_init_element_{element}` pattern:
+
+- `fluentform/editor_init_element_step_start` — core now augments the step-start element when this filter fires
+- `fluentform/editor_init_element_ratings` — core now wires the new icon-preset / SVG / color options into the ratings element editor
+
+If your extension already filters either element, re-check the merged `$item` shape — the core now contributes more keys to it. The Ratings additions include icon presets, custom inline SVG markup, and active/inactive color options exposed through `FluentForm\App\Services\FormBuilder\RatingIcon`; the step-start additions surface the new keyboard-shortcut and progress-bar options to the editor.
+:::
+
+</explain-block>
+
+<explain-block title="fluentform/fields_requiring_advanced_script">
+
+**Parameters**
+
+- `$advancedFields` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/fields_requiring_advanced_script', function ($advancedFields) {
+    return $advancedFields;
+}, 10, 1);
+```
+
+**Reference**
+
+`$advancedFields = apply_filters('fluentform/fields_requiring_advanced_script', $advancedFields);`
+
+This filter is located in `app/Modules/Component/Component.php` (line 1293).
+
+</explain-block>
+
+<explain-block title="fluentform/filtered_editor_fields">
+
+**Parameters**
+
+- `$fields` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/filtered_editor_fields', function ($fields) {
+    return $fields;
+}, 10, 1);
+```
+
+**Reference**
+
+`return apply_filters('fluentform/filtered_editor_fields', $fields);`
+
+This filter is located in `app/Services/Form/Fields.php` (line 101).
+
+</explain-block>
+
+<explain-block title="fluentform/form_admin_menu">
+
+You can modify admin menu items using this filter.
+
+**Parameters**
+
+- `$permission` (array) Admin Permission Set
+- `$form_id` (int) Form ID
+- `$form` (object) Form Object
+
+**Usage**
+
+```php
+add_filter('fluentform/form_admin_menu', function($formAdminMenus, $form_id, $form) {
+   // Do your stuff here
+
+   return $formAdminMenus;
+}, 10, 3);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/form_admin_menu', $formAdminMenus, $form_id, $form);`
+
+This filter is located in FluentForm\App\Modules\Registerer\Menu -> renderFormInnerPages()
+
+</explain-block>
+
+<explain-block title="fluentform/form_class">
+
+You can use this filter to modify a form CSS classes.
+
+**Parameters**
+
+- `$item` (array) Input Item
+- `$form` (object) Form Object
+
+**Usage**
+
+```php
+add_filter('fluentform/form_class', function ($css_class, $targetForm) use ($form) {
+    if ($targetForm->id == $form->id) {
+        $css_class .= ' ff_calc_form';
+    }
+    return $css_class;
+}, 10, 2);
+
+```
+**Reference**
+
+`apply_filters('fluentform/form_class', $formClass, $form);`
+
+This filter is located in FluentForm\App\Services\FormBuilder\FormBuilder -> build($form, $extraCssClass = '', $instanceCssClass = '', $atts = [])
+
+</explain-block>
+
+<explain-block title="fluentform/form_fields_update">
+
+This filter returns the updated field when updating a form field.
+
+**Parameters**
+
+- `$formFields` (array) Form Fields
+- `$formId` (int) Form ID
+
+**Usage**
+
+```php
+add_filter('fluentform/form_fields_update', function ($formFields, $formId) {
+   // Do your stuff here
+
+   return $defaultSettings;
+}, 10, 2);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/form_fields_update', $formFields, $formId);`
+
+This filter is located in FluentForm\App\Services\Form\Updater -> update($attributes = [])
+
+</explain-block>
+
+<explain-block title="fluentform/form_input_types">
+
+You can use this filter to add more form input types.
+
+**Parameters**
+
+- `$types` (array) Form Input Types
+
+**Usage**
+
+```php
+add_filter('fluentform/form_input_types', function ($types) {
+    // Do your stuff here
+    
+    return $types;
+}, 10, 1);
+
+```
+**Reference**
+
+`apply_filters('fluentform/form_input_types', $types);`
+
+This filter is located in FluentForm\App\Services\Parser\Form -> setInputTypes($types = [])
+
+</explain-block>
+
+<explain-block title="fluentform/form_payment_fields">
+
+You can use this filter to add more form payment input fields.
+
+**Parameters**
+
+- `$types` (array) Form Payment Input Types
+
+**Usage**
+
+```php
+add_filter('fluentform/form_payment_fields', function ($types) {
+    // Do your stuff here
+    
+    return $types;
+}, 10, 1);
+
+```
+**Reference**
+
+`apply_filters('fluentform/form_payment_fields', $types);`
+
+This filter is located in FluentForm\App\Services\Parser\Form -> hasPaymentFields()
+
+</explain-block>
+
+<explain-block title="fluentform/form_payment_inputs">
+
+You can use this filter to modify form payment input fields types
+
+**Parameters**
+
+- `$data` (array) Form Payment Input Types
+
+**Usage**
+
+```php
+add_filter('fluentform/form_payment_inputs', function ($data) {
+    // Do your stuff here
+    
+    return $data;
+}, 10, 1);
+
+```
+**Reference**
+
+`apply_filters('fluentform/form_payment_inputs', $data);`
+
+This filter is located in FluentForm\App\Services\Parser\Form -> getPaymentInputFields($with = ['element'])
+
+</explain-block>
+
+<explain-block title="fluentform/form_settings_ajax">
+
+You can modify a form setting Ajax using this filter.
+
+**Parameters**
+
+- `$settings` (array) Form Settings
+- `$formId` (int) Form ID
+
+**Usage**
+
+```php
+add_filter('fluentform/form_settings_ajax', function ($settings, $formId) {
+   // Do your stuff here
+
+   return $settings;
+}, 10, 2);
+
+```
+
+**Reference**
+
+`applyFilters('fluentform/form_settings_ajax', $settings, $formId);`
+
+This filter is located in FluentForm\App\Settings\FormSettings -> getGeneralSettingsAjax()
+
+</explain-block>
+
+<explain-block title="fluentform/form_settings_menu">
+
+You can modify form settings menu items using this filter.
+
+**Parameters**
+
+- `$permission` (array) Admin Permission Set
+
+**Usage**
+
+```php
+add_filter('fluentform/form_settings_menu', function ($settingsMenus, $form_id) {
+   // Do your stuff here
+
+   return $settingsMenus;
+}, 10, 2);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/form_settings_menu', $settingsMenus, $form_id);`
+
+This filter is located in FluentForm\App\Modules\Registerer\Menu -> renderSettings($form_id)
+
+</explain-block>
+
+<explain-block title="fluentform/form_store_attributes">
+
+You can modify Form attributes just Before storing the Form to the Database.
+
+**Parameters**
+
+- `$storeAttributes` (array) Form default attributes
+
+**Usage**
+
+```php
+add_filter('fluentform/form_store_attributes', function ($storeAttributes) {
+   // Do your stuff here
+
+   return $storeAttributes;
+}, 10, 1);
+
+```
+**Reference**
+
+`apply_filters('fluentform/form_store_attributes', array_filter($storeAttributes));`
+
+This filter is located in FluentForm\App\Models\Form -> prepare($attributes = [])
+
+</explain-block>
+
+<explain-block title="fluentform/form_submission_confirmation">
+
+You can use this filter hook to alter form confirmation message after a successful form submission.
+
+**Parameters**
+
+- `$confirmation` (array) Confirmation Details
+```php
+$confirmation = [
+    'redirectTo'           => 'samePage'  // or customUrl or customPage
+    'messageToShow'        => 'Thank you for your message. We will get in touch with you shortly'
+    'customPage'           => '' 
+    'samePageFormBehavior' => 'hide_form' // or reset_form 
+    'customUrl'            => 'https://yourcustomurl.com'
+];
+```
+- `$formData` (array) Form Data
+- `$form` (object) Form Object
+
+**Usage**
+
+```php
+add_filter('fluentform/form_submission_confirmation', function($confirmation, $formData, $form) {
+   // Do your stuff here
+
+   return $confirmation;
+}, 10, 3);
+
+```
+The following would apply to a specific form with id 5:
+```php
+add_filter('fluentform/form_submission_confirmation', function($confirmation, $formData, $form)
+{
+   if ($form->id != 5) {
+      return $confirmation;
+   }
+
+   // Do your stuffs here 
+   return $confirmation;
+}, 10, 3);
+
+```
+**Reference**
+
+`apply_filters('fluentform/submission_confirmation', $returnData, $form, $confirmation);`
+
+This filter is located in FluentForm\App\Services\Form\SubmissionHandlerService -> getReturnData($insertId, $form, $formData)
+
+</explain-block>
+
+<explain-block title="fluentform/form_vars_for_JS">
+
+You can modify Form Default Variables Javascript using this filter.
+
+**Parameters**
+
+- `$form_vars` (array) Form Variables
+- `$form` (object) Form Object
+
+**Usage**
+
+```php
+add_filter('fluentform/form_vars_for_JS', function($form_vars, $form) {
+   // Do your stuff here
+
+   return $form_vars;
+}, 10, 2);
+
+```
+**Reference**
+
+`apply_filters('fluentform/form_vars_for_JS', $form_vars, $form);`
+
+This filter is located in FluentForm\App\Modules\Component\Component -> renderForm($atts))
+
+</explain-block>
+
+<explain-block title="fluentform/form_wrapper_classes">
+
+**Parameters**
+
+- `$wrapperClasses` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/form_wrapper_classes', function ($wrapperClasses, $form) {
+    return $wrapperClasses;
+}, 10, 2);
+```
+
+**Reference**
+
+`$wrapperClasses = apply_filters('fluentform/form_wrapper_classes', $wrapperClasses, $form);`
+
+This filter is located in `app/Services/FormBuilder/FormBuilder.php` (line 152).
+
+</explain-block>
+
+<explain-block title="fluentform/forms_default_settings">
+
+You can modify Form Default Settings using this filter.
+
+**Parameters**
+
+- `$defaultSettings` (array) Form default Settings
+
+**Usage**
+
+```php
+add_filter('fluentform/forms_default_settings', function ($defaultSettings) {
+   // Do your stuff here
+
+   return $defaultSettings;
+}, 10, 1);
+
+```
+**Reference**
+
+`apply_filters('fluentform/forms_default_settings', array_filter($data));`
+
+This filter is located in FluentForm\App\Models\Form -> getFormsDefaultSettings($formId = false)
+
+</explain-block>
+
+<explain-block title="fluentform/frontend_date_format">
+
+You can modify date formats to show in form frontend using the filter.
+
+**Parameters**
+
+- `$dateFormats` (array) Date formats Settings
+- `$settings` (array) Field Settings  
+- `$form` (object) Form Object  
+
+**Usage**
+
+```php
+add_filter('fluentform/frontend_date_format', function ($dateFormats, $settings, $form) {
+    // Do your stuff here
+    
+    return $dateFormats;
+}, 10, 3);
+
+```
+Date formats to filter:
+```php
+[
+    'dateFormat'    => $dateFormat,
+    'enableTime'    => $hasTime,
+    'noCalendar'    => ! $this->hasDate($dateFormat),
+    'disableMobile' => true,
+    'time_24hr'     => $time24,
+];
+```
+
+**Reference**
+
+`apply_filters('fluentform/frontend_date_format', $dateFormats, $settings, $form);`
+
+This filter is located in FluentForm\App\Services\FormBuilder\Components\DateTime -> getDateFormatConfigJSON($settings, $form)
+
+</explain-block>
+
+<explain-block title="fluentform/global_form_vars">
+
+This filter returns the variables for localizing with fluentform script.
+
+**Parameters**
+
+- `$globalVars` (array) Localized Global Variable Array
+
+**Usage**
+
+```php
+add_filter('fluentform/global_form_vars', function ($globalVars) {
+   // Do your stuff here
+
+   return $globalVars;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/global_form_vars', $data);`
+
+This filter is located in FluentForm\App\Modules\Component\Component -> renderForm($atts)
+
+</explain-block>
+
+<explain-block title="fluentform/honeypot_name">
+
+You can change Honeypot name using this filter just before rendering the form.
+
+**Parameters**
+
+- `$name` (string) Honeypot Field Name
+- `$formId` (int) Form ID
+
+**Usage**
+
+```php
+add_filter('fluentform/honeypot_name', function($name, $formId) {
+   // Do your stuff here
+   $customStr = 'custom_name';
+   $name = 'item__' . $formId . '__fluent_checkme_' . $customStr;
+
+   return $name;
+}, 10, 2);
+
+```
+**Reference**
+
+`apply_filters('fluentform/honeypot_name', 'item__' . $formId . '__fluent_checkme_', $formId);`
+
+This filter is located in FluentForm\App\Modules\Form\HoneyPot -> getFieldName($formId)
+
+</explain-block>
+
+<explain-block title="fluentform/honeypot_status">
+
+You can toggle Honeypot status using this filter.
+
+**Parameters**
+
+- `$status` (boolean) Whether Honeypot status is Enabled
+- `$formId` (int) Form ID
+
+**Usage**
+
+```php
+add_filter('fluentform/honeypot_status', function($status, $formId) {
+   // Do your stuff here
+
+   return $status;
+}, 10, 2);
+
+```
+**Reference**
+
+`apply_filters('fluentform/honeypot_status', $status, $formId);`
+
+This filter is located in FluentForm\App\Modules\Form\Honeypot -> isEnabled($formId = false)
+
+</explain-block>
+
+<explain-block title="fluentform/image_type_options">
+
+**Parameters**
+
+- `$fluentformImageTypeOptions` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/image_type_options', function ($fluentformImageTypeOptions) {
+    return $fluentformImageTypeOptions;
+}, 10, 1);
+```
+
+**Reference**
+
+`$fluentformImageTypeOptions = apply_filters('fluentform/image_type_options', $fluentformImageTypeOptions);`
+
+This filter is located in `app/Services/FormBuilder/ValidationRuleSettings.php` (line 81).
+
+</explain-block>
+
+<explain-block title="fluentform/inner_route_has_permission">
+
+You can check admin menu route has proper permission using this filter.
+
+**Parameters**
+
+- `$hasPermission` (boolean) Whether the current route has permission
+- `$route` (string) Route Name
+- `$formId` (int) Form ID
+
+**Usage**
+
+```php
+add_filter('fluentform/inner_route_has_permission', function($hasPermission, $route, $formId) {
+   // Do your stuff here
+
+   return $hasPermission;
+}, 10, 3);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/form_inner_route_permission_set', Acl::hasPermission($toVerifyPermission), $route, $formId);`
+
+This filter is located in FluentForm\App\Modules\Registerer\Menu -> renderFormAdminRoute()
+
+</explain-block>
+
+<explain-block title="'fluentform/input_data_' . $element">
+
+This filter returns the input labels for the Submission on the Submission page.
+
+**Parameters**
+
+- `$fieldData` (array) Form Data of the Field
+- `$field` (array) Field Data
+- `$formData` (array) Form Data
+- `$form` (object) Form Object
+
+**Usage**
+
+```php
+add_filter('fluentform/input_data_input_number', function ($fieldData, $field, $formData, $form) {
+    // Do your stuff here
+    $formatter = ArrayHelper::get($field, 'raw.settings.numeric_formatter');
+    if (!$formatter) {
+        return $value;
+    }
+        
+    return Helper::getNumericValue($value, $formatter);
+}, 10, 4);
+
+```
+**Reference**
+
+`apply_filters('fluentform/input_data_' . $element, $formData[$fieldName], $field, $formData, $this->form);`
+
+This filter is located in FluentForm\App\Services\Form\FormValidationService -> validateSubmission(&$fields, &$formData)
+
+</explain-block>
+
+<explain-block title="fluentform/is_form_renderable">
+
+You can check if the form is renderable using this filter.
+
+**Parameters**
+
+- `$isAllowed` (array) Form Status
+- `$form` (object) Form Object
+
+**Usage**
+
+```php
+add_filter('fluentform/is_form_renderable', function ($isAllowed, $form){
+   // Do your stuff here
+   
+   return $isAllowed;
+}, 10, 2);
+```
+
+**Reference**
+
+`apply_filters('fluentform/is_form_renderable', $isAllowed, $this->form);`
+
+This filter is located in FluentForm\App\Services\Form\FormValidationService -> validateRestrictions(&$fields)
+
+</explain-block>
+
+<explain-block title="'fluentform/is_hide_submit_btn_' . $form->id">
+
+You can hide / show submit button using the filter.
+
+**Parameters**
+
+- `$status` (boolean) Whether show / hide Submit Button
+
+**Usage**
+
+```php
+add_filter('fluentform/is_hide_submit_btn_' . $form->id, function ($status) {
+    // Do your stuff here
+    
+    return $status;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/is_hide_submit_btn_' . $form->id, false);`
+
+This filter is located in FluentForm\App\Services\FormBuilder\Components\SubmitButton -> compile($data, $form)
 
 </explain-block>
 
@@ -334,194 +1176,188 @@ This filter is located in FluentForm\App\Modules\Component\Component -> maybeLoa
 
 </explain-block>
 
-<explain-block title="fluentform/global_form_vars">
+<explain-block title="fluentform/numeric_styles">
 
-This filter returns the variables for localizing with fluentform script.
+You can modify or add more numeric formatters to number inputs using this filter.
 
 **Parameters**
 
-- `$globalVars` (array) Localized Global Variable Array
+- `$numericFormatters` (array) all numeric formats
 
 **Usage**
 
 ```php
-add_filter('fluentform/global_form_vars', function ($globalVars) {
+add_filter('fluentform/numeric_styles', function($numericFormatters) {
    // Do your stuff here
 
-   return $globalVars;
+  return $staus;
 }, 10, 1);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/global_form_vars', $data);`
+`apply_filters('fluentform/numeric_styles', $numericFormatters);`
 
-This filter is located in FluentForm\App\Modules\Component\Component -> renderForm($atts)
+This filter is located in FluentForm\App\Helpers\Helper -> getNumericFormatters()
 
 </explain-block>
 
-<explain-block title="fluentform/form_vars_for_JS">
+<explain-block title="fluentform/predefined_dropdown_forms">
 
-You can modify Form Default Variables Javascript using this filter.
+You can add or modify Predefined Post Forms in Form Templates using this filter.
 
 **Parameters**
 
-- `$form_vars` (array) Form Variables
+- `$forms` (array) Template Post Forms
+
+**Usage**
+
+```php
+add_filter('fluentform/predefined_dropdown_forms', function($forms) {
+   // Do your stuff here
+
+   return $forms;
+}, 10, 1);
+
+```
+**Reference**
+
+`apply_filters('fluentform/predefined_dropdown_forms', $dropDownForms),`
+
+This filter is located in FluentForm\App\Services\Form\FormService -> templates()
+
+</explain-block>
+
+<explain-block title="fluentform/predefined_forms">
+
+You can add or modify Predefined Forms in Form Templates using this filter.
+
+**Parameters**
+
+- `$forms` (array) Template Forms
+
+**Usage**
+
+```php
+add_filter('fluentform/predefined_forms', function ($forms) {
+   // Do your stuff here
+
+   return $forms;
+}, 10, 1);
+
+```
+**Reference**
+
+`apply_filters('fluentform/predefined_forms', $forms);`
+
+This filter is located in FluentForm\App\Models\Traits\PredefinedForms -> findPredefinedForm($attributes = [])
+
+</explain-block>
+
+<explain-block title="fluentform/prevent_malicious_attacks">
+
+You can toggle malicious attack prevention using this filter.
+
+**Parameters**
+
+- `$status` (boolean) Whether Malicious Attack Prevention Enabled
+- `$formId` (int) Form ID
+
+**Usage**
+
+```php
+add_filter('fluentform/prevent_malicious_attacks', function($status, $formId) {
+   // Do your stuff here
+
+   return $status;
+}, 10, 2);
+
+```
+**Reference**
+
+`apply_filters('fluentform/prevent_malicious_attacks', true, $this->form->id);`
+
+This filter is located in FluentForm\App\Services\Form\FormValidationService -> preventMaliciousAttacks()
+
+</explain-block>
+
+<explain-block title="fluentform/redirect_url_value">
+
+<Badge type="warning" vertical="top" text="Added in 6.2.x" />
+
+Filter the final redirect URL value computed after a successful submission, just before it's sent back to the browser as part of the confirmation response. Useful for appending query parameters, swapping domains, or rewriting the URL based on submission content.
+
+**Parameters**
+
+- `$url` (string) The fully built redirect URL
+- `$formData` (array) Submitted form data
+- `$form` (object) Form being processed
+
+**Usage**
+
+```php
+add_filter('fluentform/redirect_url_value', function ($url, $formData, $form) {
+    return add_query_arg('utm_source', 'fluentform', $url);
+}, 10, 3);
+```
+
+**Reference**
+
+`apply_filters('fluentform/redirect_url_value', $url, $formData, $form);`
+
+This filter is located in `FluentForm\App\Services\Form\SubmissionHandlerService`.
+
+</explain-block>
+
+<explain-block title="fluentform/render_field_as_html">
+
+**Parameters**
+
+- `$isHtml` — see source
+- `$values` — see source
+- `$form_id` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/render_field_as_html', function ($isHtml, $values, $form_id) {
+    return $isHtml;
+}, 10, 3);
+```
+
+**Reference**
+
+`$isHtml = apply_filters('fluentform/render_field_as_html', $isHtml, $values, $form_id);`
+
+This filter is located in `app/Modules/Form/FormDataParser.php` (line 141).
+
+</explain-block>
+
+<explain-block title="fluentform/rendering_form">
+
+This filter hook is fired before form render. You can use this to change rendered form.
+
+**Parameters**
+
 - `$form` (object) Form Object
 
 **Usage**
 
 ```php
-add_filter('fluentform/form_vars_for_JS', function($form_vars, $form) {
-   // Do your stuff here
-
-   return $form_vars;
-}, 10, 2);
-
-```
-**Reference**
-
-`apply_filters('fluentform/form_vars_for_JS', $form_vars, $form);`
-
-This filter is located in FluentForm\App\Modules\Component\Component -> renderForm($atts))
-
-</explain-block>
-
-<explain-block title="fluentform/disabled_analytics">
-
-Using this filter you can toggle the form analytics.
-
-**Parameters**
-
-- `$status` (boolean) whether form analytics is enabled
-
-**Usage**
-
-```php
-add_filter('fluentform/disabled_analytics', function($status) {
-   // Do your stuff here
-
-   return $status;
+add_filter('fluentform/rendering_form', function ($form) {
+    // Do your stuff here
+    
+    return $form;
 }, 10, 1);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/disabled_analytics', $disableAnalytics);`
+`apply_filters('fluentform/rendering_form', $form);`
 
-This filter is located in FluentForm\App\Modules\Component\Component -> renderForm($atts)
-
-</explain-block>
-
-<explain-block title="fluentform/date_i18n">
-
-This filter returns date fields internationalized strings.
-
-**Parameters**
-
-- `$i18n` (array) Internationalized Strings
-
-**Usage**
-
-```php
-add_filter('fluentform/date_i18n', function ($i18n) {
-   // Do your stuff here
-
-   return $i18n;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/date_i18n', $i18n);`
-
-This filter is located in FluentForm\App\Modules\Component\Component -> getDatei18n()
-
-</explain-block>
-
-<explain-block title="'fluentform/settings_module_' . $module">
-
-This filter returns form extra settings component.
-
-**Parameters**
-
-- `$component` (array) Components
-- `$formId` (int) Form ID
-
-**Usage**
-
-```php
-add_filter('fluentform/settings_module_' . $module, function ($component, $formId) {
-   // Do your stuff here
-
-   return $result;
-}, 10, 2);
-
-```
-**Reference**
-
-`apply_filters('fluentform/settings_module_' . $module, $component, $formId);`
-
-This filter is located in FluentForm\App\Modules\Form\Settings\ExtraSettings -> getExtraSettingsComponent()
-
-</explain-block>
-
-<explain-block title="fluentform/form_settings_ajax">
-
-You can modify a form setting Ajax using this filter.
-
-**Parameters**
-
-- `$settings` (array) Form Settings
-- `$formId` (int) Form ID
-
-**Usage**
-
-```php
-add_filter('fluentform/form_settings_ajax', function ($settings, $formId) {
-   // Do your stuff here
-
-   return $settings;
-}, 10, 2);
-
-```
-
-**Reference**
-
-`applyFilters('fluentform/form_settings_ajax', $settings, $formId);`
-
-This filter is located in FluentForm\App\Settings\FormSettings -> getGeneralSettingsAjax()
-
-</explain-block>
-
-<explain-block title="fluentform/form_fields_update">
-
-This filter returns the updated field when updating a form field.
-
-**Parameters**
-
-- `$formFields` (array) Form Fields
-- `$formId` (int) Form ID
-
-**Usage**
-
-```php
-add_filter('fluentform/form_fields_update', function ($formFields, $formId) {
-   // Do your stuff here
-
-   return $defaultSettings;
-}, 10, 2);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/form_fields_update', $formFields, $formId);`
-
-This filter is located in FluentForm\App\Services\Form\Updater -> update($attributes = [])
+This filter is located in FluentForm\app\Modules\Component\Component -> renderForm($atts)
 
 </explain-block>
 
@@ -565,53 +1401,117 @@ This filter is located in FluentForm\App\Modules\Form\FormDataParser -> parseDat
 
 </explain-block>
 
-<explain-block title="fluentform/form_submission_confirmation">
-
-You can use this filter hook to alter form confirmation message after a successful form submission.
+<explain-block title="fluentform/select_group_component_ajax_options">
 
 **Parameters**
 
-- `$confirmation` (array) Confirmation Details
-```php
-$confirmation = [
-    'redirectTo'           => 'samePage'  // or customUrl or customPage
-    'messageToShow'        => 'Thank you for your message. We will get in touch with you shortly'
-    'customPage'           => '' 
-    'samePageFormBehavior' => 'hide_form' // or reset_form 
-    'customUrl'            => 'https://yourcustomurl.com'
-];
-```
-- `$formData` (array) Form Data
-- `$form` (object) Form Object
+- `$args` — see source
+- `$requestData` — see source
 
 **Usage**
 
 ```php
-add_filter('fluentform/form_submission_confirmation', function($confirmation, $formData, $form) {
+add_filter('fluentform/select_group_component_ajax_options', function ($args, $requestData) {
+    return $args;
+}, 10, 2);
+```
+
+**Reference**
+
+`$ajaxList = apply_filters('fluentform/select_group_component_ajax_options', [], $requestData);`
+
+This filter is located in `app/Hooks/Ajax.php` (line 257).
+
+</explain-block>
+
+<explain-block title="'fluentform/settings_module_' . $module">
+
+This filter returns form extra settings component.
+
+**Parameters**
+
+- `$component` (array) Components
+- `$formId` (int) Form ID
+
+**Usage**
+
+```php
+add_filter('fluentform/settings_module_' . $module, function ($component, $formId) {
    // Do your stuff here
 
-   return $confirmation;
-}, 10, 3);
-
-```
-The following would apply to a specific form with id 5:
-```php
-add_filter('fluentform/form_submission_confirmation', function($confirmation, $formData, $form)
-{
-   if ($form->id != 5) {
-      return $confirmation;
-   }
-
-   // Do your stuffs here 
-   return $confirmation;
-}, 10, 3);
+   return $result;
+}, 10, 2);
 
 ```
 **Reference**
 
-`apply_filters('fluentform/submission_confirmation', $returnData, $form, $confirmation);`
+`apply_filters('fluentform/settings_module_' . $module, $component, $formId);`
 
-This filter is located in FluentForm\App\Services\Form\SubmissionHandlerService -> getReturnData($insertId, $form, $formData)
+This filter is located in FluentForm\App\Modules\Form\Settings\ExtraSettings -> getExtraSettingsComponent()
+
+</explain-block>
+
+<explain-block title="fluentform/show_preview_promo">
+
+You can use this filter to toggle preview promo.
+
+**Parameters**
+
+- `$status` (boolean) Whether to show preview promo
+
+**Usage**
+
+```php
+add_filter('fluentform/show_preview_promo', function ($status) {
+    // Do your stuff here
+    
+    return $status;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/show_preview_promo', true);`
+
+This filter is located in FluentForm\app\views\frameless\template\show_preview.php
+
+</explain-block>
+
+<explain-block title="fluentform/submission_confirmation">
+
+This filter is available just before sending the success message to the user. You can use this filter hook to alter the form confirmation message and redirect settings dynamically.
+
+**Parameters**
+
+- `$returnData` (array) Submitted Data
+- `$form` (object) Form Object
+- `$confirmation` (array) Submission Confirmation Message
+- `$insertId` (int) Submission ID
+- `$formData` (array) Form Data
+
+**Usage**
+
+```php
+add_filter('fluentform/submission_confirmation', function ($returnData, $form, $confirmation, $insertId, $formData) {
+    // Do your stuff here
+    
+    return $returnData;
+}, 10, 5);
+
+```
+```php
+$returnData = [
+    'redirectUrl' => wp_sanitize_redirect(urldecode($redirectUrl)),
+    'message'     => $message,
+];
+```
+
+**Reference**
+
+`apply_filters('fluentform/submission_confirmation', $returnData, $form, $confirmation, $insertId, $formData);`
+
+This filter is located in FluentForm\app\Services\Form\SubmissionHandlerService -> getReturnData($insertId, $form, $formData)
 
 </explain-block>
 
@@ -644,32 +1544,32 @@ This filter is located in FluentForm\App\Services\Form\SubmissionHandlerServices
 
 </explain-block>
 
-<explain-block title="fluentform/validations">
+<explain-block title="fluentform/submit_button_force_no_style">
 
-This filter returns all validations before form submission.
+You can modify admin menu items using this filter.
 
 **Parameters**
 
-- `$originalValidations` (array) Default Validations
+- `$permission` (array) Admin Permission Set
+- `$form_id` (int) Form ID
 - `$form` (object) Form Object
-- `$formData` (array) Form Data
 
 **Usage**
 
 ```php
-add_filter('fluentform/validations', function ($originalValidations, $form, $formData) {
+add_filter('fluentform/form_admin_menu', function($formAdminMenus, $form_id, $form) {
    // Do your stuff here
 
-   return $originalValidations;
+   return $formAdminMenus;
 }, 10, 3);
 
 ```
 
 **Reference**
 
-` apply_filters('fluentform/validations', $originalValidations, $this->form, $formData);`
+`apply_filters('fluentform/form_admin_menu', $formAdminMenus, $form_id, $form);`
 
-This filter is located in FluentForm\App\Services\Form -> validateSubmission(&$fields, &$formData)
+This filter is located in FluentForm\App\Modules\Registerer\Menu -> renderFormInnerPages()
 
 </explain-block>
 
@@ -757,787 +1657,31 @@ This filter is located in FluentForm\App\Services\Form\FormValidationService -> 
 
 </explain-block>
 
-<explain-block title="fluentform/prevent_malicious_attacks">
+<explain-block title="fluentform/validations">
 
-You can toggle malicious attack prevention using this filter.
-
-**Parameters**
-
-- `$status` (boolean) Whether Malicious Attack Prevention Enabled
-- `$formId` (int) Form ID
-
-**Usage**
-
-```php
-add_filter('fluentform/prevent_malicious_attacks', function($status, $formId) {
-   // Do your stuff here
-
-   return $status;
-}, 10, 2);
-
-```
-**Reference**
-
-`apply_filters('fluentform/prevent_malicious_attacks', true, $this->form->id);`
-
-This filter is located in FluentForm\App\Services\Form\FormValidationService -> preventMaliciousAttacks()
-
-</explain-block>
-
-<explain-block title="fluentform/honeypot_status">
-
-You can toggle Honeypot status using this filter.
+This filter returns all validations before form submission.
 
 **Parameters**
 
-- `$status` (boolean) Whether Honeypot status is Enabled
-- `$formId` (int) Form ID
-
-**Usage**
-
-```php
-add_filter('fluentform/honeypot_status', function($status, $formId) {
-   // Do your stuff here
-
-   return $status;
-}, 10, 2);
-
-```
-**Reference**
-
-`apply_filters('fluentform/honeypot_status', $status, $formId);`
-
-This filter is located in FluentForm\App\Modules\Form\Honeypot -> isEnabled($formId = false)
-
-</explain-block>
-
-<explain-block title="fluentform/honeypot_name">
-
-You can change Honeypot name using this filter just before rendering the form.
-
-**Parameters**
-
-- `$name` (string) Honeypot Field Name
-- `$formId` (int) Form ID
-
-**Usage**
-
-```php
-add_filter('fluentform/honeypot_name', function($name, $formId) {
-   // Do your stuff here
-   $customStr = 'custom_name';
-   $name = 'item__' . $formId . '__fluent_checkme_' . $customStr;
-
-   return $name;
-}, 10, 2);
-
-```
-**Reference**
-
-`apply_filters('fluentform/honeypot_name', 'item__' . $formId . '__fluent_checkme_', $formId);`
-
-This filter is located in FluentForm\App\Modules\Form\HoneyPot -> getFieldName($formId)
-
-</explain-block>
-
-<explain-block title="fluentform/predefined_forms">
-
-You can add or modify Predefined Forms in Form Templates using this filter.
-
-**Parameters**
-
-- `$forms` (array) Template Forms
-
-**Usage**
-
-```php
-add_filter('fluentform/predefined_forms', function ($forms) {
-   // Do your stuff here
-
-   return $forms;
-}, 10, 1);
-
-```
-**Reference**
-
-`apply_filters('fluentform/predefined_forms', $forms);`
-
-This filter is located in FluentForm\App\Models\Traits\PredefinedForms -> findPredefinedForm($attributes = [])
-
-</explain-block>
-
-<explain-block title="fluentform/predefined_dropdown_forms">
-
-You can add or modify Predefined Post Forms in Form Templates using this filter.
-
-**Parameters**
-
-- `$forms` (array) Template Post Forms
-
-**Usage**
-
-```php
-add_filter('fluentform/predefined_dropdown_forms', function($forms) {
-   // Do your stuff here
-
-   return $forms;
-}, 10, 1);
-
-```
-**Reference**
-
-`apply_filters('fluentform/predefined_dropdown_forms', $dropDownForms),`
-
-This filter is located in FluentForm\App\Services\Form\FormService -> templates()
-
-</explain-block>
-
-<explain-block title="'fluentform/editor_init_element_' . $formField['element']">
-
-Rendered form fields can be modified using this filter.
-
-**Parameters**
-
-- `$formField` (array) Form Field
+- `$originalValidations` (array) Default Validations
 - `$form` (object) Form Object
-
-**Usage**
-
-```php
-add_filter('fluentform/editor_init_element_input_text', function ($element) {
-    if (!isset($element['attributes']['maxlength'])) {
-        $element['attributes']['maxlength'] = '';
-    }
-    
-    return $element;
-});
-```
-```php
-add_filter('fluentform/editor_init_element_input_number', function ($item) {
-    if (!isset($item['settings']['number_step'])) {
-        $item['settings']['number_step'] = '';
-    }
-    if (!isset($item['settings']['numeric_formatter'])) {
-        $item['settings']['numeric_formatter'] = '';
-    }
-    if (!isset($item['settings']['prefix_label'])) {
-        $item['settings']['prefix_label'] = '';
-    }
-    if (!isset($item['settings']['suffix_label'])) {
-        $item['settings']['suffix_label'] = '';
-    }
-
-    return $item;
-});
-```
-
-**Reference**
-
-`apply_filters('fluentform/editor_init_element_' . $formField['element'], $formField, $form);`
-
-This filter is located in FluentForm\App\Modules\Registerer\Menu -> enqueueEditorAssets()
-
-</explain-block>
-
-<explain-block title="fluentform/inner_route_has_permission">
-
-You can check admin menu route has proper permission using this filter.
-
-**Parameters**
-
-- `$hasPermission` (boolean) Whether the current route has permission
-- `$route` (string) Route Name
-- `$formId` (int) Form ID
-
-**Usage**
-
-```php
-add_filter('fluentform/inner_route_has_permission', function($hasPermission, $route, $formId) {
-   // Do your stuff here
-
-   return $hasPermission;
-}, 10, 3);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/form_inner_route_permission_set', Acl::hasPermission($toVerifyPermission), $route, $formId);`
-
-This filter is located in FluentForm\App\Modules\Registerer\Menu -> renderFormAdminRoute()
-
-</explain-block>
-
-<explain-block title="fluentform/form_admin_menu">
-
-You can modify admin menu items using this filter.
-
-**Parameters**
-
-- `$permission` (array) Admin Permission Set
-- `$form_id` (int) Form ID
-- `$form` (object) Form Object
-
-**Usage**
-
-```php
-add_filter('fluentform/form_admin_menu', function($formAdminMenus, $form_id, $form) {
-   // Do your stuff here
-
-   return $formAdminMenus;
-}, 10, 3);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/form_admin_menu', $formAdminMenus, $form_id, $form);`
-
-This filter is located in FluentForm\App\Modules\Registerer\Menu -> renderFormInnerPages()
-
-</explain-block>
-
-<explain-block title="fluentform/form_settings_menu">
-
-You can modify form settings menu items using this filter.
-
-**Parameters**
-
-- `$permission` (array) Admin Permission Set
-
-**Usage**
-
-```php
-add_filter('fluentform/form_settings_menu', function ($settingsMenus, $form_id) {
-   // Do your stuff here
-
-   return $settingsMenus;
-}, 10, 2);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/form_settings_menu', $settingsMenus, $form_id);`
-
-This filter is located in FluentForm\App\Modules\Registerer\Menu -> renderSettings($form_id)
-
-</explain-block>
-
-<explain-block title="fluentform/editor_element_search_tags">
-
-You can modify editor element search tags using this filter.
-
-**Parameters**
-
-- `$searchTags` (array) Editor Fields
-- `$form` (object) Form Object
-
-**Usage**
-
-```php
-add_filter('fluentform/editor_element_search_tags', function ($searchTags, $form) {
-   // Do your stuff here
-
-   return $searchTags;
-}, 10, 2);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/editor_element_search_tags', $searchTags, $form);`
-
-This filter is located in FluentForm\App\Modules\Registerer\Menu -> enqueueEditorAssets()
-
-</explain-block>
-
-<explain-block title="fluentform/editor_element_settings_placement">
-
-Using this filter you can insert more editor settings for input in the editor.
-
-**Parameters**
-
-- `$placements` (array) Editor Fields
-- `$form` (object) Form Object
-
-**Usage**
-
-```php
-add_filter('fluentform/editor_element_settings_placement', function ($placements, $form) {
-   // Do your stuff here
-
-   return $placements;
-}, 10, 2);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/editor_element_settings_placement', $elementPlacements, $form);`
-
-This filter is located in FluentForm\App\Modules\Registerer\Menu -> enqueueEditorAssets()
-
-</explain-block>
-
-<explain-block title="fluentform/conversational_editor_elements">
-
-You can modify conversational editor elements using this filter.
-
-**Parameters**
-
-- `$elements` (array) Conversational Editor Elements
-- `$formId` (int) Form ID
-
-**Usage**
-
-```php
-add_filter('fluentform/conversational_editor_elements', function ($elements, $formId) {
-    // Do your stuff here
-    
-    return $elements;
-}, 10, 1);
-
-```
-**Reference**
-
-`apply_filters('fluentform/conversational_editor_elements', $elements, $formId);`
-
-This filter is located in FluentForm\App\Modules\Widgets\EditorButtonModule -> pageSupportedMediaButtons()
-
-</explain-block>
-
-<explain-block title="'fluentform/input_data_' . $element">
-
-This filter returns the input labels for the Submission on the Submission page.
-
-**Parameters**
-
-- `$fieldData` (array) Form Data of the Field
-- `$field` (array) Field Data
-- `$formData` (array) Form Data
-- `$form` (object) Form Object
-
-**Usage**
-
-```php
-add_filter('fluentform/input_data_input_number', function ($fieldData, $field, $formData, $form) {
-    // Do your stuff here
-    $formatter = ArrayHelper::get($field, 'raw.settings.numeric_formatter');
-    if (!$formatter) {
-        return $value;
-    }
-        
-    return Helper::getNumericValue($value, $formatter);
-}, 10, 4);
-
-```
-**Reference**
-
-`apply_filters('fluentform/input_data_' . $element, $formData[$fieldName], $field, $formData, $this->form);`
-
-This filter is located in FluentForm\App\Services\Form\FormValidationService -> validateSubmission(&$fields, &$formData)
-
-</explain-block>
-
-<explain-block title="fluentform/before_render_item">
-
-You can use this filter to modify the form inputs before form render.
-
-**Parameters**
-
-- `$item` (array) Input Item
-- `$form` (object) Form Object
-
-**Usage**
-
-```php
-add_filter('fluentform/before_render_item', function ($item, $form) {
-    // Do your stuff here
-    
-    return $item;
-}, 10, 2);
-
-```
-**Reference**
-
-`apply_filters('fluentform/before_render_item',  $item, $form);`
-
-This filter is located in FluentForm\App\Services\FormBuilder -> buildFormBody($form)
-
-</explain-block>
-
-<explain-block title="fluentform/frontend_date_format">
-
-You can modify date formats to show in form frontend using the filter.
-
-**Parameters**
-
-- `$dateFormats` (array) Date formats Settings
-- `$settings` (array) Field Settings  
-- `$form` (object) Form Object  
-
-**Usage**
-
-```php
-add_filter('fluentform/frontend_date_format', function ($dateFormats, $settings, $form) {
-    // Do your stuff here
-    
-    return $dateFormats;
-}, 10, 3);
-
-```
-Date formats to filter:
-```php
-[
-    'dateFormat'    => $dateFormat,
-    'enableTime'    => $hasTime,
-    'noCalendar'    => ! $this->hasDate($dateFormat),
-    'disableMobile' => true,
-    'time_24hr'     => $time24,
-];
-```
-
-**Reference**
-
-`apply_filters('fluentform/frontend_date_format', $dateFormats, $settings, $form);`
-
-This filter is located in FluentForm\App\Services\FormBuilder\Components\DateTime -> getDateFormatConfigJSON($settings, $form)
-
-</explain-block>
-
-<explain-block title="'fluentform/is_hide_submit_btn_' . $form->id">
-
-You can hide / show submit button using the filter.
-
-**Parameters**
-
-- `$status` (boolean) Whether show / hide Submit Button
-
-**Usage**
-
-```php
-add_filter('fluentform/is_hide_submit_btn_' . $form->id, function ($status) {
-    // Do your stuff here
-    
-    return $status;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/is_hide_submit_btn_' . $form->id, false);`
-
-This filter is located in FluentForm\App\Services\FormBuilder\Components\SubmitButton -> compile($data, $form)
-
-</explain-block>
-
-<explain-block title="fluentform/submit_button_force_no_style">
-
-You can modify admin menu items using this filter.
-
-**Parameters**
-
-- `$permission` (array) Admin Permission Set
-- `$form_id` (int) Form ID
-- `$form` (object) Form Object
-
-**Usage**
-
-```php
-add_filter('fluentform/form_admin_menu', function($formAdminMenus, $form_id, $form) {
-   // Do your stuff here
-
-   return $formAdminMenus;
-}, 10, 3);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/form_admin_menu', $formAdminMenus, $form_id, $form);`
-
-This filter is located in FluentForm\App\Modules\Registerer\Menu -> renderFormInnerPages()
-
-</explain-block>
-
-<explain-block title="fluentform/submit_button_force_no_style">
-
-You can adjust submit button style to have no style using this filter.
-
-**Parameters**
-
-- `$status` (boolean) Whether the submit button style is active
-
-**Usage**
-
-```php
-add_filter('fluentform/submit_button_force_no_style', function($status) {
-   // Do your stuff here
-
-   return $status;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/submit_button_force_no_style', $status);`
-
-This filter is located in FluentForm\App\Services\FormBuilder\Components\SubmitButton -> compile($data, $form)
-
-</explain-block>
-
-<explain-block title="fluentform/disable_inputmode">
-
-You can disable text input field using the filter.
-
-**Parameters**
-
-- `$status` (boolean) Whether text input is disabled
-
-**Usage**
-
-```php
-add_filter('fluentform/disable_inputmode', function ($status) {
-   // Do your stuff here
-
-   return $status;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/disable_inputmode', $status);`
-
-This filter is located in FluentForm\App\Services\FormBuilder\Components\Text -> compile($data, $form)
-
-</explain-block>
-
-<explain-block title="fluentform/form_class">
-
-You can use this filter to modify a form CSS classes.
-
-**Parameters**
-
-- `$item` (array) Input Item
-- `$form` (object) Form Object
-
-**Usage**
-
-```php
-add_filter('fluentform/form_class', function ($css_class, $targetForm) use ($form) {
-    if ($targetForm->id == $form->id) {
-        $css_class .= ' ff_calc_form';
-    }
-    return $css_class;
-}, 10, 2);
-
-```
-**Reference**
-
-`apply_filters('fluentform/form_class', $formClass, $form);`
-
-This filter is located in FluentForm\App\Services\FormBuilder\FormBuilder -> build($form, $extraCssClass = '', $instanceCssClass = '', $atts = [])
-
-</explain-block>
-
-<explain-block title="fluentform/disable_accessibility_fieldset">
-
-You can use this filter to toggle form accessibility status and fieldset.
-
-**Parameters**
-
-- `$status` (boolean) Whether the accessibility status is enabled
-- `$form` (object) Form Object
-
-**Usage**
-
-```php
-add_filter('fluentform/disable_accessibility_fieldset', function ($status, $form) {
-    // Do your stuff here
-    
-    return $status;
-}, 10, 2);
-
-```
-**Reference**
-
-`apply_filters('fluentform/disable_accessibility_fieldset', true, $form);`
-
-This filter is located in FluentForm\App\Services\FormBuilder\FormBuilder -> build($form, $extraCssClass = '', $instanceCssClass = '', $atts = [])
-
-</explain-block>
-
-<explain-block title="fluentform/form_input_types">
-
-You can use this filter to add more form input types.
-
-**Parameters**
-
-- `$types` (array) Form Input Types
-
-**Usage**
-
-```php
-add_filter('fluentform/form_input_types', function ($types) {
-    // Do your stuff here
-    
-    return $types;
-}, 10, 1);
-
-```
-**Reference**
-
-`apply_filters('fluentform/form_input_types', $types);`
-
-This filter is located in FluentForm\App\Services\Parser\Form -> setInputTypes($types = [])
-
-</explain-block>
-
-<explain-block title="fluentform/form_payment_fields">
-
-You can use this filter to add more form payment input fields.
-
-**Parameters**
-
-- `$types` (array) Form Payment Input Types
-
-**Usage**
-
-```php
-add_filter('fluentform/form_payment_fields', function ($types) {
-    // Do your stuff here
-    
-    return $types;
-}, 10, 1);
-
-```
-**Reference**
-
-`apply_filters('fluentform/form_payment_fields', $types);`
-
-This filter is located in FluentForm\App\Services\Parser\Form -> hasPaymentFields()
-
-</explain-block>
-
-<explain-block title="fluentform/form_payment_inputs">
-
-You can use this filter to modify form payment input fields types
-
-**Parameters**
-
-- `$data` (array) Form Payment Input Types
-
-**Usage**
-
-```php
-add_filter('fluentform/form_payment_inputs', function ($data) {
-    // Do your stuff here
-    
-    return $data;
-}, 10, 1);
-
-```
-**Reference**
-
-`apply_filters('fluentform/form_payment_inputs', $data);`
-
-This filter is located in FluentForm\App\Services\Parser\Form -> getPaymentInputFields($with = ['element'])
-
-</explain-block>
-
-<explain-block title="fluentform/show_preview_promo">
-
-You can use this filter to toggle preview promo.
-
-**Parameters**
-
-- `$status` (boolean) Whether to show preview promo
-
-**Usage**
-
-```php
-add_filter('fluentform/show_preview_promo', function ($status) {
-    // Do your stuff here
-    
-    return $status;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/show_preview_promo', true);`
-
-This filter is located in FluentForm\app\views\frameless\template\show_preview.php
-
-</explain-block>
-
-<explain-block title="fluentform/rendering_form">
-
-This filter hook is fired before form render. You can use this to change rendered form.
-
-**Parameters**
-
-- `$form` (object) Form Object
-
-**Usage**
-
-```php
-add_filter('fluentform/rendering_form', function ($form) {
-    // Do your stuff here
-    
-    return $form;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/rendering_form', $form);`
-
-This filter is located in FluentForm\app\Modules\Component\Component -> renderForm($atts)
-
-</explain-block>
-
-<explain-block title="fluentform/submission_confirmation">
-
-This filter is available just before sending the success message to the user. You can use this filter hook to alter the form confirmation message and redirect settings dynamically.
-
-**Parameters**
-
-- `$returnData` (array) Submitted Data
-- `$form` (object) Form Object
-- `$confirmation` (array) Submission Confirmation Message
-- `$insertId` (int) Submission ID
 - `$formData` (array) Form Data
 
 **Usage**
 
 ```php
-add_filter('fluentform/submission_confirmation', function ($returnData, $form, $confirmation, $insertId, $formData) {
-    // Do your stuff here
-    
-    return $returnData;
-}, 10, 5);
+add_filter('fluentform/validations', function ($originalValidations, $form, $formData) {
+   // Do your stuff here
 
-```
-```php
-$returnData = [
-    'redirectUrl' => wp_sanitize_redirect(urldecode($redirectUrl)),
-    'message'     => $message,
-];
+   return $originalValidations;
+}, 10, 3);
+
 ```
 
 **Reference**
 
-`apply_filters('fluentform/submission_confirmation', $returnData, $form, $confirmation, $insertId, $formData);`
+` apply_filters('fluentform/validations', $originalValidations, $this->form, $formData);`
 
-This filter is located in FluentForm\app\Services\Form\SubmissionHandlerService -> getReturnData($insertId, $form, $formData)
+This filter is located in FluentForm\App\Services\Form -> validateSubmission(&$fields, &$formData)
 
 </explain-block>
-
-

--- a/src/hooks/filters/integration.md
+++ b/src/hooks/filters/integration.md
@@ -4,58 +4,30 @@
 
 These filters let you modify integration feeds, notification data, and third-party connections.
 
-<explain-block title="fluentform/global_notification_active_types">
+<explain-block title="fluentform/api_failed_log">
 
-This filter returns the active notification feeds for the current form ID.
+This filter checks the logging of the failed API calls for development environment status.
 
 **Parameters**
 
-- `$types` (array) Active Feeds
+- `$isDev` (boolean) Checks whether development environment is Dev or Production
+- `$form` (object) Form
+- `$feed` (array) Current Feed
 
 **Usage**
 
 ```php
-add_filter('fluentform/global_notification_active_types', function ($types) {
+add_filter('fluentform/api_failed_log', function($isDev, $form, $feed) {
    // Do your stuff here
-   $types['notifications'] = 'email_notifications';
-   return $types;
-}, 10, 1);
+   return $isDev;
+}, 10, 3);
 
 ```
-
 **Reference**
 
-`apply_filters('fluentform/global_notification_active_types', [], $form->id);`
+`apply_filters('fluentform/api_failed_log', $isDev, $form, $feed);`
 
-This filter is located in FluentForm\App\Hooks\Handlers\GlobalNotificationHandler -> globalNotify()
-
-</explain-block>
-
-<explain-block title="'fluentform/notifying_async_' . $integrationKey">
-
-This filter checks if the integration is asynchronous or not. If you are working on an integration you can return false to run the integration instantly.
-
-**Parameters**
-
-- `$status` (boolean) True / False
-- `$formId` (int) Form Id
-
-**Usage**
-
-```php
-add_filter('fluentform/notifying_async_' . $integrationKey, function ($status, $formId) {
-   // Do your stuff here
-   
-   return $status; 
-}, 10, 2);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/notifying_async_' . $integrationKey, true, $form->id);`
-
-This filter is located in FluentForm\App\Hooks\Handlers\GlobalNotificationHandler -> globalNotify()
+This filter is located in FluentForm\App\Hooks\actions.php
 
 </explain-block>
 
@@ -87,30 +59,131 @@ This filter is located in FluentForm\App\Hooks\actions.php
 
 </explain-block>
 
-<explain-block title="fluentform/api_failed_log">
+<explain-block title="fluentform/failed_integration_email_body">
 
-This filter checks the logging of the failed API calls for development environment status.
+<Badge type="tip" vertical="top" text="Pro" />
 
 **Parameters**
 
-- `$isDev` (boolean) Checks whether development environment is Dev or Production
-- `$form` (object) Form
-- `$feed` (array) Current Feed
+- `$emailBody` — see source
+- `$data` — see source
 
 **Usage**
 
 ```php
-add_filter('fluentform/api_failed_log', function($isDev, $form, $feed) {
-   // Do your stuff here
-   return $isDev;
-}, 10, 3);
+add_filter('fluentform/failed_integration_email_body', function ($emailBody, $data) {
+    return $emailBody;
+}, 10, 2);
+```
+
+**Reference**
+
+`$emailBody = apply_filters('fluentform/failed_integration_email_body', $emailBody, $data);`
+
+This filter is located in `src/classes/FailedIntegrationNotification.php` (line 143).
+
+</explain-block>
+
+<explain-block title="fluentform/failed_integration_email_subject">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$emailSubject` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/failed_integration_email_subject', function ($emailSubject) {
+    return $emailSubject;
+}, 10, 1);
+```
+
+**Reference**
+
+`$emailSubject = apply_filters('fluentform/failed_integration_email_subject', $emailSubject);`
+
+This filter is located in `src/classes/FailedIntegrationNotification.php` (line 164).
+
+</explain-block>
+
+<explain-block title="fluentform/failed_integration_notification_time_gap">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$value` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/failed_integration_notification_time_gap', function ($value) {
+    return $value;
+}, 10, 1);
+```
+
+**Reference**
+
+`$time = apply_filters('fluentform/failed_integration_notification_time_gap', 3600);// set time by default 1 hour gap`
+
+This filter is located in `src/classes/FailedIntegrationNotification.php` (line 177).
+
+</explain-block>
+
+<explain-block title="fluentform/get_available_form_integrations">
+
+You can use this filter to modify all available integrations.
+
+**Parameters**
+
+- `$availableIntegrations` (array) All Available Integrations
+- `$formId` (int) Form ID
+
+**Usage**
+
+```php
+add_filter('fluentform/get_available_form_integrations', function ($availableIntegrations, $formId) {
+    // Do your stuff here
+    
+    return $availableIntegrations;
+}, 10, 2);
 
 ```
 **Reference**
 
-`apply_filters('fluentform/api_failed_log', $isDev, $form, $feed);`
+`apply_filters('fluentform/get_available_form_integrations', $availableIntegrations, $formId);`
 
-This filter is located in FluentForm\App\Hooks\actions.php
+This filter is located in FluentForm\App\Services\Integration\GlobalIntegrationManager -> getAllFormIntegrations()
+
+</explain-block>
+
+<explain-block title="'fluentform/get_integration_defaults_' . $integrationName">
+
+You can tweak integration default settings using the filter.
+
+**Parameters**
+
+- `$settings` (array) Integration Settings
+- `$formId` (int) Form ID
+
+**Usage**
+
+```php
+add_filter('fluentform/get_integration_values_' . $integrationName, function ($settings, $formId) {
+   // Do your stuff here
+
+   return $settings;
+}, 10, 2);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/get_integration_defaults_' . $integrationName, $settings, $formId);`
+
+This filter is located in FluentForm\App\Services\Integrations\GlobalIntegrationManager -> getIntegrationSettings()
 
 </explain-block>
 
@@ -148,143 +221,25 @@ This filter is located in FluentForm\App\Https\Controllers\FormIntegrationContro
 
 </explain-block>
 
-<explain-block title="fluentform/validation_user_registration_errors">
-
-This filter return user registration validation error before submission.
+<explain-block title="fluentform/get_integration_settings_fields_">
 
 **Parameters**
 
-- `$errors` (array) Errors
-- `$formData` (array) Form Data
-- `$form` (Object) Form Object
-- `$fields` (array) Form Fields
+- See source
 
 **Usage**
 
 ```php
-add_filter('fluentform/validation_user_registration_errors', function($errors, $formData, $form, $fields) {
-   // Do your stuff here
-
-   return $errors;
-}, 10, 4);
-
-```
-**Reference**
-
-`apply_filters('fluentform/validation_user_registration_errors', $errors, $formData, $this->form, $fields);`
-
-This filter is located in FluentForm\App\Services\Form\FormValidationService -> validateSubmission(&$fields, &$formData)
-
-</explain-block>
-
-<explain-block title="fluentform/validation_user_update_errors">
-
-This filter return user update validation error before submission.
-
-**Parameters**
-
-- `$errors` (array) Errors
-- `$formData` (array) Form Data
-- `$form` (Object) Form Object
-- `$fields` (array) Form Fields
-
-**Usage**
-
-```php
-add_filter('fluentform/validation_user_update_errors', function($errors, $formData, $form, $fields) {
-   // Do your stuff here
-
-   return $errors;
-}, 10, 4);
-
-```
-**Reference**
-
-`apply_filters('fluentform/validation_user_update_errors', $errors, $formData, $this->form, $fields);`
-
-This filter is located in FluentForm\App\Services\Form\FormValidationService -> validateSubmission(&$fields, &$formData)
-
-</explain-block>
-
-<explain-block title="fluentform/mailchimp_keep_existing_interests">
-
-You can modify double optin status to keep existing interest in mailchimp using the filter.
-
-**Parameters**
-
-- `$status` (string) Whether the Double Optin is pending or subscribed
-- `$formId` (int) Form ID
-
-**Usage**
-
-```php
-add_filter('fluentform/mailchimp_keep_existing_interests', function ($status, $formId) {
-   // Do your stuff here
-
-   return $status;
-}, 10, 2);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/mailchimp_keep_existing_interests', $status, $form->id);`
-
-This filter is located in FluentForm\App\Services\Integration\MailChimp\MailChimpSubscriber -> subscribe($feed, $formData, $entry, $form)
-
-</explain-block>
-
-<explain-block title="fluentform/mailchimp_keep_existing_tags">
-
-You can modify to keep existing tags in mailchimp using the filter.
-
-**Parameters**
-
-- `$status` (boolean) Whether the status is true or false
-- `$formId` (int) Form ID
-
-**Usage**
-
-```php
-add_filter('fluentform/mailchimp_keep_existing_tags', function ($status, $formId) {
-   // Do your stuff here
-
-   return $status;
-}, 10, 2);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/mailchimp_keep_existing_tags', true, $form->id);`
-
-This filter is located in FluentForm\App\Services\Integration\MailChimp\MailChimpSubscriber -> subscribe($feed, $formData, $entry, $form)
-
-</explain-block>
-
-<explain-block title="fluentform/mailchimp_api_timeout">
-
-This filter allows you to modify the timeout value for MailChimp API requests.
-
-**Parameters**
-
-- `$timeout` (int) The default timeout value in seconds
-
-**Usage**
-
-```php
-add_filter('fluentform/mailchimp_api_timeout', function ($timeout) {
-   // Do your stuff here
-   // Increase timeout for slow connections
-   return 60; // 60 seconds
+add_filter('fluentform/get_integration_settings_fields_', function ($value) {
+    return $value;
 }, 10, 1);
 ```
 
 **Reference**
 
-`apply_filters('fluentform/mailchimp_api_timeout', $timeout);`
+`$settingsFields = apply_filters('fluentform/get_integration_settings_fields_' . $integrationName, $settings, $formId, $settings);`
 
-This filter is located in `FluentForm\App\Services\Integrations\MailChimp\MailChimp` -> `makeRequest()`
+This filter is located in `app/Services/Integrations/FormIntegrationService.php` (line 93).
 
 </explain-block>
 
@@ -314,224 +269,6 @@ add_filter('fluentform/get_integration_values_' . $integrationName, function ($s
 `apply_filters('fluentform/get_integration_values_' . $integrationName, $settings, $feed, $formId);`
 
 This filter is located in FluentForm\App\Services\Integrations\GlobalIntegrationManager -> getIntegrationSettings()
-
-</explain-block>
-
-<explain-block title="'fluentform/get_integration_defaults_' . $integrationName">
-
-You can tweak integration default settings using the filter.
-
-**Parameters**
-
-- `$settings` (array) Integration Settings
-- `$formId` (int) Form ID
-
-**Usage**
-
-```php
-add_filter('fluentform/get_integration_values_' . $integrationName, function ($settings, $formId) {
-   // Do your stuff here
-
-   return $settings;
-}, 10, 2);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/get_integration_defaults_' . $integrationName, $settings, $formId);`
-
-This filter is located in FluentForm\App\Services\Integrations\GlobalIntegrationManager -> getIntegrationSettings()
-
-</explain-block>
-
-<explain-block title="'fluentform/save_integration_value_' . $integrationName">
-
-You can modify integration mapped form value before saving it to the database using the filter.
-
-**Parameters**
-
-- `$integration` (array) Integration Settings
-- `$integrationId` (int) Integration ID
-- `$formId` (int) Form ID
-
-**Usage**
-
-```php
-add_filter('fluentform/save_integration_value_' . $integrationName, function ($integration, $integrationId, $formId) {
-   // Do your stuff here
-
-   return $integration;
-}, 10, 3);
-
-```
-```php 
-add_filter('fluentform/save_integration_value_mailchimp', [$this, 'sanitizeSettings'], 10, 3);
-
-public function sanitizeSettings($integration, $integrationId, $formId)
-{
-    if (fluentformCanUnfilteredHTML()) {
-        return $integration;
-    }
-    $sanitizeMap = [
-        'status'                 => 'rest_sanitize_boolean',
-        'enabled'                => 'rest_sanitize_boolean',
-        'type'                   => 'sanitize_text_field',
-        'list_id'                => 'sanitize_text_field',
-        'list_name'              => 'sanitize_text_field',
-        'name'                   => 'sanitize_text_field',
-        'tags'                   => 'sanitize_text_field',
-        'tag_ids_selection_type' => 'sanitize_text_field',
-        'fieldEmailAddress'      => 'sanitize_text_field',
-        'doubleOptIn'            => 'rest_sanitize_bolean',
-        'resubscribe'            => 'rest_sanitize_bolean',
-        'note'                   => 'sanitize_text_field',
-    ];
-    
-    return fluentform_backend_sanitizer($integration, $sanitizeMap);
-}
-```
-
-**Reference**
-
-`apply_filters('fluentform/save_integration_value_' . $integrationName, $integration, $integrationId, $formId);`
-
-This filter is located in FluentForm\App\Services\Integrations\GlobalIntegrationManager -> saveIntegrationSettings()
-
-</explain-block>
-
-<explain-block title="'fluentform/save_integration_value_' . $integrationName">
-
-You can modify integration settings value before saving it to the database using the filter.
-
-**Parameters**
-
-- `$data` (array) Integration Settings
-- `$integrationId` (int) Integration ID
-
-**Usage**
-
-```php
-add_filter('fluentform/save_integration_value_' . $integrationName, function ($data, $integrationId) {
-   // Do your stuff here
-
-   return $data;
-}, 10, 2);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/save_integration_value_' . $integrationName, $data, $integrationId);`
-
-This filter is located in FluentForm\App\Services\Integrations\GlobalIntegrationManager -> saveIntegrationSettings()
-
-</explain-block>
-
-<explain-block title="fluentform/global_notification_types">
-
-You can use this filter to modify all global notifications keys.
-
-**Parameters**
-
-- `$notificationKeys` (array) Global Notification Keys
-- `$formId` (int) Form ID
-
-**Usage**
-
-```php
-add_filter('fluentform/global_notification_types', function ($notificationKeys, $formId) {
-    // Do your stuff here
-    
-    return $notificationKeys;
-}, 10, 2);
-
-```
-**Reference**
-
-`apply_filters('fluentform/global_notification_types', $notificationKeys, $formId);`
-
-This filter is located in FluentForm\App\Services\Integration\GlobalIntegrationManager -> getAllFormIntegrations()
-
-</explain-block>
-
-<explain-block title="'fluentform/global_notification_feed_' . $feed->meta_key">
-
-You can use this filter to modify global notifications feed data.
-
-**Parameters**
-
-- `$feedData` (array) Mapped Form Data
-- `$formId` (int) Form ID
-
-**Usage**
-
-```php
-add_filter('fluentform/global_notification_feed_' . $feed->meta_key, function ($feedData, $formId) {
-    // Do your stuff here
-    
-    return $feedData;
-}, 10, 2);
-
-```
-**Reference**
-
-`apply_filters('fluentform/global_notification_feed_' . $feed->meta_key, $feedData, $formId);`
-
-This filter is located in FluentForm\App\Services\Integration\GlobalIntegrationManager -> getNotificationFeeds($formId)
-
-</explain-block>
-
-<explain-block title="fluentform/get_available_form_integrations">
-
-You can use this filter to modify all available integrations.
-
-**Parameters**
-
-- `$availableIntegrations` (array) All Available Integrations
-- `$formId` (int) Form ID
-
-**Usage**
-
-```php
-add_filter('fluentform/get_available_form_integrations', function ($availableIntegrations, $formId) {
-    // Do your stuff here
-    
-    return $availableIntegrations;
-}, 10, 2);
-
-```
-**Reference**
-
-`apply_filters('fluentform/get_available_form_integrations', $availableIntegrations, $formId);`
-
-This filter is located in FluentForm\App\Services\Integration\GlobalIntegrationManager -> getAllFormIntegrations()
-
-</explain-block>
-
-<explain-block title="'fluentform/global_integration_settings_' . $settingsKey">
-
-You can use this filter to modify all integration field settings.
-
-**Parameters**
-
-- `$settings` (array) All Available Integrations Field Settings
-
-**Usage**
-
-```php
-add_filter('fluentform/global_integration_settings_' . $settingsKey, function ($settings) {
-    // Do your stuff here
-    
-    return $settings;
-}, 10, 1);
-
-```
-**Reference**
-
-`apply_filters('fluentform/global_integration_settings_' . $settingsKey', $settings);`
-
-This filter is located in FluentForm\App\Services\Integration\GlobalIntegrationManager -> getGlobalSettingsAjax()
 
 </explain-block>
 
@@ -569,59 +306,132 @@ This filter is located in FluentForm\app\Modules\AddOnModules -> showFluentAddOn
 
 </explain-block>
 
-<explain-block title="'fluentform/integration_data_' . $this->integrationKey">
-
-You can modify any integration data through valid integration key before form submission by using this filter.
+<explain-block title="fluentform/global_integration_fields_">
 
 **Parameters**
 
-- `$addData` (array) Submitted Data
-- `$feed` (array) Form Feed
-- `$entry` (array) Submission
+- See source
 
 **Usage**
 
 ```php
-add_filter('fluentform/integration_data_' . $this->integrationKey, function ($addData, $feed, $entry) {
-    // Do your stuff here
-    
-    return $addData;
-}, 10, 3);
-
+add_filter('fluentform/global_integration_fields_', function ($value) {
+    return $value;
+}, 10, 1);
 ```
 
 **Reference**
 
-`apply_filters('fluentform/integration_data_' . $this->integrationKey, $addData, $feed, $entry);`
+`$fieldSettings = apply_filters('fluentform/global_integration_fields_' . $settingsKey, $fieldSettings);`
 
-This filter is located in FluentFormPro\src\Integrations\ActiveCampaign\Bootstrap -> notify($feed, $formData, $entry, $form)
+This filter is located in `app/Services/Integrations/GlobalIntegrationService.php` (line 32).
 
 </explain-block>
 
-<explain-block title="fluentform/integration_constantcontact_action_by">
+<explain-block title="'fluentform/global_integration_settings_' . $settingsKey">
 
-You can edit constant contact API url action using the filter.
+You can use this filter to modify all integration field settings.
 
 **Parameters**
 
-- `$actionName` (array) Action Name
+- `$settings` (array) All Available Integrations Field Settings
 
 **Usage**
 
 ```php
-add_filter('fluentform/integration_constantcontact_action_by', function ($actionName) {
+add_filter('fluentform/global_integration_settings_' . $settingsKey, function ($settings) {
     // Do your stuff here
     
-    return $actionName;
+    return $settings;
+}, 10, 1);
+
+```
+**Reference**
+
+`apply_filters('fluentform/global_integration_settings_' . $settingsKey', $settings);`
+
+This filter is located in FluentForm\App\Services\Integration\GlobalIntegrationManager -> getGlobalSettingsAjax()
+
+</explain-block>
+
+<explain-block title="fluentform/global_notification_active_types">
+
+This filter returns the active notification feeds for the current form ID.
+
+**Parameters**
+
+- `$types` (array) Active Feeds
+
+**Usage**
+
+```php
+add_filter('fluentform/global_notification_active_types', function ($types) {
+   // Do your stuff here
+   $types['notifications'] = 'email_notifications';
+   return $types;
 }, 10, 1);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/integration_constantcontact_action_by', $actionName);`
+`apply_filters('fluentform/global_notification_active_types', [], $form->id);`
 
-This filter is located in FluentFormPro\src\Integrations\ConstantContact\API -> getApiUrl($resource)
+This filter is located in FluentForm\App\Hooks\Handlers\GlobalNotificationHandler -> globalNotify()
+
+</explain-block>
+
+<explain-block title="'fluentform/global_notification_feed_' . $feed->meta_key">
+
+You can use this filter to modify global notifications feed data.
+
+**Parameters**
+
+- `$feedData` (array) Mapped Form Data
+- `$formId` (int) Form ID
+
+**Usage**
+
+```php
+add_filter('fluentform/global_notification_feed_' . $feed->meta_key, function ($feedData, $formId) {
+    // Do your stuff here
+    
+    return $feedData;
+}, 10, 2);
+
+```
+**Reference**
+
+`apply_filters('fluentform/global_notification_feed_' . $feed->meta_key, $feedData, $formId);`
+
+This filter is located in FluentForm\App\Services\Integration\GlobalIntegrationManager -> getNotificationFeeds($formId)
+
+</explain-block>
+
+<explain-block title="fluentform/global_notification_types">
+
+You can use this filter to modify all global notifications keys.
+
+**Parameters**
+
+- `$notificationKeys` (array) Global Notification Keys
+- `$formId` (int) Form ID
+
+**Usage**
+
+```php
+add_filter('fluentform/global_notification_types', function ($notificationKeys, $formId) {
+    // Do your stuff here
+    
+    return $notificationKeys;
+}, 10, 2);
+
+```
+**Reference**
+
+`apply_filters('fluentform/global_notification_types', $notificationKeys, $formId);`
+
+This filter is located in FluentForm\App\Services\Integration\GlobalIntegrationManager -> getAllFormIntegrations()
 
 </explain-block>
 
@@ -685,6 +495,88 @@ This filter is located in FluentFormPro\src\Integrations\IContact\IContactApi ->
 
 </explain-block>
 
+<explain-block title="fluentform/integration_constantcontact_action_by">
+
+You can edit constant contact API url action using the filter.
+
+**Parameters**
+
+- `$actionName` (array) Action Name
+
+**Usage**
+
+```php
+add_filter('fluentform/integration_constantcontact_action_by', function ($actionName) {
+    // Do your stuff here
+    
+    return $actionName;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/integration_constantcontact_action_by', $actionName);`
+
+This filter is located in FluentFormPro\src\Integrations\ConstantContact\API -> getApiUrl($resource)
+
+</explain-block>
+
+<explain-block title="'fluentform/integration_data_' . $this->integrationKey">
+
+You can modify any integration data through valid integration key before form submission by using this filter.
+
+**Parameters**
+
+- `$addData` (array) Submitted Data
+- `$feed` (array) Form Feed
+- `$entry` (array) Submission
+
+**Usage**
+
+```php
+add_filter('fluentform/integration_data_' . $this->integrationKey, function ($addData, $feed, $entry) {
+    // Do your stuff here
+    
+    return $addData;
+}, 10, 3);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/integration_data_' . $this->integrationKey, $addData, $feed, $entry);`
+
+This filter is located in FluentFormPro\src\Integrations\ActiveCampaign\Bootstrap -> notify($feed, $formData, $entry, $form)
+
+</explain-block>
+
+<explain-block title="fluentform/integration_data_zapier">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$payload` — see source
+- `$feed` — see source
+- `$entry` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/integration_data_zapier', function ($payload, $feed, $entry) {
+    return $payload;
+}, 10, 3);
+```
+
+**Reference**
+
+`$payload = apply_filters('fluentform/integration_data_zapier', $payload, $feed, $entry);`
+
+This filter is located in `src/Integrations/Zapier/NotifyTrait.php` (line 34).
+
+</explain-block>
+
 <explain-block title="fluentform/integration_discord_message">
 
 You can modify discord message arguments using the filter.
@@ -727,6 +619,31 @@ $messageArgs = [
 `apply_filters('fluentform/integration_discord_message', $messageArgs, $feed);`
 
 This filter is located in FluentFormPro\src\Integrations\Discord\Bootstrap -> notify($feed, $formData, $entry, $form)
+
+</explain-block>
+
+<explain-block title="fluentform/integration_feed_before_parse">
+
+**Parameters**
+
+- `$feed` — see source
+- `$insertId` — see source
+- `$formData` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/integration_feed_before_parse', function ($feed, $insertId, $formData, $form) {
+    return $feed;
+}, 10, 4);
+```
+
+**Reference**
+
+`$feed = apply_filters('fluentform/integration_feed_before_parse', $feed, $insertId, $formData, $form);`
+
+This filter is located in `app/Hooks/Handlers/GlobalNotificationHandler.php` (line 103).
 
 </explain-block>
 
@@ -824,5 +741,296 @@ add_filter('fluentform/inventory_validation_error', function ($stockOutMsg, $fie
 `apply_filters('fluentform/inventory_validation_error', $stockOutMsg, $fieldName, $item, $this->formData, $this->form);`
 
 This filter is located in FluentFormPro\src\classes\Inventory\InventoryValidation -> validate()
+
+</explain-block>
+
+<explain-block title="fluentform/is_integration_enabled_">
+
+**Parameters**
+
+- See source
+
+**Usage**
+
+```php
+add_filter('fluentform/is_integration_enabled_', function ($value) {
+    return $value;
+}, 10, 1);
+```
+
+**Reference**
+
+`return apply_filters('fluentform/is_integration_enabled_'.$integrationKey, $isEnabled);`
+
+This filter is located in `app/Services/Integrations/GlobalIntegrationService.php` (line 66).
+
+</explain-block>
+
+<explain-block title="fluentform/mailchimp_api_timeout">
+
+This filter allows you to modify the timeout value for MailChimp API requests.
+
+**Parameters**
+
+- `$timeout` (int) The default timeout value in seconds
+
+**Usage**
+
+```php
+add_filter('fluentform/mailchimp_api_timeout', function ($timeout) {
+   // Do your stuff here
+   // Increase timeout for slow connections
+   return 60; // 60 seconds
+}, 10, 1);
+```
+
+**Reference**
+
+`apply_filters('fluentform/mailchimp_api_timeout', $timeout);`
+
+This filter is located in `FluentForm\App\Services\Integrations\MailChimp\MailChimp` -> `makeRequest()`
+
+</explain-block>
+
+<explain-block title="fluentform/mailchimp_keep_existing_interests">
+
+You can modify double optin status to keep existing interest in mailchimp using the filter.
+
+**Parameters**
+
+- `$status` (string) Whether the Double Optin is pending or subscribed
+- `$formId` (int) Form ID
+
+**Usage**
+
+```php
+add_filter('fluentform/mailchimp_keep_existing_interests', function ($status, $formId) {
+   // Do your stuff here
+
+   return $status;
+}, 10, 2);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/mailchimp_keep_existing_interests', $status, $form->id);`
+
+This filter is located in FluentForm\App\Services\Integration\MailChimp\MailChimpSubscriber -> subscribe($feed, $formData, $entry, $form)
+
+</explain-block>
+
+<explain-block title="fluentform/mailchimp_keep_existing_tags">
+
+You can modify to keep existing tags in mailchimp using the filter.
+
+**Parameters**
+
+- `$status` (boolean) Whether the status is true or false
+- `$formId` (int) Form ID
+
+**Usage**
+
+```php
+add_filter('fluentform/mailchimp_keep_existing_tags', function ($status, $formId) {
+   // Do your stuff here
+
+   return $status;
+}, 10, 2);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/mailchimp_keep_existing_tags', true, $form->id);`
+
+This filter is located in FluentForm\App\Services\Integration\MailChimp\MailChimpSubscriber -> subscribe($feed, $formData, $entry, $form)
+
+</explain-block>
+
+<explain-block title="'fluentform/notifying_async_' . $integrationKey">
+
+This filter checks if the integration is asynchronous or not. If you are working on an integration you can return false to run the integration instantly.
+
+**Parameters**
+
+- `$status` (boolean) True / False
+- `$formId` (int) Form Id
+
+**Usage**
+
+```php
+add_filter('fluentform/notifying_async_' . $integrationKey, function ($status, $formId) {
+   // Do your stuff here
+   
+   return $status; 
+}, 10, 2);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/notifying_async_' . $integrationKey, true, $form->id);`
+
+This filter is located in FluentForm\App\Hooks\Handlers\GlobalNotificationHandler -> globalNotify()
+
+</explain-block>
+
+<explain-block title="fluentform/save_integration_settings_">
+
+**Parameters**
+
+- See source
+
+**Usage**
+
+```php
+add_filter('fluentform/save_integration_settings_', function ($value) {
+    return $value;
+}, 10, 1);
+```
+
+**Reference**
+
+`$data = apply_filters('fluentform/save_integration_settings_' . $integrationName, $data, $integrationId);`
+
+This filter is located in `app/Services/Integrations/FormIntegrationService.php` (line 162).
+
+</explain-block>
+
+<explain-block title="'fluentform/save_integration_value_' . $integrationName">
+
+You can modify integration mapped form value before saving it to the database using the filter.
+
+**Parameters**
+
+- `$integration` (array) Integration Settings
+- `$integrationId` (int) Integration ID
+- `$formId` (int) Form ID
+
+**Usage**
+
+```php
+add_filter('fluentform/save_integration_value_' . $integrationName, function ($integration, $integrationId, $formId) {
+   // Do your stuff here
+
+   return $integration;
+}, 10, 3);
+
+```
+```php 
+add_filter('fluentform/save_integration_value_mailchimp', [$this, 'sanitizeSettings'], 10, 3);
+
+public function sanitizeSettings($integration, $integrationId, $formId)
+{
+    if (fluentformCanUnfilteredHTML()) {
+        return $integration;
+    }
+    $sanitizeMap = [
+        'status'                 => 'rest_sanitize_boolean',
+        'enabled'                => 'rest_sanitize_boolean',
+        'type'                   => 'sanitize_text_field',
+        'list_id'                => 'sanitize_text_field',
+        'list_name'              => 'sanitize_text_field',
+        'name'                   => 'sanitize_text_field',
+        'tags'                   => 'sanitize_text_field',
+        'tag_ids_selection_type' => 'sanitize_text_field',
+        'fieldEmailAddress'      => 'sanitize_text_field',
+        'doubleOptIn'            => 'rest_sanitize_bolean',
+        'resubscribe'            => 'rest_sanitize_bolean',
+        'note'                   => 'sanitize_text_field',
+    ];
+    
+    return fluentform_backend_sanitizer($integration, $sanitizeMap);
+}
+```
+
+**Reference**
+
+`apply_filters('fluentform/save_integration_value_' . $integrationName, $integration, $integrationId, $formId);`
+
+This filter is located in FluentForm\App\Services\Integrations\GlobalIntegrationManager -> saveIntegrationSettings()
+
+</explain-block>
+
+<explain-block title="fluentform/slack_field_label_selection">
+
+**Parameters**
+
+- `$labels` — see source
+- `$settings` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/slack_field_label_selection', function ($labels, $settings, $form) {
+    return $labels;
+}, 10, 3);
+```
+
+**Reference**
+
+`$labels = apply_filters('fluentform/slack_field_label_selection', $labels, $settings, $form);`
+
+This filter is located in `app/Services/Integrations/Slack/Slack.php` (line 49).
+
+</explain-block>
+
+<explain-block title="fluentform/validation_user_registration_errors">
+
+This filter return user registration validation error before submission.
+
+**Parameters**
+
+- `$errors` (array) Errors
+- `$formData` (array) Form Data
+- `$form` (Object) Form Object
+- `$fields` (array) Form Fields
+
+**Usage**
+
+```php
+add_filter('fluentform/validation_user_registration_errors', function($errors, $formData, $form, $fields) {
+   // Do your stuff here
+
+   return $errors;
+}, 10, 4);
+
+```
+**Reference**
+
+`apply_filters('fluentform/validation_user_registration_errors', $errors, $formData, $this->form, $fields);`
+
+This filter is located in FluentForm\App\Services\Form\FormValidationService -> validateSubmission(&$fields, &$formData)
+
+</explain-block>
+
+<explain-block title="fluentform/validation_user_update_errors">
+
+This filter return user update validation error before submission.
+
+**Parameters**
+
+- `$errors` (array) Errors
+- `$formData` (array) Form Data
+- `$form` (Object) Form Object
+- `$fields` (array) Form Fields
+
+**Usage**
+
+```php
+add_filter('fluentform/validation_user_update_errors', function($errors, $formData, $form, $fields) {
+   // Do your stuff here
+
+   return $errors;
+}, 10, 4);
+
+```
+**Reference**
+
+`apply_filters('fluentform/validation_user_update_errors', $errors, $formData, $this->form, $fields);`
+
+This filter is located in FluentForm\App\Services\Form\FormValidationService -> validateSubmission(&$fields, &$formData)
 
 </explain-block>

--- a/src/hooks/filters/messages.md
+++ b/src/hooks/filters/messages.md
@@ -1,0 +1,255 @@
+# Messages Filters
+
+<Badge type="tip" vertical="top" text="Filter Hooks" /> <Badge type="warning" vertical="top" text="11 Filters" />
+
+<explain-block title="fluentform/address_autocomplete_messages">
+
+**Parameters**
+
+- `$globalAddressMessages` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/address_autocomplete_messages', function ($globalAddressMessages, $form) {
+    return $globalAddressMessages;
+}, 10, 2);
+```
+
+**Reference**
+
+`$globalAddressMessages = apply_filters('fluentform/address_autocomplete_messages', $globalAddressMessages, $form);`
+
+This filter is located in `app/Modules/Component/Component.php` (line 710).
+
+</explain-block>
+
+<explain-block title="fluentform/country_restriction_message">
+
+**Parameters**
+
+- `$value` — see source
+- `$this` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/country_restriction_message', function ($value, $this) {
+    return $value;
+}, 10, 2);
+```
+
+**Reference**
+
+`$message = apply_filters('fluentform/country_restriction_message', Arr::get($settings, 'fields.country.message', $defaultMessage), $this->form);`
+
+This filter is located in `app/Services/Form/FormValidationService.php` (line 822).
+
+</explain-block>
+
+<explain-block title="fluentform/deny_empty_submission_message">
+
+**Parameters**
+
+- `$customMessage` — see source
+- `$this` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/deny_empty_submission_message', function ($customMessage, $this) {
+    return $customMessage;
+}, 10, 2);
+```
+
+**Reference**
+
+`$customMessage = fluentform_sanitize_html(apply_filters('fluentform/deny_empty_submission_message', $customMessage, $this->form));`
+
+This filter is located in `app/Services/Form/FormValidationService.php` (line 333).
+
+</explain-block>
+
+<explain-block title="fluentform/form_requires_login_message">
+
+**Parameters**
+
+- `$restrictions` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/form_requires_login_message', function ($restrictions, $form) {
+    return $restrictions;
+}, 10, 2);
+```
+
+**Reference**
+
+`$isRenderable['message'] = apply_filters('fluentform/form_requires_login_message', $restrictions['requireLoginMsg'], $form);`
+
+This filter is located in `app/Modules/Component/Component.php` (line 1124).
+
+</explain-block>
+
+<explain-block title="fluentform/form_save_progress_messages">
+
+**Parameters**
+
+- `$saveProgressMessages` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/form_save_progress_messages', function ($saveProgressMessages, $form) {
+    return $saveProgressMessages;
+}, 10, 2);
+```
+
+**Reference**
+
+`$saveProgressMessages = apply_filters('fluentform/form_save_progress_messages', $saveProgressMessages, $form);`
+
+This filter is located in `app/Modules/Component/Component.php` (line 1536).
+
+</explain-block>
+
+<explain-block title="fluentform/form_submission_messages">
+
+**Parameters**
+
+- `$globalMessages` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/form_submission_messages', function ($globalMessages, $form) {
+    return $globalMessages;
+}, 10, 2);
+```
+
+**Reference**
+
+`$globalMessages = apply_filters('fluentform/form_submission_messages', $globalMessages, $form);`
+
+This filter is located in `app/Modules/Component/Component.php` (line 699).
+
+</explain-block>
+
+<explain-block title="fluentform/ip_restriction_message">
+
+**Parameters**
+
+- `$value` — see source
+- `$this` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/ip_restriction_message', function ($value, $this) {
+    return $value;
+}, 10, 2);
+```
+
+**Reference**
+
+`$message = apply_filters('fluentform/ip_restriction_message', Arr::get($settings, 'fields.ip.message', $defaultMessage), $this->form);`
+
+This filter is located in `app/Services/Form/FormValidationService.php` (line 801).
+
+</explain-block>
+
+<explain-block title="fluentform/keyword_restriction_message">
+
+**Parameters**
+
+- `$value` — see source
+- `$this` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/keyword_restriction_message', function ($value, $this) {
+    return $value;
+}, 10, 2);
+```
+
+**Reference**
+
+`$message = apply_filters('fluentform/keyword_restriction_message', Arr::get($settings, 'fields.keywords.message', $defaultMessage), $this->form);`
+
+This filter is located in `app/Services/Form/FormValidationService.php` (line 852).
+
+</explain-block>
+
+<explain-block title="fluentform/schedule_form_expired_message">
+
+**Parameters**
+
+- `$restrictions` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/schedule_form_expired_message', function ($restrictions, $form) {
+    return $restrictions;
+}, 10, 2);
+```
+
+**Reference**
+
+`$isRenderable['message'] = apply_filters('fluentform/schedule_form_expired_message', $restrictions['expiredMsg'], $form->id);`
+
+This filter is located in `app/Modules/Component/Component.php` (line 1094).
+
+</explain-block>
+
+<explain-block title="fluentform/schedule_form_pending_message">
+
+**Parameters**
+
+- `$restrictions` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/schedule_form_pending_message', function ($restrictions, $form) {
+    return $restrictions;
+}, 10, 2);
+```
+
+**Reference**
+
+`$isRenderable['message'] = apply_filters('fluentform/schedule_form_pending_message', $restrictions['pendingMsg'], $form->id);`
+
+This filter is located in `app/Modules/Component/Component.php` (line 1089).
+
+</explain-block>
+
+<explain-block title="fluentform/unpublished_form_submission_message">
+
+**Parameters**
+
+- `$message` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/unpublished_form_submission_message', function ($message) {
+    return $message;
+}, 10, 1);
+```
+
+**Reference**
+
+`$isRenderable['message'] = apply_filters('fluentform/unpublished_form_submission_message',__('Invalid Form!', 'fluentform'));`
+
+This filter is located in `app/Modules/Component/Component.php` (line 1001).
+
+</explain-block>

--- a/src/hooks/filters/miscellaneous.md
+++ b/src/hooks/filters/miscellaneous.md
@@ -4,389 +4,25 @@
 
 These filters cover file uploads, analytics, permissions, shortcodes, and other general-purpose hooks.
 
-<explain-block title="fluentform/file_upload_options">
-
-You can change Fluent Forms default file upload location by using this filter.
+<explain-block title="fluentform/ajax_url">
 
 **Parameters**
 
-- `$locations` (array) File Upload Location
+- `$value` — see source
 
 **Usage**
 
 ```php
-add_filter('fluentform/file_upload_options', function ($locations){
-
-   // Do your stuff here
+add_filter('fluentform/ajax_url', function ($value) {
+    return $value;
 }, 10, 1);
 ```
 
 **Reference**
 
-`apply_filters('fluentform/file_upload_options', $locations);`
+`return apply_filters('fluentform/ajax_url', admin_url('admin-ajax.php'));`
 
-This filter is located in FluentForm\App\Helpers\Helper -> fileUploadLocations()
-
-</explain-block>
-
-<explain-block title="fluentform/skip_no_conflict">
-
-You can toggle the no conflict mode using this filter.
-
-**Parameters**
-
-- `$isConflict` (boolean) Whether no conflict mode is enabled
-
-**Usage**
-
-```php
-add_filter('fluentform/skip_no_conflict', function ($isSkip) {
-   // Do your stuff here
-   
-   return $isSkip;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/skip_no_conflict', $isSkip);`
-
-This filter is located in FluentForm\App\Hooks\actions.php
-
-</explain-block>
-
-<explain-block title="fluentform/permission_set">
-
-You can add or modify Fluentform Permission Set using this filter.
-
-**Parameters**
-
-- `$permissionSet` (array) Permission set
-
-**Usage**
-
-```php
-add_filter('fluentform/permission_set', function ($permissionSet) {
-   // Do your stuff here
-   
-   array_push($permissionSet, 'fluentform_dashboard_access');
-   return $permissionSet;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/permission_set', $data);`
-
-This filter is located in FluentForm\App\Modules\Acl -> getPermissionSet()
-
-</explain-block>
-
-<explain-block title="'fluentform/verify_user_permission_' . $permission">
-
-This filter verifies each permission.
-
-**Parameters**
-
-- `$allowed` (array) Form default Settings
-- `$formId` (int) Form ID
-
-**Usage**
-
-```php
-add_filter('fluentform/verify_user_permission_' . $permission, function ($allowed, $formId) {
-   // Do your stuff here
-
-   return $allowed;
-}, 10, 2);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/verify_user_permission_' . $permission, $allowed, $formId);`
-
-This filter is located in FluentForm\App\Modules\Acl -> hasPermission($permissions, $formId = false)
-
-</explain-block>
-
-<explain-block title="fluentform/current_user_capability">
-
-You can modify Current User Capability using this filter.
-
-**Parameters**
-
-- `$capability` (array) User Capabilities
-
-**Usage**
-
-```php
-add_filter('fluentform/current_user_capability', function ($capability) {
-   // Do your stuff here
-
-   return $capability;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/current_user_capability', static::$capability);`
-
-This filter is located in FluentForm\App\Modules\Acl -> getCurrentUserCapability()
-
-</explain-block>
-
-<explain-block title="fluentform/current_user_permissions">
-
-You can modify Current User Permission using this filter.
-
-**Parameters**
-
-- `$userPermissions` (array) Current User Permissions
-
-**Usage**
-
-```php
-add_filter('fluentform/current_user_permissions', function ($userPermissions) {
-   // Do your stuff here
-
-   return $userPermissions;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/current_user_permissions', $userPermissions);`
-
-This filter is located in FluentForm\App\Models\Form -> getUserPermissions($user = false)
-
-</explain-block>
-
-<explain-block title="fluentform/nonce_error">
-
-You can modify NONCE error message using this filter.
-
-**Parameters**
-
-- `$errorMessage` (string) Error Message
-
-**Usage**
-
-```php
-add_filter('fluentform/nonce_error', function ($errorMessage) {
-   // Do your stuff here
-
-   return $errorMessage;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/nonce_error', $message);`
-
-This filter is located in FluentForm\App\Services\Form\FormValidationService -> validateNonce()
-
-</explain-block>
-
-<explain-block title="fluentform/shortcode_defaults">
-
-This filter sets the defaults values for the shortcode.
-
-**Parameters**
-
-- `$defaults` (array) Default Shortcode Values
-- `$atts` (array) Shortcode Attributes
-
-**Usage**
-
-```php
-add_filter('fluentform/shortcode_defaults', function($defaults , $atts) {
-   // Do your stuff here
-
-   return $atts;
-}, 10, 2);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/shortcode_defaults', $data, $atts);`
-
-This filter is located in FluentForm\App\Modules\Component\Component -> addFluentFormShortCode()
-
-</explain-block>
-
-<explain-block title="fluentform/shortcode_feed_text">
-
-This filter returns the message of the shortcode for a feed.
-
-**Parameters**
-
-- `$feedText` (string) Shortcode Feed Text
-- `$form` (object) Form Object
-
-**Usage**
-
-```php
-add_filter('fluentform/shortcode_feed_text', function ($feedText, $form) {
-   // Do your stuff here
-
-   return $feedText;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/shortcode_feed_text', $feedText, $form);`
-
-This filter is located in FluentForm\App\Modules\Component\Component -> renderForm($atts)
-
-</explain-block>
-
-<explain-block title="fluentform/parse_default_value">
-
-You can modify form default shortcode value using this filter.
-
-**Parameters**
-
-- `$value` (string) Parseable Shortcode Value
-- `$form` (object) Form Object
-
-**Usage**
-
-```php
-add_filter('fluentform/parse_default_value', function($value, $form) {
-   // Do your stuff here
-
-   return $value;
-}, 10, 2);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/parse_default_value', $attrDefaultValues[$pattern], $form);`
-
-This filter is located in FluentForm\App\Modules\Component\Component -> replaceEditorSmartCodes($output, $form)
-
-
-</explain-block>
-
-<explain-block title="fluentform/parse_default_values">
-
-You can modify Shortcode's all parseable values using this filter.
-
-**Parameters**
-
-- `$attrDefaultValues` (array) Parseable All Shortcode Values
-
-**Usage**
-
-```php
-add_filter('fluentform/parse_default_values', function($attrDefaultValues) {
-   // Do your stuff here
-
-   return $attrDefaultValues;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/parse_default_values', $attrDefaultValues);`
-
-This filter is located in FluentForm\App\Modules\Component\Component -> replaceEditorSmartCodes($output, $form)
-
-</explain-block>
-
-<explain-block title="fluentform/akismet_fields">
-
-This filter is used in the Akismet handler.
-
-**Parameters**
-
-- `$info` (array) Akismet Data
-- `$data` (array) Form Data
-- `$form` (object) Form Object
-
-**Usage**
-
-```php
-add_filter('fluentform/akismet_fields', function ($info, $data, $form) {
-   // Do your stuff here
-
-   return $info;
-}, 10, 3);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/akismet_fields', $info, $data, $form);`
-
-This filter is located in FluentForm\App\Modules\AkismetHandler -> getAkismetFields($data, $form)
-
-</explain-block>
-
-<explain-block title="fluentform/find_shortcode_params">
-
-This filter returns Fluent Forms shortcode used in the site.
-
-**Parameters**
-
-- `$params` (array) Post Type
-
-**Usage**
-
-```php
-add_filter('fluentform/find_shortcode_params', function($params) {
-   // Do your stuff here
-
-   return $params;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/find_shortcode_params', $params);`
-
-This filter is located in FluentForm\App\Services\Form\FormService -> findShortCodePage($formId)
-
-</explain-block>
-
-<explain-block title="fluentform/will_parse_url_value">
-
-You can toggle redirect URL parsing in confirmation Message using the filter.
-
-**Parameters**
-
-- `$status` (boolean) Whether Parse the URL
-- `$form` (object) Form Object
-
-**Usage**
-
-```php
-add_filter('fluentform/will_parse_url_value', function($status, $form) {
-   // Do your stuff here
-
-   return $status;
-}, 10, 2);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/will_parse_url_value', $parseUrl, $form);`
-
-This filter is located in FluentForm\App\Services\Form\SubmissionHandlerServices -> getReturnData($insertId, $form,
-$formData)
+This filter is located in `app/Helpers/Helper.php` (line 1403).
 
 </explain-block>
 
@@ -419,6 +55,35 @@ This filter is located in FluentForm\App\Services\Form\FormValidationService -> 
 
 </explain-block>
 
+<explain-block title="fluentform/akismet_fields">
+
+This filter is used in the Akismet handler.
+
+**Parameters**
+
+- `$info` (array) Akismet Data
+- `$data` (array) Form Data
+- `$form` (object) Form Object
+
+**Usage**
+
+```php
+add_filter('fluentform/akismet_fields', function ($info, $data, $form) {
+   // Do your stuff here
+
+   return $info;
+}, 10, 3);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/akismet_fields', $info, $data, $form);`
+
+This filter is located in FluentForm\App\Modules\AkismetHandler -> getAkismetFields($data, $form)
+
+</explain-block>
+
 <explain-block title="fluentform/akismet_spam_result">
 
 You can toggle Akismet spam result using this filter.
@@ -448,260 +113,33 @@ This filter is located in FluentForm\App\Services\Form\FormValidationService -> 
 
 </explain-block>
 
-<explain-block title="fluentform/has_recaptcha">
+<explain-block title="fluentform/all_data_shortcode_html">
 
-You can toggle Recaptcha using this filter.
+You can use this filter to modify {all_data} shortcode as HTML.
 
 **Parameters**
 
-- `$status` (boolean) Whether Recaptcha is enabled
+- `$html` (string) HTML string
+- `$formFields` (array) Form Fields
+- `$inputLabels` (array) Input Labels
+- `$response` (object) Form Response
 
 **Usage**
 
 ```php
-add_filter('fluentform/has_recaptcha', function($status) {
-   // Do your stuff here
-
-   return $status;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/has_recaptcha', $hasAutoRecap);`
-
-This filter is located in FluentForm\App\Services\Form\FormValidationService -> validateReCaptcha()
-
-</explain-block>
-
-<explain-block title="fluentform/disable_captcha">
-
-You can disable specific captcha validation using this filter. This is useful when you want to bypass captcha validation in certain scenarios.
-
-**Parameters**
-
-- `$isDisabled` (boolean) Whether captcha validation is disabled
-- `$form` (object) Form Object
-- `$captchaType` (string) The type of captcha ('recaptcha', 'hcaptcha', 'turnstile')
-
-**Usage**
-
-```php
-add_filter('fluentform/disable_captcha', function($isDisabled, $form, $captchaType) {
-   // Disable reCAPTCHA for a specific form
-   if ($captchaType === 'recaptcha' && $form->id === 123) {
-      return true;
-   }
-   
-   return $isDisabled;
-}, 10, 3);
-```
-
-**Reference**
-
-`apply_filters('fluentform/disable_captcha', false, $this->form, 'recaptcha');`
-`apply_filters('fluentform/disable_captcha', false, $this->form, 'hcaptcha');`
-`apply_filters('fluentform/disable_captcha', false, $this->form, 'turnstile');`
-
-This filter is located in `FluentForm\App\Services\Form\FormValidationService` -> `validateReCaptcha()`, `validateHCaptcha()`, and `validateTurnstile()`
-
-</explain-block>
-
-<explain-block title="fluentform/has_hcaptcha">
-
-You can toggle Hcaptcha using this filter.
-
-**Parameters**
-
-- `$status` (boolean) Whether Hcaptcha is enabled
-
-**Usage**
-
-```php
-add_filter('fluentform/has_hcaptcha', function($status) {
-   // Do your stuff here
-
-   return $status;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/has_hcaptcha', $hasAutoHcap);`
-
-This filter is located in FluentForm\App\Services\Form\FormValidationService -> validateHCaptcha()
-
-</explain-block>
-
-<explain-block title="fluentform/has_turnstile">
-
-You can toggle Turnstile using this filter.
-
-**Parameters**
-
-- `$status` (boolean) Whether Turnstile is enabled
-
-**Usage**
-
-```php
-add_filter('fluentform/has_turnstile', function($status) {
-   // Do your stuff here
-
-   return $status;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/has_turnstile', $hasAutoTurnsTile);`
-
-This filter is located in FluentForm\App\Services\Form\FormValidationService -> validateTurnstile()
-
-</explain-block>
-
-<explain-block title="fluentform/recaptcha_v3_ref_score">
-
-You can set Recaptcha Reference Score using this filter. By default, score is set to 0.5.
-
-**Parameters**
-
-- `$score` Reference Score between 0 and 1
-
-**Usage**
-
-```php
-add_filter('fluentform/recaptcha_v3_ref_score', function($score) {
-   // Do your stuff here
-
-   return $score;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentforms/recaptcha_v3_ref_score', $value);`
-
-This filter is located in FluentForm\App\Modules\ReCaptcha\ReCaptcha -> validate($token, $secret = null, $version = '
-v2_visible')
-
-</explain-block>
-
-<explain-block title="'fluentform/editor_shortcode_callback_group_' . $group">
-
-You can modify shortcode group using the filter.
-
-**Parameters**
-
-- `$handler` (array) All Shortcode Group
-- `$form` (object) Form Object
-- `$handlerArray` (array) Shortcode Handlers Group
-
-**Usage**
-
-```php
-add_filter('fluentform/editor_shortcode_callback_group_' . $group, function ($handler, $form, $handlerArray) {
-   // Do your stuff here
-
-   return '{' . $handler . '}';
-}, 10, 3);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/editor_shortcode_callback_group_' . $group, '{' . $handler . '}', $form, $handlerArray);`
-
-This filter is located in FluentForm\App\Services\FormBuilder\EditorShortcodeParser -> filter($value, $form)
-
-</explain-block>
-
-<explain-block title="'fluentform/editor_shortcode_callback_' . $handler">
-
-You can modify shortcode handler using the filter.
-
-**Parameters**
-
-- `$handler` (array) Shortcode Handler Array
-- `$form` (object) Form Object
-
-**Usage**
-
-```php
-add_filter('fluentform/editor_shortcode_callback_' . $handler, function ($handler, $form) {
-   // Do your stuff here
-
-   return $handler;
-}, 10, 2);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/editor_shortcode_callback_' . $handler, $handler, $form);`
-
-This filter is located in FluentForm\App\Services\FormBuilder\EditorShortcodeParser -> filter($value, $form)
-
-</explain-block>
-
-<explain-block title="fluentform/editor_element_customization_settings">
-
-This filter returns the input element settings components in editor.
-
-**Parameters**
-
-- `$settings` (array) Element settings
-
-**Usage**
-
-```php
-add_filter('fluentform/editor_element_customization_settings', function ($settings) {
-    if ($customSettings = $this->getEditorCustomizationSettings()) {
-    $settings = array_merge($settings, $customSettings);
-    }
-
-    return $settings;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/editor_element_customization_settings', $element_customization_settings);`
-
-This filter is located in FluentForm\App\Services\FormBuilder\ElementCustomization
-
-</explain-block>
-
-<explain-block title="fluentform/html_attributes">
-
-You can use this filter to modify the form attributes before form render.
-
-**Parameters**
-
-- `$data` (array) Form HTML attributes
-- `$form` (object) Form Object
-
-**Usage**
-
-```php
-add_filter('fluentform/html_attributes', function ($data, $form) {
+add_filter('fluentform/all_data_shortcode_html', function ($html, $formFields, $inputLabels, $response) {
     // Do your stuff here
     
-    return $data;
-}, 10, 2);
+    return $html;
+}, 10, 1);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/html_attributes', $data, $form);`
+`apply_filters('fluentform/all_data_shortcode_html',  __return_true());`
 
-This filter is located in FluentForm\App\Services\FormBuilder\FormBuilder -> build($form, $extraCssClass = '',
-$instanceCssClass = '', $atts = [])
+This filter is located in FluentForm\App\Services\FormBuilder\ShortcodeParser -> getOtherData($key)
 
 </explain-block>
 
@@ -759,146 +197,485 @@ This filter is located in FluentForm\App\Services\FormBuilder\ShortcodeParser ->
 
 </explain-block>
 
-<explain-block title="fluentform/all_data_shortcode_html">
+<explain-block title="fluentform/allow_legacy_token_decrypt">
 
-You can use this filter to modify {all_data} shortcode as HTML.
+<Badge type="warning" vertical="top" text="Added in 6.2.1" />
+
+Opt-in fallback that lets the Protector helper decrypt tokens issued under the pre-6.2.0 HMAC scheme. Useful if you upgraded to 6.2.x while live signed URLs (save-and-resume links, share links, payment-callback tokens) issued under the old scheme are still in the wild and you need them to keep validating during the transition.
 
 **Parameters**
 
-- `$html` (string) HTML string
-- `$formFields` (array) Form Fields
-- `$inputLabels` (array) Input Labels
-- `$response` (object) Form Response
+- `$allow` (bool) Default `false`. Return `true` to attempt legacy token decryption when modern decryption fails.
 
 **Usage**
 
 ```php
-add_filter('fluentform/all_data_shortcode_html', function ($html, $formFields, $inputLabels, $response) {
+add_filter('fluentform/allow_legacy_token_decrypt', '__return_true');
+```
+
+**Reference**
+
+`apply_filters('fluentform/allow_legacy_token_decrypt', false);`
+
+This filter is located in `FluentForm\App\Helpers\Protector`.
+
+</explain-block>
+
+<explain-block title="fluentform/allowed_html_tags">
+
+You can use this filter to add HTML attributes for sanitization.
+
+**Parameters**
+
+- `$tags` (array) HTML Attributes
+
+**Usage**
+
+```php
+add_filter('fluentform/allowed_html_tags', function ($tags) {
     // Do your stuff here
     
-    return $html;
+    return $tags;
 }, 10, 1);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/all_data_shortcode_html',  __return_true());`
+`apply_filters('fluentform/allowed_html_tags', $tags);`
 
-This filter is located in FluentForm\App\Services\FormBuilder\ShortcodeParser -> getOtherData($key)
+This filter is located in FluentForm\boot\globals.php -> fluentform_sanitize_html($html)
 
 </explain-block>
 
-<explain-block title="fluentform/shortcode_parser_callback_pdf.download_link.public">
+<explain-block title="fluentform/backend_sanitized_values">
 
-You can use this filter to modify the public PDF download link.
+You can use this filter to add inputs values for sanitization.
 
 **Parameters**
 
-- `$key` (string) Key Name
-- `$instance` (object) Shortcode Parser Instance
+- `$inputs` (array) Form Inputs
 
 **Usage**
 
 ```php
-add_filter('fluentform/shortcode_parser_callback_pdf.download_link.public', function ($key, $instance) {
+add_filter('fluentform/backend_sanitized_values', function ($inputs) {
     // Do your stuff here
     
-    return $key;
+    return $inputs;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/backend_sanitized_values', $inputs);`
+
+This filter is located in FluentForm\boot\globals.php -> fluentform_backend_sanitizer($inputs, $sanitizeMap = [])
+
+</explain-block>
+
+<explain-block title="fluentform/cleanup_days_count">
+
+You can use this filter to set days count for cleanup old data through scheduler.
+
+**Parameters**
+
+- `$days` (int) Days Count, By default 60
+
+**Usage**
+
+```php
+add_filter('fluentform/cleanup_days_count', function ($days) {
+    // Do your stuff here
+    
+    return $days;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/cleanup_days_count', $days);`
+
+This filter is located in FluentForm\App\Services\Scheduler\Scheduler -> cleanUpOldData()
+
+</explain-block>
+
+<explain-block title="fluentform/conditional_shortcode_defaults">
+
+You can use this filter to modify shortcode default.
+
+**Parameters**
+
+- `$default` (array) Shortcode Default
+- `$atts` (array) Shortcode Attributes
+
+**Usage**
+
+```php
+add_filter('fluentform/conditional_shortcode_defaults', function ($default, $atts) {
+    // Do your stuff here
+    
+    return $default;
+}, 10, 2);
+
+```
+```php
+$default = [
+    'field' => '',
+    'is'    => '',
+    'to'    => ''
+];
+```
+
+**Reference**
+
+`apply_filters('fluentform/conditional_shortcode_defaults', $default, $atts);`
+
+This filter is located in FluentFormPro\src\classes\ConditionalContent -> handle($atts, $content)
+
+</explain-block>
+
+<explain-block title="fluentform/current_user_allowed_forms">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$value` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/current_user_allowed_forms', function ($value) {
+    return $value;
+}, 10, 1);
+```
+
+**Reference**
+
+`$allowFormIds = apply_filters('fluentform/current_user_allowed_forms', false);`
+
+This filter is located in `src/Payments/Classes/PaymentEntries.php` (line 73).
+
+</explain-block>
+
+<explain-block title="fluentform/current_user_capability">
+
+You can modify Current User Capability using this filter.
+
+**Parameters**
+
+- `$capability` (array) User Capabilities
+
+**Usage**
+
+```php
+add_filter('fluentform/current_user_capability', function ($capability) {
+   // Do your stuff here
+
+   return $capability;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/current_user_capability', static::$capability);`
+
+This filter is located in FluentForm\App\Modules\Acl -> getCurrentUserCapability()
+
+</explain-block>
+
+<explain-block title="fluentform/current_user_permissions">
+
+You can modify Current User Permission using this filter.
+
+**Parameters**
+
+- `$userPermissions` (array) Current User Permissions
+
+**Usage**
+
+```php
+add_filter('fluentform/current_user_permissions', function ($userPermissions) {
+   // Do your stuff here
+
+   return $userPermissions;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/current_user_permissions', $userPermissions);`
+
+This filter is located in FluentForm\App\Models\Form -> getUserPermissions($user = false)
+
+</explain-block>
+
+<explain-block title="fluentform/disable_attachment_delete">
+
+You can toggle double option confirmation file attachment by using this filter.
+
+**Parameters**
+
+- `$status` (boolean) Whether the attachment is disabled
+- `$formId` (int) Form ID
+
+**Usage**
+
+```php
+add_filter('fluentform/disable_attachment_delete', function ($status, $formId) {
+    // Do your stuff here
+    
+    return $status;
 }, 10, 2);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/shortcode_parser_callback_pdf.download_link.public', $key, $instance);`
+`apply_filters('fluentform/disable_attachment_delete', $status, $entry->form_id));`
 
-This filter is located in FluentForm\App\Services\FormBuilder -> getOtherData($key)
+This filter is located in FluentFormPro\src\classes\DoubleOption -> deleteAssociateFiles($entry)
 
 </explain-block>
 
-<explain-block title="fluentform/shortcode_parser_callback_random_string">
+<explain-block title="fluentform/disable_captcha">
 
-You can use this filter to modify the any shortcode with random string.
+You can disable specific captcha validation using this filter. This is useful when you want to bypass captcha validation in certain scenarios.
 
 **Parameters**
 
-- `$value` (string) Name of the Shortcode after .
-- `$prefix` (string) Prefix of the Shortcode before .
-- `$instance` (object) Shortcode Parser Instance
+- `$isDisabled` (boolean) Whether captcha validation is disabled
+- `$form` (object) Form Object
+- `$captchaType` (string) The type of captcha ('recaptcha', 'hcaptcha', 'turnstile')
 
 **Usage**
 
 ```php
-add_filter('fluentform/shortcode_parser_callback_random_string', function ($value, $prefix, $instance) {
+add_filter('fluentform/disable_captcha', function($isDisabled, $form, $captchaType) {
+   // Disable reCAPTCHA for a specific form
+   if ($captchaType === 'recaptcha' && $form->id === 123) {
+      return true;
+   }
+   
+   return $isDisabled;
+}, 10, 3);
+```
+
+**Reference**
+
+`apply_filters('fluentform/disable_captcha', false, $this->form, 'recaptcha');`
+`apply_filters('fluentform/disable_captcha', false, $this->form, 'hcaptcha');`
+`apply_filters('fluentform/disable_captcha', false, $this->form, 'turnstile');`
+
+This filter is located in `FluentForm\App\Services\Form\FormValidationService` -> `validateReCaptcha()`, `validateHCaptcha()`, and `validateTurnstile()`
+
+</explain-block>
+
+<explain-block title="fluentform/disable_fields_sanitize">
+
+You can use this filter to toggle disable fields sanitization.
+
+**Parameters**
+
+- `$status` (boolean) Whether disabled fields sanitization is enabled
+
+**Usage**
+
+```php
+add_filter('fluentform/disable_fields_sanitize', function ($status) {
     // Do your stuff here
     
-    return $value;
-}, 10, 3);
+    return $status;
+}, 10, 1);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/shortcode_parser_callback_random_string', $value, $prefix, static::getInstance());`
+`apply_filters('fluentform/disable_fields_sanitize', $status);`
 
-This filter is located in FluentForm\App\Services\FormBuilder -> getOtherData($key)
+This filter is located in FluentForm\boot\globals.php -> fluentformCanUnfilteredHTML()
 
 </explain-block>
 
-<explain-block title="'fluentform/smartcode_group_' . $group">
-
-You can use this filter to modify the smartcode with a specific group.
+<explain-block title="fluentform/disable_input_mode">
 
 **Parameters**
 
-- `$property` (string) Smartcode Name
-- `$instance` (object) Shortcode Parser Instance
+- `$value` — see source
 
 **Usage**
 
 ```php
-add_filter('fluentform/smartcode_group_' . $group, function ($property, $instance) {
+add_filter('fluentform/disable_input_mode', function ($value) {
+    return $value;
+}, 10, 1);
+```
+
+**Reference**
+
+`$isDisable = apply_filters('fluentform/disable_input_mode', false);`
+
+This filter is located in `app/Services/FormBuilder/Components/Text.php` (line 60).
+
+</explain-block>
+
+<explain-block title="fluentform/disabled_components">
+
+You can use this filter to modify disabled components.
+
+**Parameters**
+
+- `$disabled` (array) Disabled Components
+
+**Usage**
+
+```php
+add_filter('fluentform/disabled_components', function ($disabled) {
     // Do your stuff here
     
-    return $value;
+    return $disabled;
+}, 10, 1);
+
+```
+
+```php
+$disabled['ratings'] = [
+    'disabled'    => true,
+    'title'       => __('Ratings', 'fluentform'),
+    'description' => __('Ratings is not available with the free version. Please upgrade to pro to get all the advanced features.', 'fluentform'),
+    'image'       => '',
+    'video'       => 'https://www.youtube.com/embed/YGdkNspMaEs',
+];
+$disabled['tabular_grid'] = [
+    'disabled'    => true,
+    'title'       => __('Checkable Grid', 'fluentform'),
+    'description' => __('Checkable Grid is not available with the free version. Please upgrade to pro to get all the advanced features.', 'fluentform'),
+    'image'       => '',
+    'video'       => 'https://www.youtube.com/embed/ayI3TzXXANA',
+];
+```
+
+**Reference**
+
+`apply_filters('fluentform/disabled_components', $disabled);`
+
+This filter is located in FluentForm\app\Services\Form\FormServices -> getDisabledComponents()
+
+</explain-block>
+
+<explain-block title="fluentform/double_optin_invalid_confirmation_url_message">
+
+This filter allows you to customize double optin invalid confirmation URL messages
+
+**Parameters**
+
+- `$message` (string) The default massage
+
+**Usage**
+
+```php
+add_filter('fluentform/double_optin_invalid_confirmation_url_message', function ($message) {
+    // Modify the message
+    return __('Sorry! Invalid Form Confirmation URL. Please contact the site admin.', 'fluentformpro');
+}, 10, 2);
+```
+**Reference**
+
+`apply_filters('fluentform/double_optin_invalid_confirmation_url_message', __('Sorry! Invalid Form Confirmation URL', 'fluentformpro'));`
+
+This filter is located in the `FluentFormPro\classes\DoubleOptin` -> `confirmSubmission` method.
+
+</explain-block>
+
+<explain-block title="fluentform/editor_element_customization_settings">
+
+This filter returns the input element settings components in editor.
+
+**Parameters**
+
+- `$settings` (array) Element settings
+
+**Usage**
+
+```php
+add_filter('fluentform/editor_element_customization_settings', function ($settings) {
+    if ($customSettings = $this->getEditorCustomizationSettings()) {
+    $settings = array_merge($settings, $customSettings);
+    }
+
+    return $settings;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/editor_element_customization_settings', $element_customization_settings);`
+
+This filter is located in FluentForm\App\Services\FormBuilder\ElementCustomization
+
+</explain-block>
+
+<explain-block title="'fluentform/editor_shortcode_callback_' . $handler">
+
+You can modify shortcode handler using the filter.
+
+**Parameters**
+
+- `$handler` (array) Shortcode Handler Array
+- `$form` (object) Form Object
+
+**Usage**
+
+```php
+add_filter('fluentform/editor_shortcode_callback_' . $handler, function ($handler, $form) {
+   // Do your stuff here
+
+   return $handler;
 }, 10, 2);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/smartcode_group_' . $group, $property, static::getInstance());`
+`apply_filters('fluentform/editor_shortcode_callback_' . $handler, $handler, $form);`
 
-This filter is located in FluentForm\App\Services\FormBuilder -> getOtherData($key)
+This filter is located in FluentForm\App\Services\FormBuilder\EditorShortcodeParser -> filter($value, $form)
 
 </explain-block>
 
-<explain-block title="'fluentform/shortcode_parser_callback_' . $key">
+<explain-block title="'fluentform/editor_shortcode_callback_group_' . $group">
 
-You can use this filter to modify the any shortcode with matching key.
+You can modify shortcode group using the filter.
 
 **Parameters**
 
-- `$key` (string) Key Name
-- `$instance` (object) Shortcode Parser Instance
+- `$handler` (array) All Shortcode Group
+- `$form` (object) Form Object
+- `$handlerArray` (array) Shortcode Handlers Group
 
 **Usage**
 
 ```php
-add_filter('fluentform/shortcode_parser_callback_' . $key, function ($key, $instance) {
-    // Do your stuff here
-    
-    return $key;
+add_filter('fluentform/editor_shortcode_callback_group_' . $group, function ($handler, $form, $handlerArray) {
+   // Do your stuff here
+
+   return '{' . $handler . '}';
 }, 10, 3);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/shortcode_parser_callback_' . $key, static::getInstance());`
+`apply_filters('fluentform/editor_shortcode_callback_group_' . $group, '{' . $handler . '}', $form, $handlerArray);`
 
-This filter is located in FluentForm\App\Services\FormBuilder -> getOtherData($key)
+This filter is located in FluentForm\App\Services\FormBuilder\EditorShortcodeParser -> filter($value, $form)
 
 </explain-block>
 
@@ -1128,99 +905,399 @@ This filter is located in FluentForm\App\Services\FormBuilder\ValidationRuleSett
 
 </explain-block>
 
-<explain-block title="fluentform/cleanup_days_count">
+<explain-block title="fluentform/email_exists_validation_message">
 
-You can use this filter to set days count for cleanup old data through scheduler.
+Change User registration existing email validation message
 
 **Parameters**
-
-- `$days` (int) Days Count, By default 60
+- `validationMsg` (string) Message
+- `$form` (object) Form Object
+- `$feed` (array) Integraion Feed Data
+- `$email` (string) Email 
 
 **Usage**
 
 ```php
-add_filter('fluentform/cleanup_days_count', function ($days) {
-    // Do your stuff here
-    
-    return $days;
+add_filter('fluentform/email_exists_validation_message', function($validationMsg) {
+    $validationMsg = "This email is already registered. Please choose another one.";
+    return $validationMsg;
 }, 10, 1);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/cleanup_days_count', $days);`
+`apply_filters('fluentform/email_exists_validation_message', $validationMsg, $form, $feed, $email);`
 
-This filter is located in FluentForm\App\Services\Scheduler\Scheduler -> cleanUpOldData()
+This filter is located in fluentformpro/src/Integrations/UserRegistration/UserRegistrationApi.php
 
 </explain-block>
 
-<explain-block title="fluentform/allowed_html_tags">
-
-You can use this filter to add HTML attributes for sanitization.
+<explain-block title="fluentform/exclude_js_slugs_from_dequeue">
 
 **Parameters**
 
-- `$tags` (array) HTML Attributes
+- `$args` — see source
 
 **Usage**
 
 ```php
-add_filter('fluentform/allowed_html_tags', function ($tags) {
-    // Do your stuff here
-    
-    return $tags;
+add_filter('fluentform/exclude_js_slugs_from_dequeue', function ($args) {
+    return $args;
+}, 10, 1);
+```
+
+**Reference**
+
+`$excludeSlugs = apply_filters('fluentform/exclude_js_slugs_from_dequeue', ['fluentform']);`
+
+This filter is located in `app/Hooks/actions.php` (line 195).
+
+</explain-block>
+
+<explain-block title="fluentform/extractor_parser_custom_fields">
+
+**Parameters**
+
+- `$customFields` — see source
+- `$this` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/extractor_parser_custom_fields', function ($customFields, $this) {
+    return $customFields;
+}, 10, 2);
+```
+
+**Reference**
+
+`$customFields = apply_filters('fluentform/extractor_parser_custom_fields', $customFields, $this->field);`
+
+This filter is located in `app/Services/Parser/Extractor.php` (line 401).
+
+</explain-block>
+
+<explain-block title="fluentform/file_upload_options">
+
+You can change Fluent Forms default file upload location by using this filter.
+
+**Parameters**
+
+- `$locations` (array) File Upload Location
+
+**Usage**
+
+```php
+add_filter('fluentform/file_upload_options', function ($locations){
+
+   // Do your stuff here
+}, 10, 1);
+```
+
+**Reference**
+
+`apply_filters('fluentform/file_upload_options', $locations);`
+
+This filter is located in FluentForm\App\Helpers\Helper -> fileUploadLocations()
+
+</explain-block>
+
+<explain-block title="fluentform/find_shortcode_builder_meta_keys">
+
+<Badge type="warning" vertical="top" text="Added in 6.2.x" />
+
+Extend the list of post-meta keys the admin "Find" feature scans when locating which posts/pages embed a given form. Use this when your page builder stores form shortcodes inside a custom meta key that Fluent Forms does not know about.
+
+**Parameters**
+
+- `$metaKeys` (array) Default list of meta keys searched
+
+**Usage**
+
+```php
+add_filter('fluentform/find_shortcode_builder_meta_keys', function ($metaKeys) {
+    $metaKeys[] = '_my_builder_content';
+    return $metaKeys;
+}, 10, 1);
+```
+
+**Reference**
+
+`apply_filters('fluentform/find_shortcode_builder_meta_keys', $metaKeys);`
+
+This filter is located in `FluentForm\App\Services\Form\FormService`.
+
+</explain-block>
+
+<explain-block title="fluentform/find_shortcode_excluded_post_types">
+
+<Badge type="warning" vertical="top" text="Added in 6.2.x" />
+
+Exclude additional post types from the admin "Find" feature scan. Useful for skipping large or irrelevant post types that slow down the search.
+
+**Parameters**
+
+- `$excludedPostTypes` (array) Default excluded post types
+
+**Usage**
+
+```php
+add_filter('fluentform/find_shortcode_excluded_post_types', function ($excluded) {
+    $excluded[] = 'product_variation';
+    return $excluded;
+}, 10, 1);
+```
+
+**Reference**
+
+`apply_filters('fluentform/find_shortcode_excluded_post_types', $excludedPostTypes);`
+
+This filter is located in `FluentForm\App\Services\Form\FormService`.
+
+</explain-block>
+
+<explain-block title="fluentform/find_shortcode_params">
+
+This filter returns Fluent Forms shortcode used in the site.
+
+**Parameters**
+
+- `$params` (array) Post Type
+
+**Usage**
+
+```php
+add_filter('fluentform/find_shortcode_params', function($params) {
+   // Do your stuff here
+
+   return $params;
 }, 10, 1);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/allowed_html_tags', $tags);`
+`apply_filters('fluentform/find_shortcode_params', $params);`
 
-This filter is located in FluentForm\boot\globals.php -> fluentform_sanitize_html($html)
+This filter is located in FluentForm\App\Services\Form\FormService -> findShortCodePage($formId)
 
 </explain-block>
 
-<explain-block title="fluentform/backend_sanitized_values">
+<explain-block title="fluentform/generated_protection_token">
 
-You can use this filter to add inputs values for sanitization.
+This filter allows you to modify the generated protection token.
 
 **Parameters**
 
-- `$inputs` (array) Form Inputs
+- `$token` (string) The encrypted token
+- `$formId` (int) The ID of the form
+- `$timeStamp` (int) The current timestamp
 
 **Usage**
 
 ```php
-add_filter('fluentform/backend_sanitized_values', function ($inputs) {
-    // Do your stuff here
-    
-    return $inputs;
+add_filter('fluentform/generated_protection_token', function ($token, $formId, $timeStamp) {
+    // Modify the token
+    return $token;
+}, 10, 3);
+```
+**Reference**
+
+`apply_filters('fluentform/generated_protection_token', Protector::encrypt($data), $formId, $timeStamp);`
+
+This filter is located in the FluentForm\App\Modules\Form\TokenBasedSpamProtection -> generateToken method.
+
+</explain-block>
+
+<explain-block title="fluentform/get_global_message_">
+
+**Parameters**
+
+- See source
+
+**Usage**
+
+```php
+add_filter('fluentform/get_global_message_', function ($value) {
+    return $value;
+}, 10, 1);
+```
+
+**Reference**
+
+`$rule['message'] = apply_filters('fluentform/get_global_message_' . $ruleName, $rule['message']);;`
+
+This filter is located in `app/Services/FluentConversational/Classes/Converter/Converter.php` (line 1384).
+
+</explain-block>
+
+<explain-block title="fluentform/global_search_active">
+
+**Parameters**
+
+- `$value` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/global_search_active', function ($value) {
+    return $value;
+}, 10, 1);
+```
+
+**Reference**
+
+`'global_search_active' => apply_filters('fluentform/global_search_active', 'yes'),`
+
+This filter is located in `app/Hooks/actions.php` (line 762).
+
+</explain-block>
+
+<explain-block title="fluentform/global_search_links">
+
+**Parameters**
+
+- `$links` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/global_search_links', function ($links) {
+    return $links;
+}, 10, 1);
+```
+
+**Reference**
+
+`"links" => apply_filters('fluentform/global_search_links', $links),`
+
+This filter is located in `app/Services/GlobalSearchService.php` (line 503).
+
+</explain-block>
+
+<explain-block title="fluentform/has_hcaptcha">
+
+You can toggle Hcaptcha using this filter.
+
+**Parameters**
+
+- `$status` (boolean) Whether Hcaptcha is enabled
+
+**Usage**
+
+```php
+add_filter('fluentform/has_hcaptcha', function($status) {
+   // Do your stuff here
+
+   return $status;
 }, 10, 1);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/backend_sanitized_values', $inputs);`
+`apply_filters('fluentform/has_hcaptcha', $hasAutoHcap);`
 
-This filter is located in FluentForm\boot\globals.php -> fluentform_backend_sanitizer($inputs, $sanitizeMap = [])
+This filter is located in FluentForm\App\Services\Form\FormValidationService -> validateHCaptcha()
 
 </explain-block>
 
-<explain-block title="fluentform/disable_fields_sanitize">
+<explain-block title="fluentform/has_recaptcha">
 
-You can use this filter to toggle disable fields sanitization.
+You can toggle Recaptcha using this filter.
 
 **Parameters**
 
-- `$status` (boolean) Whether disabled fields sanitization is enabled
+- `$status` (boolean) Whether Recaptcha is enabled
 
 **Usage**
 
 ```php
-add_filter('fluentform/disable_fields_sanitize', function ($status) {
+add_filter('fluentform/has_recaptcha', function($status) {
+   // Do your stuff here
+
+   return $status;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/has_recaptcha', $hasAutoRecap);`
+
+This filter is located in FluentForm\App\Services\Form\FormValidationService -> validateReCaptcha()
+
+</explain-block>
+
+<explain-block title="fluentform/has_turnstile">
+
+You can toggle Turnstile using this filter.
+
+**Parameters**
+
+- `$status` (boolean) Whether Turnstile is enabled
+
+**Usage**
+
+```php
+add_filter('fluentform/has_turnstile', function($status) {
+   // Do your stuff here
+
+   return $status;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/has_turnstile', $hasAutoTurnsTile);`
+
+This filter is located in FluentForm\App\Services\Form\FormValidationService -> validateTurnstile()
+
+</explain-block>
+
+<explain-block title="fluentform/html_attributes">
+
+You can use this filter to modify the form attributes before form render.
+
+**Parameters**
+
+- `$data` (array) Form HTML attributes
+- `$form` (object) Form Object
+
+**Usage**
+
+```php
+add_filter('fluentform/html_attributes', function ($data, $form) {
+    // Do your stuff here
+    
+    return $data;
+}, 10, 2);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/html_attributes', $data, $form);`
+
+This filter is located in FluentForm\App\Services\FormBuilder\FormBuilder -> build($form, $extraCssClass = '',
+$instanceCssClass = '', $atts = [])
+
+</explain-block>
+
+<explain-block title="fluentform/https_local_ssl_verify">
+
+You can use this to toggle the local SSL verification for async requests.
+
+**Parameters**
+
+- `$status` (boolean) Whether local SSL verification is enabled
+
+**Usage**
+
+```php
+add_filter('fluentform/https_local_ssl_verify', function ($status) {
     // Do your stuff here
     
     return $status;
@@ -1230,84 +1307,151 @@ add_filter('fluentform/disable_fields_sanitize', function ($status) {
 
 **Reference**
 
-`apply_filters('fluentform/disable_fields_sanitize', $status);`
+`apply_filters('fluentform/https_local_ssl_verify', false);`
 
-This filter is located in FluentForm\boot\globals.php -> fluentformCanUnfilteredHTML()
+This filter is located in FluentForm\app\Services\WPAsync\FluentFormAsyncRequest -> dispatchAjax($data = [])
 
 </explain-block>
 
-<explain-block title="fluentform/disabled_components">
-
-You can use this filter to modify disabled components.
+<explain-block title="fluentform/info_shortcode_defaults">
 
 **Parameters**
 
-- `$disabled` (array) Disabled Components
+- `$data` — see source
+- `$atts` — see source
 
 **Usage**
 
 ```php
-add_filter('fluentform/disabled_components', function ($disabled) {
-    // Do your stuff here
-    
-    return $disabled;
+add_filter('fluentform/info_shortcode_defaults', function ($data, $atts) {
+    return $data;
+}, 10, 2);
+```
+
+**Reference**
+
+`$shortcodeDefaults = apply_filters('fluentform/info_shortcode_defaults', $data, $atts);`
+
+This filter is located in `app/Modules/Component/Component.php` (line 1334).
+
+</explain-block>
+
+<explain-block title="fluentform/input_label_shortcode">
+
+**Parameters**
+
+- `$inputLabel` — see source
+- `$key` — see source
+- `$value` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/input_label_shortcode', function ($inputLabel, $key, $value) {
+    return $inputLabel;
+}, 10, 3);
+```
+
+**Reference**
+
+`return apply_filters('fluentform/input_label_shortcode', $inputLabel, $key, static::getForm());`
+
+This filter is located in `app/Services/FormBuilder/ShortCodeParser.php` (line 294).
+
+</explain-block>
+
+<explain-block title="fluentform/load_form_instance_js_var_immediately">
+
+**Parameters**
+
+- `$value` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/load_form_instance_js_var_immediately', function ($value) {
+    return $value;
+}, 10, 1);
+```
+
+**Reference**
+
+`$otherScriptsRenderImmediately = apply_filters('fluentform/load_form_instance_js_var_immediately', false);`
+
+This filter is located in `app/Modules/Component/Component.php` (line 769).
+
+</explain-block>
+
+<explain-block title="fluentform/mask_input_mode">
+
+**Parameters**
+
+- `$inputMode` — see source
+- `$data` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/mask_input_mode', function ($inputMode, $data, $form) {
+    return $inputMode;
+}, 10, 3);
+```
+
+**Reference**
+
+`$inputMode = apply_filters('fluentform/mask_input_mode', $inputMode, $data, $form);`
+
+This filter is located in `app/Services/FormBuilder/Components/Text.php` (line 71).
+
+</explain-block>
+
+<explain-block title="fluentform/moment_date_time_format">
+
+**Parameters**
+
+- `$format` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/moment_date_time_format', function ($format) {
+    return $format;
+}, 10, 1);
+```
+
+**Reference**
+
+`return apply_filters('fluentform/moment_date_time_format', $format);`
+
+This filter is located in `app/Helpers/Helper.php` (line 1458).
+
+</explain-block>
+
+<explain-block title="fluentform/nonce_error">
+
+You can modify NONCE error message using this filter.
+
+**Parameters**
+
+- `$errorMessage` (string) Error Message
+
+**Usage**
+
+```php
+add_filter('fluentform/nonce_error', function ($errorMessage) {
+   // Do your stuff here
+
+   return $errorMessage;
 }, 10, 1);
 
 ```
 
-```php
-$disabled['ratings'] = [
-    'disabled'    => true,
-    'title'       => __('Ratings', 'fluentform'),
-    'description' => __('Ratings is not available with the free version. Please upgrade to pro to get all the advanced features.', 'fluentform'),
-    'image'       => '',
-    'video'       => 'https://www.youtube.com/embed/YGdkNspMaEs',
-];
-$disabled['tabular_grid'] = [
-    'disabled'    => true,
-    'title'       => __('Checkable Grid', 'fluentform'),
-    'description' => __('Checkable Grid is not available with the free version. Please upgrade to pro to get all the advanced features.', 'fluentform'),
-    'image'       => '',
-    'video'       => 'https://www.youtube.com/embed/ayI3TzXXANA',
-];
-```
-
 **Reference**
 
-`apply_filters('fluentform/disabled_components', $disabled);`
+`apply_filters('fluentform/nonce_error', $message);`
 
-This filter is located in FluentForm\app\Services\Form\FormServices -> getDisabledComponents()
-
-</explain-block>
-
-<explain-block title="fluentform/validation_error">
-
-This filter hook is fired before form render. You can use this to change rendered form.
-
-**Parameters**
-
-- `$errors` (array) Validation Errors
-- `$formData` (array) Form Data
-- `$form` (object) Form Object
-- `$fields` (array) Form Fields
-
-**Usage**
-
-```php
-add_filter('fluentform/validation_error', function ($errors, $formData, $form, $fields) {
-    // Do your stuff here
-    
-    return $returnData;
-}, 10, 4);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/validation_error', $errors, $this->form, $fields, $this->formData);`
-
-This filter is located in FluentForm\app\Services\Form\SubmissionHandlerService -> getReturnData($insertId, $form,
-$formData)
+This filter is located in FluentForm\App\Services\Form\FormValidationService -> validateNonce()
 
 </explain-block>
 
@@ -1339,171 +1483,136 @@ This filter is located in FluentForm\app\Services\Form\FormValidationService -> 
 
 </explain-block>
 
-<explain-block title="fluentform/https_local_ssl_verify">
-
-You can use this to toggle the local SSL verification for async requests.
+<explain-block title="fluentform/number_input_mode">
 
 **Parameters**
 
-- `$status` (boolean) Whether local SSL verification is enabled
+- `$inputMode` — see source
+- `$data` — see source
+- `$form` — see source
 
 **Usage**
 
 ```php
-add_filter('fluentform/https_local_ssl_verify', function ($status) {
-    // Do your stuff here
-    
-    return $status;
-}, 10, 1);
-
+add_filter('fluentform/number_input_mode', function ($inputMode, $data, $form) {
+    return $inputMode;
+}, 10, 3);
 ```
 
 **Reference**
 
-`apply_filters('fluentform/https_local_ssl_verify', false);`
+`$inputMode = apply_filters('fluentform/number_input_mode', $inputMode, $data, $form);`
 
-This filter is located in FluentForm\app\Services\WPAsync\FluentFormAsyncRequest -> dispatchAjax($data = [])
+This filter is located in `app/Services/FormBuilder/Components/Text.php` (line 126).
 
 </explain-block>
 
-<explain-block title="fluentform/conditional_shortcode_defaults">
+<explain-block title="fluentform/parse_default_value">
 
-You can use this filter to modify shortcode default.
+You can modify form default shortcode value using this filter.
 
 **Parameters**
 
-- `$default` (array) Shortcode Default
-- `$atts` (array) Shortcode Attributes
+- `$value` (string) Parseable Shortcode Value
+- `$form` (object) Form Object
 
 **Usage**
 
 ```php
-add_filter('fluentform/conditional_shortcode_defaults', function ($default, $atts) {
-    // Do your stuff here
-    
-    return $default;
-}, 10, 2);
+add_filter('fluentform/parse_default_value', function($value, $form) {
+   // Do your stuff here
 
-```
-```php
-$default = [
-    'field' => '',
-    'is'    => '',
-    'to'    => ''
-];
-```
-
-**Reference**
-
-`apply_filters('fluentform/conditional_shortcode_defaults', $default, $atts);`
-
-This filter is located in FluentFormPro\src\classes\ConditionalContent -> handle($atts, $content)
-
-</explain-block>
-
-<explain-block title="fluentform/disable_attachment_delete">
-
-You can toggle double option confirmation file attachment by using this filter.
-
-**Parameters**
-
-- `$status` (boolean) Whether the attachment is disabled
-- `$formId` (int) Form ID
-
-**Usage**
-
-```php
-add_filter('fluentform/disable_attachment_delete', function ($status, $formId) {
-    // Do your stuff here
-    
-    return $status;
+   return $value;
 }, 10, 2);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/disable_attachment_delete', $status, $entry->form_id));`
+`apply_filters('fluentform/parse_default_value', $attrDefaultValues[$pattern], $form);`
 
-This filter is located in FluentFormPro\src\classes\DoubleOption -> deleteAssociateFiles($entry)
+This filter is located in FluentForm\App\Modules\Component\Component -> replaceEditorSmartCodes($output, $form)
 
 </explain-block>
 
-<explain-block title="fluentform/style_presets">
+<explain-block title="fluentform/parse_default_values">
 
-You can modify form styler by using this filter.
+You can modify Shortcode's all parseable values using this filter.
 
 **Parameters**
 
-- `$presets` (array) Form Styler Presets
+- `$attrDefaultValues` (array) Parseable All Shortcode Values
 
 **Usage**
 
 ```php
-add_filter('fluentform/style_presets', function ($presets) {
-    // Do your stuff here
-    
-    return $presets;
-}, 10, 1);
+add_filter('fluentform/parse_default_values', function($attrDefaultValues) {
+   // Do your stuff here
 
-```
-```php
-$presets = [
-    '' => [
-        'label' => __('Default', ''),
-        'src' => ''
-    ],
-    'ffs_modern_b' => [
-        'label' => __('Modern (Bold)', ''),
-        'src' => FLUENTFORMPRO_DIR_URL . 'public/css/skin_modern_bold.css'
-    ],
-    'ffs_modern_l' => [
-        'label' => __('Modern (Light)', ''),
-        'src' => FLUENTFORMPRO_DIR_URL . 'public/css/skin_modern_light.css'
-    ],
-    'ffs_classic' => [
-        'label' => __('Classic', ''),
-        'src' => FLUENTFORMPRO_DIR_URL . 'public/css/skin_classic.css'
-    ],
-    'ffs_bootstrap' => [
-        'label' => __('Bootstrap Style', ''),
-        'src' => FLUENTFORMPRO_DIR_URL . 'public/css/skin_bootstrap.css'
-    ],
-];
-```
-
-**Reference**
-
-`apply_filters('fluentform/style_presets', $presets);`
-
-This filter is located in FluentFormPro\src\classes\FormStyler -> getPresets()
-
-</explain-block>
-
-<explain-block title="fluentform/post_type_selection_types_args">
-
-You can modify post type args using this filter.
-
-**Parameters**
-
-- `$args` (array) Post Type Args
-
-**Usage**
-
-```php
-add_filter('fluentform/post_type_selection_types_args', function ($args) {
-    // Do your stuff here
-    
-    return $args;
+   return $attrDefaultValues;
 }, 10, 1);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/post_type_selection_types_args', $args);`
+`apply_filters('fluentform/parse_default_values', $attrDefaultValues);`
 
-This filter is located in FluentFormPro\src\Components\PostSelectionField -> generalEditorElement()
+This filter is located in FluentForm\App\Modules\Component\Component -> replaceEditorSmartCodes($output, $form)
+
+</explain-block>
+
+<explain-block title="fluentform/pdf_html_format">
+
+You can set HTML formatted value on PDF header, body or footer using this filter.
+
+**Parameters**
+
+- `$feed` (array) PDF parts (header, body or footer)
+
+**Usage**
+
+```php
+add_filter('fluentform/pdf_html_format', function($feed) {
+    $feed[] = 'body';
+    return $feed;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/pdf_html_format', []);`
+
+This filter is located in FluentForm\app\Hooks\Filters.php
+
+</explain-block>
+
+<explain-block title="fluentform/permission_set">
+
+You can add or modify Fluentform Permission Set using this filter.
+
+**Parameters**
+
+- `$permissionSet` (array) Permission set
+
+**Usage**
+
+```php
+add_filter('fluentform/permission_set', function ($permissionSet) {
+   // Do your stuff here
+   
+   array_push($permissionSet, 'fluentform_dashboard_access');
+   return $permissionSet;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/permission_set', $data);`
+
+This filter is located in FluentForm\App\Modules\Acl -> getPermissionSet()
 
 </explain-block>
 
@@ -1590,58 +1699,382 @@ This filter is located in FluentFormPro\src\Components\PostSelectionField -> gen
 
 </explain-block>
 
-<explain-block title="fluentform/pdf_html_format">
+<explain-block title="fluentform/post_type_selection_types_args">
 
-You can set HTML formatted value on PDF header, body or footer using this filter.
+You can modify post type args using this filter.
 
 **Parameters**
 
-- `$feed` (array) PDF parts (header, body or footer)
+- `$args` (array) Post Type Args
 
 **Usage**
 
 ```php
-add_filter('fluentform/pdf_html_format', function($feed) {
-    $feed[] = 'body';
-    return $feed;
+add_filter('fluentform/post_type_selection_types_args', function ($args) {
+    // Do your stuff here
+    
+    return $args;
 }, 10, 1);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/pdf_html_format', []);`
+`apply_filters('fluentform/post_type_selection_types_args', $args);`
 
-This filter is located in FluentForm\app\Hooks\Filters.php
+This filter is located in FluentFormPro\src\Components\PostSelectionField -> generalEditorElement()
 
 </explain-block>
 
+<explain-block title="fluentform/pretty_url_base_slug">
 
-<explain-block title="fluentform/email_exists_validation_message">
+<Badge type="tip" vertical="top" text="Pro" /> <Badge type="warning" vertical="top" text="Added in 6.2.3" />
 
-Change User registration existing email validation message
+Change the base URL slug used by Pro's Pretty URL feature for Landing Pages and Conversational Form share pages. Default is `form`, producing URLs like `https://site.com/form/my-form/`.
 
 **Parameters**
-- `validationMsg` (string) Message
-- `$form` (object) Form Object
-- `$feed` (array) Integraion Feed Data
-- `$email` (string) Email 
+
+- `$baseSlug` (string) Default `'form'`
 
 **Usage**
 
 ```php
-add_filter('fluentform/email_exists_validation_message', function($validationMsg) {
-    $validationMsg = "This email is already registered. Please choose another one.";
-    return $validationMsg;
+add_filter('fluentform/pretty_url_base_slug', function ($baseSlug) {
+    return 'apply'; // → https://site.com/apply/my-form/
+}, 10, 1);
+```
+
+::: warning Flush rewrite rules
+After changing the base slug, visit Settings → Permalinks once (or call `flush_rewrite_rules()`) so WordPress picks up the new rewrite.
+:::
+
+**Reference**
+
+`apply_filters('fluentform/pretty_url_base_slug', 'form');`
+
+This filter is located in `FluentFormPro\classes\SharePage\FormPrettyUrlService`.
+
+</explain-block>
+
+<explain-block title="fluentform/recaptcha_v3_ref_score">
+
+You can set Recaptcha Reference Score using this filter. By default, score is set to 0.5.
+
+**Parameters**
+
+- `$score` Reference Score between 0 and 1
+
+**Usage**
+
+```php
+add_filter('fluentform/recaptcha_v3_ref_score', function($score) {
+   // Do your stuff here
+
+   return $score;
 }, 10, 1);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/email_exists_validation_message', $validationMsg, $form, $feed, $email);`
+`apply_filters('fluentforms/recaptcha_v3_ref_score', $value);`
 
-This filter is located in fluentformpro/src/Integrations/UserRegistration/UserRegistrationApi.php
+This filter is located in FluentForm\App\Modules\ReCaptcha\ReCaptcha -> validate($token, $secret = null, $version = '
+v2_visible')
+
+</explain-block>
+
+<explain-block title="fluentform/shortcode_defaults">
+
+This filter sets the defaults values for the shortcode.
+
+**Parameters**
+
+- `$defaults` (array) Default Shortcode Values
+- `$atts` (array) Shortcode Attributes
+
+**Usage**
+
+```php
+add_filter('fluentform/shortcode_defaults', function($defaults , $atts) {
+   // Do your stuff here
+
+   return $atts;
+}, 10, 2);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/shortcode_defaults', $data, $atts);`
+
+This filter is located in FluentForm\App\Modules\Component\Component -> addFluentFormShortCode()
+
+</explain-block>
+
+<explain-block title="fluentform/shortcode_feed_text">
+
+This filter returns the message of the shortcode for a feed.
+
+**Parameters**
+
+- `$feedText` (string) Shortcode Feed Text
+- `$form` (object) Form Object
+
+**Usage**
+
+```php
+add_filter('fluentform/shortcode_feed_text', function ($feedText, $form) {
+   // Do your stuff here
+
+   return $feedText;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/shortcode_feed_text', $feedText, $form);`
+
+This filter is located in FluentForm\App\Modules\Component\Component -> renderForm($atts)
+
+</explain-block>
+
+<explain-block title="'fluentform/shortcode_parser_callback_' . $key">
+
+You can use this filter to modify the any shortcode with matching key.
+
+**Parameters**
+
+- `$key` (string) Key Name
+- `$instance` (object) Shortcode Parser Instance
+
+**Usage**
+
+```php
+add_filter('fluentform/shortcode_parser_callback_' . $key, function ($key, $instance) {
+    // Do your stuff here
+    
+    return $key;
+}, 10, 3);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/shortcode_parser_callback_' . $key, static::getInstance());`
+
+This filter is located in FluentForm\App\Services\FormBuilder -> getOtherData($key)
+
+</explain-block>
+
+<explain-block title="fluentform/shortcode_parser_callback_pdf.download_link.public">
+
+You can use this filter to modify the public PDF download link.
+
+**Parameters**
+
+- `$key` (string) Key Name
+- `$instance` (object) Shortcode Parser Instance
+
+**Usage**
+
+```php
+add_filter('fluentform/shortcode_parser_callback_pdf.download_link.public', function ($key, $instance) {
+    // Do your stuff here
+    
+    return $key;
+}, 10, 2);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/shortcode_parser_callback_pdf.download_link.public', $key, $instance);`
+
+This filter is located in FluentForm\App\Services\FormBuilder -> getOtherData($key)
+
+</explain-block>
+
+<explain-block title="fluentform/shortcode_parser_callback_random_string">
+
+You can use this filter to modify the any shortcode with random string.
+
+**Parameters**
+
+- `$value` (string) Name of the Shortcode after .
+- `$prefix` (string) Prefix of the Shortcode before .
+- `$instance` (object) Shortcode Parser Instance
+
+**Usage**
+
+```php
+add_filter('fluentform/shortcode_parser_callback_random_string', function ($value, $prefix, $instance) {
+    // Do your stuff here
+    
+    return $value;
+}, 10, 3);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/shortcode_parser_callback_random_string', $value, $prefix, static::getInstance());`
+
+This filter is located in FluentForm\App\Services\FormBuilder -> getOtherData($key)
+
+</explain-block>
+
+<explain-block title="fluentform/show_hide_elements_debounce_time">
+
+**Parameters**
+
+- `$value` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/show_hide_elements_debounce_time', function ($value) {
+    return $value;
+}, 10, 1);
+```
+
+**Reference**
+
+`'debounce_time'    => apply_filters('fluentform/show_hide_elements_debounce_time', 300),`
+
+This filter is located in `app/Modules/Component/Component.php` (line 740).
+
+</explain-block>
+
+<explain-block title="fluentform/skip_no_conflict">
+
+You can toggle the no conflict mode using this filter.
+
+**Parameters**
+
+- `$isConflict` (boolean) Whether no conflict mode is enabled
+
+**Usage**
+
+```php
+add_filter('fluentform/skip_no_conflict', function ($isSkip) {
+   // Do your stuff here
+   
+   return $isSkip;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/skip_no_conflict', $isSkip);`
+
+This filter is located in FluentForm\App\Hooks\actions.php
+
+</explain-block>
+
+<explain-block title="fluentform/skip_validation_inputs_with_options">
+
+**Parameters**
+
+- `$value` — see source
+- `$fieldType` — see source
+- `$form` — see source
+- `$formData` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/skip_validation_inputs_with_options', function ($value, $fieldType, $form, $formData) {
+    return $value;
+}, 10, 4);
+```
+
+**Reference**
+
+`$skipValidationInputsWithOptions = apply_filters('fluentform/skip_validation_inputs_with_options', false, $fieldType, $form, $formData);`
+
+This filter is located in `app/Helpers/Helper.php` (line 1237).
+
+</explain-block>
+
+<explain-block title="'fluentform/smartcode_group_' . $group">
+
+You can use this filter to modify the smartcode with a specific group.
+
+**Parameters**
+
+- `$property` (string) Smartcode Name
+- `$instance` (object) Shortcode Parser Instance
+
+**Usage**
+
+```php
+add_filter('fluentform/smartcode_group_' . $group, function ($property, $instance) {
+    // Do your stuff here
+    
+    return $value;
+}, 10, 2);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/smartcode_group_' . $group, $property, static::getInstance());`
+
+This filter is located in FluentForm\App\Services\FormBuilder -> getOtherData($key)
+
+</explain-block>
+
+<explain-block title="fluentform/style_presets">
+
+You can modify form styler by using this filter.
+
+**Parameters**
+
+- `$presets` (array) Form Styler Presets
+
+**Usage**
+
+```php
+add_filter('fluentform/style_presets', function ($presets) {
+    // Do your stuff here
+    
+    return $presets;
+}, 10, 1);
+
+```
+```php
+$presets = [
+    '' => [
+        'label' => __('Default', ''),
+        'src' => ''
+    ],
+    'ffs_modern_b' => [
+        'label' => __('Modern (Bold)', ''),
+        'src' => FLUENTFORMPRO_DIR_URL . 'public/css/skin_modern_bold.css'
+    ],
+    'ffs_modern_l' => [
+        'label' => __('Modern (Light)', ''),
+        'src' => FLUENTFORMPRO_DIR_URL . 'public/css/skin_modern_light.css'
+    ],
+    'ffs_classic' => [
+        'label' => __('Classic', ''),
+        'src' => FLUENTFORMPRO_DIR_URL . 'public/css/skin_classic.css'
+    ],
+    'ffs_bootstrap' => [
+        'label' => __('Bootstrap Style', ''),
+        'src' => FLUENTFORMPRO_DIR_URL . 'public/css/skin_bootstrap.css'
+    ],
+];
+```
+
+**Reference**
+
+`apply_filters('fluentform/style_presets', $presets);`
+
+This filter is located in FluentFormPro\src\classes\FormStyler -> getPresets()
 
 </explain-block>
 
@@ -1669,29 +2102,31 @@ This filter is located in the FluentForm\App\Modules\Form\TokenBasedSpamProtecti
 
 </explain-block>
 
-<explain-block title="fluentform/generated_protection_token">
+<explain-block title="fluentform/token_based_spam_protection_status">
 
-This filter allows you to modify the generated protection token.
+This filter allows you to modify the status of token-based spam protection for a specific form. You can use this to enable or disable protection for certain forms based on custom logic.
 
 **Parameters**
 
-- `$token` (string) The encrypted token
-- `$formId` (int) The ID of the form
-- `$timeStamp` (int) The current timestamp
+- `$status` (bool) The current status of token-based protection 
+- `$formId` (int|false) The ID of the form, or false if not specific to a form
 
 **Usage**
 
 ```php
-add_filter('fluentform/generated_protection_token', function ($token, $formId, $timeStamp) {
-    // Modify the token
-    return $token;
-}, 10, 3);
+add_filter('fluentform/token_based_spam_protection_status', function ($status, $formId) {
+    // Disable protection for a specific form
+    if ($formId === 123) {
+        return false;
+    }
+    return $status;
+}, 10, 2);
 ```
 **Reference**
 
-`apply_filters('fluentform/generated_protection_token', Protector::encrypt($data), $formId, $timeStamp);`
+`apply_filters('fluentform/token_based_spam_protection_status', $status, $formId);`
 
-This filter is located in the FluentForm\App\Modules\Form\TokenBasedSpamProtection -> generateToken method.
+This filter is located in the FluentForm\App\Modules\Form\TokenBasedSpamProtection -> isEnabled method.
 
 </explain-block>
 
@@ -1717,33 +2152,6 @@ add_filter('fluentform/token_based_validation_error_message', function ($errorMe
 `apply_filters('fluentform/token_based_validation_error_message', __('Suspicious activity detected. Form submission blocked', 'fluentform'), $formId);`
 
 This filter is located in the FluentForm\App\Modules\Form\TokenBasedSpamProtection -> verify method.
-
-</explain-block>
-
-<explain-block title="fluentform/token_expiration_time">
-
-This filter allows you to modify the expiration time for the protection token. If the protection token expires, form submission will fail. Adjust this value based on your security requirements and expected user behavior.
-
-**Parameters**
-
-- `$expirationTime` (int) The default expiration time in seconds 
-- `$formId` (int) The ID of the form
-
-**Usage**
-
-```php
-add_filter('fluentform/token_expiration_time', function ($expirationTime, $formId) {
-    // Modify the expiration time
-    // Default is (3600s = 1 hour)
-    $expirationTime = 1800; // 30 minutes
-    return $expirationTime;
-}, 10, 2);
-```
-**Reference**
-
-`apply_filters('fluentform/token_expiration_time', 3600, $formId);`
-
-This filter is located in the FluentForm\App\Modules\Form\TokenBasedSpamProtection -> validateToken method.
 
 </explain-block>
 
@@ -1775,39 +2183,36 @@ This filter is located in the FluentForm\App\Modules\Form\TokenBasedSpamProtecti
 
 </explain-block>
 
-<explain-block title="fluentform/token_based_spam_protection_status">
+<explain-block title="fluentform/token_expiration_time">
 
-This filter allows you to modify the status of token-based spam protection for a specific form. You can use this to enable or disable protection for certain forms based on custom logic.
-
+This filter allows you to modify the expiration time for the protection token. If the protection token expires, form submission will fail. Adjust this value based on your security requirements and expected user behavior.
 
 **Parameters**
 
-- `$status` (bool) The current status of token-based protection 
-- `$formId` (int|false) The ID of the form, or false if not specific to a form
+- `$expirationTime` (int) The default expiration time in seconds 
+- `$formId` (int) The ID of the form
 
 **Usage**
 
 ```php
-add_filter('fluentform/token_based_spam_protection_status', function ($status, $formId) {
-    // Disable protection for a specific form
-    if ($formId === 123) {
-        return false;
-    }
-    return $status;
+add_filter('fluentform/token_expiration_time', function ($expirationTime, $formId) {
+    // Modify the expiration time
+    // Default is (3600s = 1 hour)
+    $expirationTime = 1800; // 30 minutes
+    return $expirationTime;
 }, 10, 2);
 ```
 **Reference**
 
-`apply_filters('fluentform/token_based_spam_protection_status', $status, $formId);`
+`apply_filters('fluentform/token_expiration_time', 3600, $formId);`
 
-This filter is located in the FluentForm\App\Modules\Form\TokenBasedSpamProtection -> isEnabled method.
+This filter is located in the FluentForm\App\Modules\Form\TokenBasedSpamProtection -> validateToken method.
 
 </explain-block>
 
 <explain-block title="fluentform/token_protection_name">
 
 This filter allows you to modify the name of the token protection field. This can be useful for customizing the field name or implementing additional obfuscation.
-
 
 **Parameters**
 
@@ -1830,26 +2235,160 @@ This filter is located in the FluentForm\App\Modules\Form\TokenBasedSpamProtecti
 
 </explain-block>
 
-<explain-block title="fluentform/double_optin_invalid_confirmation_url_message">
+<explain-block title="fluentform/validation_error">
 
-This filter allows you to customize double optin invalid confirmation URL messages
+This filter hook is fired before form render. You can use this to change rendered form.
 
 **Parameters**
 
-- `$message` (string) The default massage
+- `$errors` (array) Validation Errors
+- `$formData` (array) Form Data
+- `$form` (object) Form Object
+- `$fields` (array) Form Fields
 
 **Usage**
 
 ```php
-add_filter('fluentform/double_optin_invalid_confirmation_url_message', function ($message) {
-    // Modify the message
-    return __('Sorry! Invalid Form Confirmation URL. Please contact the site admin.', 'fluentformpro');
-}, 10, 2);
+add_filter('fluentform/validation_error', function ($errors, $formData, $form, $fields) {
+    // Do your stuff here
+    
+    return $returnData;
+}, 10, 4);
+
 ```
+
 **Reference**
 
-`apply_filters('fluentform/double_optin_invalid_confirmation_url_message', __('Sorry! Invalid Form Confirmation URL', 'fluentformpro'));`
+`apply_filters('fluentform/validation_error', $errors, $this->form, $fields, $this->formData);`
 
-This filter is located in the `FluentFormPro\classes\DoubleOptin` -> `confirmSubmission` method.
+This filter is located in FluentForm\app\Services\Form\SubmissionHandlerService -> getReturnData($insertId, $form,
+$formData)
+
+</explain-block>
+
+<explain-block title="fluentform/validation_message_unique_">
+
+**Parameters**
+
+- See source
+
+**Usage**
+
+```php
+add_filter('fluentform/validation_message_unique_', function ($value) {
+    return $value;
+}, 10, 1);
+```
+
+**Reference**
+
+`'unique' => apply_filters('fluentform/validation_message_unique_' . $typeName,`
+
+This filter is located in `app/Helpers/Helper.php` (line 583).
+
+</explain-block>
+
+<explain-block title="fluentform/validation_post_update_errors">
+
+**Parameters**
+
+- `$errors` — see source
+- `$formData` — see source
+- `$this` — see source
+- `$fields` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/validation_post_update_errors', function ($errors, $formData, $this, $fields) {
+    return $errors;
+}, 10, 4);
+```
+
+**Reference**
+
+`$errors = apply_filters('fluentform/validation_post_update_errors', $errors, $formData, $this->form, $fields);`
+
+This filter is located in `app/Services/Form/FormValidationService.php` (line 208).
+
+</explain-block>
+
+<explain-block title="'fluentform/verify_user_permission_' . $permission">
+
+This filter verifies each permission.
+
+**Parameters**
+
+- `$allowed` (array) Form default Settings
+- `$formId` (int) Form ID
+
+**Usage**
+
+```php
+add_filter('fluentform/verify_user_permission_' . $permission, function ($allowed, $formId) {
+   // Do your stuff here
+
+   return $allowed;
+}, 10, 2);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/verify_user_permission_' . $permission, $allowed, $formId);`
+
+This filter is located in FluentForm\App\Modules\Acl -> hasPermission($permissions, $formId = false)
+
+</explain-block>
+
+<explain-block title="fluentform/white_listed_fields">
+
+**Parameters**
+
+- `$whiteListedFields` — see source
+- `$formId` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/white_listed_fields', function ($whiteListedFields, $formId) {
+    return $whiteListedFields;
+}, 10, 2);
+```
+
+**Reference**
+
+`return apply_filters('fluentform/white_listed_fields', $whiteListedFields, $formId);`
+
+This filter is located in `app/Helpers/Helper.php` (line 1374).
+
+</explain-block>
+
+<explain-block title="fluentform/will_parse_url_value">
+
+You can toggle redirect URL parsing in confirmation Message using the filter.
+
+**Parameters**
+
+- `$status` (boolean) Whether Parse the URL
+- `$form` (object) Form Object
+
+**Usage**
+
+```php
+add_filter('fluentform/will_parse_url_value', function($status, $form) {
+   // Do your stuff here
+
+   return $status;
+}, 10, 2);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/will_parse_url_value', $parseUrl, $form);`
+
+This filter is located in FluentForm\App\Services\Form\SubmissionHandlerServices -> getReturnData($insertId, $form,
+$formData)
 
 </explain-block>

--- a/src/hooks/filters/payment.md
+++ b/src/hooks/filters/payment.md
@@ -4,60 +4,573 @@
 
 These filters let you modify payment processing, order items, statuses, receipts, and gateway-specific settings.
 
-<explain-block title="fluentform/payment_submission_data">
+<explain-block title="fluentform/accepted_currencies">
 
-You can use this filter to modify payment form submission data.
+You can use this filter to modify payment methods accepted currencies list.
 
 **Parameters**
 
-- `$submission` (string) Form Submission Data
-- `$form` (object) Form Object
+- `$currencies` (array) Base Payment Method Currencies
 
 **Usage**
 
 ```php
-add_filter('fluentform/payment_submission_data', function ($submission, $form) {
+add_filter('fluentform/accepted_currencies', function ($currencies) {
     // Do your stuff here
     
-    return $submission;
+    return $currencies;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/accepted_currencies', $currencies);`
+
+This filter is located in FluentFormPro\src\Payments\PaymentHandler -> getCurrencies()
+
+</explain-block>
+
+<explain-block title="fluentform/authorizenet_modal_styles">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$defaultStyles` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/authorizenet_modal_styles', function ($defaultStyles) {
+    return $defaultStyles;
+}, 10, 1);
+```
+
+**Reference**
+
+`return apply_filters('fluentform/authorizenet_modal_styles', $defaultStyles);`
+
+This filter is located in `src/Payments/PaymentMethods/AuthorizeNet/AuthorizeNetProcessor.php` (line 802).
+
+</explain-block>
+
+<explain-block title="fluentform/available_payment_methods">
+
+You can use this filter to modify available payment methods.
+
+**Parameters**
+
+- `$available_methods` (array) Available Payment Methods
+
+**Usage**
+
+```php
+add_filter('fluentform/available_payment_methods', function ($available_methods) {
+    // Do your stuff here
+    
+    return $available_methods;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/available_payment_methods', $available_methods);`
+
+This filter is located in FluentFormPro\src\Payments\Components\PaymentMethods -> getComponent()
+
+</explain-block>
+
+<explain-block title="fluentform/available_payment_statuses">
+
+You can use this filter to modify payment statuses.
+
+**Parameters**
+
+- `$paymentStatuses` (array) Payment Statuses
+
+**Usage**
+
+```php
+add_filter('fluentform/available_payment_statuses', function ($paymentStatuses) {
+    // Do your stuff here
+    
+    return $paymentStatuses;
+}, 10, 1);
+
+```
+```php
+$paymentStatuses = [
+    'paid'               => __('Paid', 'fluentformpro'),
+    'processing'         => __('Processing', 'fluentformpro'),
+    'pending'            => __('Pending', 'fluentformpro'),
+    'failed'             => __('Failed', 'fluentformpro'),
+    'refunded'           => __('Refunded', 'fluentformpro'),
+    'partially-refunded' => __('Partial Refunded', 'fluentformpro'),
+    'cancelled'          => __('Cancelled', 'fluentformpro'),
+    'requires_review'    => __('Requires Review', 'fluentformpro')
+];
+```
+
+**Reference**
+
+`apply_filters('fluentform/available_payment_statuses', $paymentStatuses);`
+
+This filter is located in FluentFormPro\src\Payments\PaymentHelper -> getPaymentStatuses()
+
+</explain-block>
+
+<explain-block title="fluentform/currencies_symbols">
+
+You can use this filter to modify currency symbols of payment methods accepted currencies.
+
+**Parameters**
+
+- `$symbols` (array) Currency Symbols List in Unicode
+
+**Usage**
+
+```php
+add_filter('fluentform/currencies_symbols', function ($symbols) {
+    // Do your stuff here
+    
+    return $symbols;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/currencies_symbols', $symbols);`
+
+This filter is located in FluentFormPro\src\Payments\PaymentHelper -> getCurrencySymbols()
+
+</explain-block>
+
+<explain-block title="fluentform/currency_symbol">
+
+You can use this filter to modify currency symbols of payment methods accepted currencies.
+
+**Parameters**
+
+- `$currency_symbol` (string) Currency Symbol in Unicode
+- `$currency` (string) Currency Name
+
+**Usage**
+
+```php
+add_filter('fluentform/currency_symbol', function ($currency_symbol, $currency) {
+    // Do your stuff here
+    
+    return $currency_symbol;
 }, 10, 2);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/payment_submission_data', $submission, $this->form);`
+`apply_filters('fluentform/currency_symbol', $currency_symbol, $currency);`
 
-This filter is located in FluentFormPro\src\Payments\Classes\PaymentAction -> draftFormEntry()
+This filter is located in FluentFormPro\src\Payments\PaymentHandler -> getCurrencySymbol($currency = '')
 
 </explain-block>
 
-<explain-block title="fluentform/submission_order_items">
+<explain-block title="fluentform/disable_stripe_connect">
 
-You can use this filter to modify payment order items data.
+You can use this filter to toggle stripe connection.
 
 **Parameters**
 
-- `$orderItems` (array) Payment Order Items
-- `$submissionData` (array) Form Submission Data
-- `$form` (object) Form Object
+- `$isDisableStripeConnect` (boolean) Whether Stripe Connection is disabled, By Default false
 
 **Usage**
 
 ```php
-add_filter('fluentform/submission_order_items', function ($orderItems, $submissionData, $form) {
+add_filter('fluentform/disable_stripe_connect', function ($isDisableStripeConnect) {
     // Do your stuff here
-
-    return $orderItems;
-}, 10, 3);
+    
+    return $isDisableStripeConnect;
+}, 10, 1);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/submission_order_items', $this->orderItems, $this->submissionData, $this->form);`
+`apply_filters('fluentform/disable_stripe_connect', $isDisableStripeConnect);`
 
-This filter is located in FluentFormPro\src\Payments\Classes\PaymentAction -> getOrderItems($forced = false)
+This filter is located in FluentFormPro\src\PaymentMethods\Stripe\StripeSettings -> getSettings()
+
+</explain-block>
+
+<explain-block title="fluentform/form_payment_settings">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$paymentSettings` — see source
+- `$formId` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/form_payment_settings', function ($paymentSettings, $formId) {
+    return $paymentSettings;
+}, 10, 2);
+```
+
+**Reference**
+
+`$paymentSettings = apply_filters('fluentform/form_payment_settings', $paymentSettings, $formId);`
+
+This filter is located in `src/Payments/AjaxEndpoints.php` (line 231).
+
+</explain-block>
+
+<explain-block title="fluentform/global_settings_component_payment_vars">
+
+**Parameters**
+
+- `$paymentVars` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/global_settings_component_payment_vars', function ($paymentVars) {
+    return $paymentVars;
+}, 10, 1);
+```
+
+**Reference**
+
+`$globalSettingVars['payment_vars'] = apply_filters('fluentform/global_settings_component_payment_vars', $paymentVars);`
+
+This filter is located in `app/Modules/Payments/PaymentHandler.php` (line 391).
+
+</explain-block>
+
+<explain-block title="fluentform/global_settings_payment_sub_menu_items">
+
+**Parameters**
+
+- `$subMenuItems` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/global_settings_payment_sub_menu_items', function ($subMenuItems) {
+    return $subMenuItems;
+}, 10, 1);
+```
+
+**Reference**
+
+`$subMenuItems = apply_filters('fluentform/global_settings_payment_sub_menu_items', $subMenuItems);`
+
+This filter is located in `app/Modules/Payments/PaymentHandler.php` (line 324).
+
+</explain-block>
+
+<explain-block title="fluentform/mollie_payment_args">
+
+You can use this filter to modify payment arguments of mollie payment method.
+
+**Parameters**
+
+- `$paymentArgs` (array) Mollie Payment Arguments
+- `$submission` (array) Form Submission
+- `$transaction` (array) Payment Transaction
+- `$form` (object) Form Object
+
+**Usage**
+
+```php
+add_filter('fluentform/mollie_payment_args', function ($paymentArgs, $submission, $transaction, $form) {
+    // Do your stuff here
+    
+    return $paymentArgs;
+}, 10, 4);
+
+```
+```php
+$paymentArgs = [
+    'amount' => [
+        'currency' => $transaction->currency,
+        'value' => number_format((float) $transaction->payment_total / 100, 2, '.', '')
+    ],
+    'description' => $form->title,
+    'redirectUrl' => $successUrl,
+    'webhookUrl' => $listener_url,
+    'metadata' => json_encode([
+        'form_id' => $form->id,
+        'submission_id' => $submission->id
+    ]),
+    'sequenceType' => 'oneoff'
+];
+```
+
+**Reference**
+
+`apply_filters('fluentform/mollie_payment_args',  $paymentArgs, $submission, $transaction, $form);`
+
+This filter is located in FluentFormPro\src\PaymentMethods\Mollie\MollieProcessor -> handleRedirect($transaction, $submission, $form, $methodSettings)
+
+</explain-block>
+
+<explain-block title="fluentform/paddle_amount_mismatch_strict">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$value` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/paddle_amount_mismatch_strict', function ($value) {
+    return $value;
+}, 10, 1);
+```
+
+**Reference**
+
+`$strict = apply_filters('fluentform/paddle_amount_mismatch_strict', true);`
+
+This filter is located in `src/Payments/PaymentMethods/Paddle/PaddleProcessor.php` (line 438).
+
+</explain-block>
+
+<explain-block title="fluentform/paddle_checkout_vars">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$checkoutVars` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/paddle_checkout_vars', function ($checkoutVars) {
+    return $checkoutVars;
+}, 10, 1);
+```
+
+**Reference**
+
+`apply_filters('fluentform/paddle_checkout_vars', $checkoutVars));`
+
+This filter is located in `src/Payments/PaymentMethods/Paddle/PaddleProcessor.php` (line 567).
+
+</explain-block>
+
+<explain-block title="fluentform/paddle_payment_args">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$paymentArgs` — see source
+- `$submission` — see source
+- `$transaction` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/paddle_payment_args', function ($paymentArgs, $submission, $transaction, $form) {
+    return $paymentArgs;
+}, 10, 4);
+```
+
+**Reference**
+
+`$paymentArgs = apply_filters('fluentform/paddle_payment_args', $paymentArgs, $submission, $transaction, $form);`
+
+This filter is located in `src/Payments/PaymentMethods/Paddle/PaddleProcessor.php` (line 178).
+
+</explain-block>
+
+<explain-block title="'fluentform/pay_method_has_sub_cancel_' . $method">
+
+You can use this filter to modify payment method if subscription has been canceled.
+
+**Parameters**
+
+- `$hasCancel` (boolean) Whether Payment Subscription Has Been Canceled
+
+**Usage**
+
+```php
+add_filter('fluentform/pay_method_has_sub_cancel_' . $method, function ($hasCancel) {
+    // Do your stuff here
+    
+    return $hasCancel;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/pay_method_has_sub_cancel_' . $method,  false);`
+
+This filter is located in FluentFormPro\src\TransactionShortcodes -> canCancelSubscription($subscription)
+
+</explain-block>
+
+<explain-block title="fluentform/payment_config">
+
+**Parameters**
+
+- `$paymentConfig` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/payment_config', function ($paymentConfig, $form) {
+    return $paymentConfig;
+}, 10, 2);
+```
+
+**Reference**
+
+`$paymentConfig = apply_filters('fluentform/payment_config', $paymentConfig, $form->id);`
+
+This filter is located in `app/Modules/Payments/PaymentHandler.php` (line 211).
+
+</explain-block>
+
+<explain-block title="fluentform/payment_confirmation_message">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$message` — see source
+- `$this` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/payment_confirmation_message', function ($message, $this, $form) {
+    return $message;
+}, 10, 3);
+```
+
+**Reference**
+
+`$message = apply_filters('fluentform/payment_confirmation_message', $message, $this->getSubmission(), $form);`
+
+This filter is located in `src/Payments/PaymentMethods/BaseProcessor.php` (line 546).
+
+</explain-block>
+
+<explain-block title="fluentform/payment_confirming_message">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$message` — see source
+- `$submission` — see source
+- `$this` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/payment_confirming_message', function ($message, $submission, $this) {
+    return $message;
+}, 10, 3);
+```
+
+**Reference**
+
+`'confirming_text'    => apply_filters('fluentform/payment_confirming_message', __('Confirming Payment, Please wait...', 'fluentformpro'), $submission, $this->getForm()),`
+
+This filter is located in `src/Payments/PaymentMethods/Paystack/PaystackProcessor.php` (line 227).
+
+</explain-block>
+
+<explain-block title="fluentform/payment_entries_human_date">
+
+You can use this filter to get payment submission date as human-readable format.
+
+**Parameters**
+
+- `$status` (boolean) Whether Payment Submission Date is in human-readable Format
+
+**Usage**
+
+```php
+add_filter('fluentform/payment_entries_human_date', function ($status) {
+    // Do your stuff here
+    
+    return $status;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/payment_entries_human_date', true);`
+
+This filter is located in FluentFormPro\src\Payments\Classes\PaymentEntries -> loadApp()
+
+</explain-block>
+
+<explain-block title="fluentform/payment_error_message">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$errorMessage` — see source
+- `$value` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/payment_error_message', function ($errorMessage, $value, $form) {
+    return $errorMessage;
+}, 10, 3);
+```
+
+**Reference**
+
+`$errors[] = apply_filters('fluentform/payment_error_message', $errorMessage, null, $form);`
+
+This filter is located in `src/Payments/PaymentMethods/Square/SquareProcessor.php` (line 411).
+
+</explain-block>
+
+<explain-block title="fluentform/payment_failed_title">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$title` — see source
+- `$this` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/payment_failed_title', function ($title, $this, $form) {
+    return $title;
+}, 10, 3);
+```
+
+**Reference**
+
+`$title = apply_filters('fluentform/payment_failed_title', $title, $this->getSubmission(), $form);`
+
+This filter is located in `src/Payments/PaymentMethods/BaseProcessor.php` (line 536).
 
 </explain-block>
 
@@ -90,59 +603,49 @@ This filter is located in FluentFormPro\src\Payments\Classes\PaymentAction -> ge
 
 </explain-block>
 
-<explain-block title="fluentform/submission_subscription_items">
-
-You can use this filter to modify payment subscription items data.
+<explain-block title="fluentform/payment_gateway_messages">
 
 **Parameters**
 
-- `$subscriptionItems` (array) Payment Subscription Items
-- `$submissionData` (array) Form Submission Data
-- `$form` (object) Form Object
+- `$gatewayMessages` — see source
+- `$form` — see source
 
 **Usage**
 
 ```php
-add_filter('fluentform/submission_subscription_items', function ($subscriptionItems, $submissionData, $form) {
-    // Do your stuff here
-
-    return $subscriptionItems;
-}, 10, 3);
-
+add_filter('fluentform/payment_gateway_messages', function ($gatewayMessages, $form) {
+    return $gatewayMessages;
+}, 10, 2);
 ```
 
 **Reference**
 
-`apply_filters('fluentform/submission_subscription_items', $this->subscriptionItems, $this->submissionData, $this->form);`
+`$gatewayMessages = apply_filters('fluentform/payment_gateway_messages', $gatewayMessages, $form);`
 
-This filter is located in FluentFormPro\src\Payments\Classes\PaymentAction -> getSubscriptionItems()
+This filter is located in `app/Modules/Component/Component.php` (line 1557).
 
 </explain-block>
 
-<explain-block title="fluentform/payment_entries_human_date">
-
-You can use this filter to get payment submission date as human-readable format.
+<explain-block title="fluentform/payment_handler_messages">
 
 **Parameters**
 
-- `$status` (boolean) Whether Payment Submission Date is in human-readable Format
+- `$paymentMessages` — see source
+- `$form` — see source
 
 **Usage**
 
 ```php
-add_filter('fluentform/payment_entries_human_date', function ($status) {
-    // Do your stuff here
-    
-    return $status;
-}, 10, 1);
-
+add_filter('fluentform/payment_handler_messages', function ($paymentMessages, $form) {
+    return $paymentMessages;
+}, 10, 2);
 ```
 
 **Reference**
 
-`apply_filters('fluentform/payment_entries_human_date', true);`
+`$paymentMessages = apply_filters('fluentform/payment_handler_messages', $paymentMessages, $form);`
 
-This filter is located in FluentFormPro\src\Payments\Classes\PaymentEntries -> loadApp()
+This filter is located in `app/Modules/Component/Component.php` (line 1526).
 
 </explain-block>
 
@@ -173,31 +676,248 @@ This filter is located in FluentFormPro\src\Payments\Classes\PaymentManagement -
 
 </explain-block>
 
-<explain-block title="fluentform/payment_receipt_pre_render_payment_info">
+<explain-block title="'fluentform/payment_method_contents_' . $methodName">
 
-You can use this filter to modify payment information pre render text.
+You can use this filter to modify specific payment method contents.
 
 **Parameters**
 
-- `$preRender` (string) Payment Info Text
-- `$entry` (object) Form Submission Object
+- `$selectedMarkups` (string) Payment Content Markup in HTML
+- `$method` (array) Payment Method
+- `$data` (array) Form Data
+- `$form` (object) Form Object
 
 **Usage**
 
 ```php
-add_filter('fluentform/payment_receipt_pre_render_payment_info', function ($preRender, $entry) {
+add_filter('fluentform/payment_method_contents_' . $methodName, function ($selectedMarkups, $method, $data, $form) {
     // Do your stuff here
     
-    return $preRender;
+    return $selectedMarkups;
+}, 10, 4);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/payment_method_contents_' . $methodName, $selectedMarkups, $method, $data, $form);`
+
+This filter is located in FluentFormPro\src\Payments\Components\PaymentMethods -> render($data, $form)
+
+</explain-block>
+
+<explain-block title="'fluentform/payment_method_public_name_' . $paymentMethod">
+
+You can use this filter to modify payment method to before showing payment info.
+
+**Parameters**
+
+- `$paymentMethod` (array) Payment Method Details
+
+**Usage**
+
+```php
+add_filter('fluentform/payment_method_public_name_' . $paymentMethod, function ($paymentMethod) {
+    // Do your stuff here
+    
+    return $paymentMethod;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/payment_method_public_name_' . $paymentMethod',  $paymentMethod);`
+
+This filter is located in FluentFormPro\src\views\receipt\payment-info.php
+
+</explain-block>
+
+<explain-block title="'fluentform/payment_method_settings_save_' . $method">
+
+You can use this filter to modify payment methods settings before saving.
+
+**Parameters**
+
+- `$settings` (array) Payment Method Settings
+
+**Usage**
+
+```php
+add_filter('fluentform/payment_method_settings_save_' . $method, function ($settings) {
+    // Do your stuff here
+    
+    return $settings;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/payment_method_settings_save_' . $method, $settings);`
+
+This filter is located in FluentFormPro\src\Payments\AjaxEndpoints -> savePaymentMethodSettings()
+
+</explain-block>
+
+<explain-block title="'fluentform/payment_method_settings_validation_' . $method">
+
+You can use this filter to modify payment methods validation settings.
+
+**Parameters**
+
+- `$payments` (array) Payment Method Settings
+
+**Usage**
+
+```php
+add_filter('fluentform/payment_method_settings_validation_' . $method, function ($payments, $settings) {
+    // Do your stuff here
+    
+    return $payments;
 }, 10, 2);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/payment_receipt_pre_render_payment_info', $preRender, $this->entry);`
+`apply_filters('fluentform/payment_method_settings_validation_' . $method, [], $settings);`
 
-This filter is located in FluentFormPro\src\Payments\Classes\PaymentReceipt -> paymentInfo()
+This filter is located in FluentFormPro\src\Payments\AjaxEndpoints -> savePaymentMethodSettings()
+
+</explain-block>
+
+<explain-block title="fluentform/payment_methods_global_settings">
+
+You can use this filter to modify payment methods global settings.
+
+**Parameters**
+
+- `$globalSettings` (array) Base Payment Method Global Settings
+
+**Usage**
+
+```php
+add_filter('fluentform/payment_methods_global_settings', function ($globalSettings) {
+    // Do your stuff here
+    
+    return $globalSettings;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/payment_methods_global_settings', $globalSettings);`
+
+This filter is located in FluentFormPro\src\Payments\PaymentHandler -> renderPaymentSettings()
+
+</explain-block>
+
+<explain-block title="fluentform/payment_modal_opening_message">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$message` — see source
+- `$submission` — see source
+- `$this` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/payment_modal_opening_message', function ($message, $submission, $this) {
+    return $message;
+}, 10, 3);
+```
+
+**Reference**
+
+`'message'            => apply_filters('fluentform/payment_modal_opening_message', __('Payment Modal is opening, Please complete the payment', 'fluentformpro'), $submission, $this->getForm()),`
+
+This filter is located in `src/Payments/PaymentMethods/Paystack/PaystackProcessor.php` (line 226).
+
+</explain-block>
+
+<explain-block title="fluentform/payment_pending_message">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$pendingMessage` — see source
+- `$submission` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/payment_pending_message', function ($pendingMessage, $submission, $form) {
+    return $pendingMessage;
+}, 10, 3);
+```
+
+**Reference**
+
+`'error'     => apply_filters('fluentform/payment_pending_message', $pendingMessage, $submission, $form)`
+
+This filter is located in `src/Payments/PaymentMethods/BaseProcessor.php` (line 808).
+
+</explain-block>
+
+<explain-block title="fluentform/payment_pending_title">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$pendingTitle` — see source
+- `$submission` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/payment_pending_title', function ($pendingTitle, $submission, $form) {
+    return $pendingTitle;
+}, 10, 3);
+```
+
+**Reference**
+
+`'title'     => apply_filters('fluentform/payment_pending_title', $pendingTitle, $submission, $form),`
+
+This filter is located in `src/Payments/PaymentMethods/BaseProcessor.php` (line 806).
+
+</explain-block>
+
+<explain-block title="fluentform/payment_receipt_pre_render_item_details">
+
+You can use this filter to modify payment order items pre render text.
+
+**Parameters**
+
+- `$preRender` (string) Payment Order Item Text
+- `$entry` (object) Form Submission Object
+- `$orderItems` (object) Order Items Object
+
+**Usage**
+
+```php
+add_filter('fluentform/payment_receipt_pre_render_item_details', function ($preRender, $entry, $orderItems) {
+    // Do your stuff here
+    
+    return $preRender;
+}, 10, 3);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/payment_receipt_pre_render_item_details', $preRender, $this->entry, $orderItems);`
+
+This filter is located in FluentFormPro\src\Payments\Classes\PaymentReceipt -> itemDetails()
 
 </explain-block>
 
@@ -229,32 +949,28 @@ This filter is located in FluentFormPro\src\Payments\Classes\PaymentReceipt -> p
 
 </explain-block>
 
-<explain-block title="fluentform/payment_receipt_pre_render_item_details">
+<explain-block title="fluentform/payment_receipt_pre_render_payment_info_list">
 
-You can use this filter to modify payment order items pre render text.
+<Badge type="tip" vertical="top" text="Pro" />
 
 **Parameters**
 
-- `$preRender` (string) Payment Order Item Text
-- `$entry` (object) Form Submission Object
-- `$orderItems` (object) Order Items Object
+- `$preRender` — see source
+- `$this` — see source
 
 **Usage**
 
 ```php
-add_filter('fluentform/payment_receipt_pre_render_item_details', function ($preRender, $entry, $orderItems) {
-    // Do your stuff here
-    
+add_filter('fluentform/payment_receipt_pre_render_payment_info_list', function ($preRender, $this) {
     return $preRender;
-}, 10, 3);
-
+}, 10, 2);
 ```
 
 **Reference**
 
-`apply_filters('fluentform/payment_receipt_pre_render_item_details', $preRender, $this->entry, $orderItems);`
+`$preRender = apply_filters('fluentform/payment_receipt_pre_render_payment_info_list', $preRender, $this->entry);`
 
-This filter is located in FluentFormPro\src\Payments\Classes\PaymentReceipt -> itemDetails()
+This filter is located in `src/Payments/Classes/PaymentReceipt.php` (line 226).
 
 </explain-block>
 
@@ -315,171 +1031,32 @@ This filter is located in FluentFormPro\src\Payments\Classes\PaymentReceipt -> g
 
 </explain-block>
 
-<explain-block title="'fluentform/payment_field_' . $elementName . '_pricing_options'">
+<explain-block title="fluentform/payment_receipt_template_base_path">
 
-You can use this filter to modify payment pricing options.
+You can use this filter to change payment receipt template base path.
 
 **Parameters**
 
-- `$pricingOptions` (array) Payment Pricing Options
-- `$item` (array) Form Payment Inputs
-- `$form` (object) Form Object
+- `$basePath` (string) Base Path
+- `$fileName` (string) File Name
+- `$data` (array) Payment Receipt Data
 
 **Usage**
 
 ```php
-add_filter('fluentform/payment_field_' . $elementName . '_pricing_options', function ($pricingOptions, $item, $form) {
+add_filter('fluentform/payment_receipt_template_base_path', function ($basePath, $fileName, $data) {
     // Do your stuff here
     
-    return $pricingOptions;
+    return $basePath;
 }, 10, 3);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/payment_field_' . $elementName . '_pricing_options', $pricingOptions, $item, $this->form);`
+`apply_filters('fluentform/payment_receipt_template_base_path',  FLUENTFORMPRO_DIR_PATH . 'src/views/receipt/', $fileName, $data);`
 
-This filter is located in FluentFormPro\src\Payments\Classes\PaymentAction -> getItemFromVariables($item, $key)
-
-</explain-block>
-
-<explain-block title="fluentform/available_payment_methods">
-
-You can use this filter to modify available payment methods.
-
-**Parameters**
-
-- `$available_methods` (array) Available Payment Methods
-
-**Usage**
-
-```php
-add_filter('fluentform/available_payment_methods', function ($available_methods) {
-    // Do your stuff here
-    
-    return $available_methods;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/available_payment_methods', $available_methods);`
-
-This filter is located in FluentFormPro\src\Payments\Components\PaymentMethods -> getComponent()
-
-</explain-block>
-
-<explain-block title="'fluentform/payment_method_contents_' . $methodName">
-
-You can use this filter to modify specific payment method contents.
-
-**Parameters**
-
-- `$selectedMarkups` (string) Payment Content Markup in HTML
-- `$method` (array) Payment Method
-- `$data` (array) Form Data
-- `$form` (object) Form Object
-
-**Usage**
-
-```php
-add_filter('fluentform/payment_method_contents_' . $methodName, function ($selectedMarkups, $method, $data, $form) {
-    // Do your stuff here
-    
-    return $selectedMarkups;
-}, 10, 4);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/payment_method_contents_' . $methodName, $selectedMarkups, $method, $data, $form);`
-
-This filter is located in FluentFormPro\src\Payments\Components\PaymentMethods -> render($data, $form)
-
-</explain-block>
-
-<explain-block title="'fluentform/transaction_data_' . $transaction->payment_method">
-
-You can use this filter to modify payment method of transaction which has already been completed.
-
-**Parameters**
-
-- `$transaction` (array) Transaction Data
-
-**Usage**
-
-```php
-add_filter('fluentform/transaction_data_' . $transaction->payment_method, function ($transaction) {
-    // Do your stuff here
-    
-    return $transaction;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/transaction_data_' . $transaction->payment_method, $transaction);`
-
-This filter is located in FluentFormPro\src\Payments\Order\OrderData -> getRefunds($submissionId)
-
-</explain-block>
-
-<explain-block title="'fluentform_subscription_items_' . $transaction->payment_method">
-
-You can use this filter to modify subscription payments which has already been completed.
-
-**Parameters**
-
-- `$transaction` (array) Transaction Data
-
-**Usage**
-
-```php
-add_filter('fluentform_subscription_items_' . $transaction->payment_method, function ($transaction) {
-    // Do your stuff here
-    
-    return $transaction;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/transaction_data_' . $transaction->payment_method, [], $transaction);`
-
-This filter is located in FluentFormPro\src\Payments\Order\OrderData -> getSubscriptionTransactions($subscriptionId)
-
-</explain-block>
-
-<explain-block title="fluentform/subscription_transactions">
-
-You can use this filter to modify payment subscription's transaction.
-
-**Parameters**
-
-- `$transactions` (array) Transaction Data
-- `$subscriptionId` (int) Payment Subscription ID
-
-**Usage**
-
-```php
-add_filter('fluentform/subscription_transactions', function ($transactions, $subscriptionId) {
-    // Do your stuff here
-    
-    return $transactions;
-}, 10, 2);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/subscription_transactions', $transactions, $subscriptionId);`
-
-This filter is located in FluentFormPro\src\Payments\Orders\OrderData -> getSubscriptionTransactions($subscriptionId)
+This filter is located in FluentFormPro\src\PaymentsHelper -> loadView($fileName, $data)
 
 </explain-block>
 
@@ -507,60 +1084,6 @@ add_filter('fluentform/payment_settings_' . $method, function ($payments) {
 `apply_filters('fluentform/payment_settings_' . $method, []);`
 
 This filter is located in FluentFormPro\src\Payments\AjaxEndpoints -> getPaymentMethodSettings()
-
-</explain-block>
-
-<explain-block title="'fluentform/payment_method_settings_validation_' . $method">
-
-You can use this filter to modify payment methods validation settings.
-
-**Parameters**
-
-- `$payments` (array) Payment Method Settings
-
-**Usage**
-
-```php
-add_filter('fluentform/payment_method_settings_validation_' . $method, function ($payments, $settings) {
-    // Do your stuff here
-    
-    return $payments;
-}, 10, 2);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/payment_method_settings_validation_' . $method, [], $settings);`
-
-This filter is located in FluentFormPro\src\Payments\AjaxEndpoints -> savePaymentMethodSettings()
-
-</explain-block>
-
-<explain-block title="'fluentform/payment_method_settings_save_' . $method">
-
-You can use this filter to modify payment methods settings before saving.
-
-**Parameters**
-
-- `$settings` (array) Payment Method Settings
-
-**Usage**
-
-```php
-add_filter('fluentform/payment_method_settings_save_' . $method, function ($settings) {
-    // Do your stuff here
-    
-    return $settings;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/payment_method_settings_save_' . $method, $settings);`
-
-This filter is located in FluentFormPro\src\Payments\AjaxEndpoints -> savePaymentMethodSettings()
 
 </explain-block>
 
@@ -592,246 +1115,111 @@ This filter is located in FluentFormPro\src\PaymentsHandler -> init()
 
 </explain-block>
 
-<explain-block title="fluentform/accepted_currencies">
+<explain-block title="fluentform/payment_stripe_secret_key">
 
-You can use this filter to modify accepted currencies.
+You can use this filter to modify stripe payment method API secret key.
 
 **Parameters**
 
-- `$currencies` (array) All Accepted Currencies
+- `$secretKey` (string) Stripe API Secret Key
+- `$formId` (int) Form ID
 
 **Usage**
 
 ```php
-add_filter('fluentform/accepted_currencies', function ($currencies) {
+add_filter('fluentform/payment_stripe_secret_key', function ($secretKey, $formId) {
     // Do your stuff here
     
-    return $currencies;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/accepted_currencies', $currencies);`
-
-This filter is located in FluentFormPro\src\PaymentsHelper -> getCurrencies()
-
-</explain-block>
-
-<explain-block title="fluentform/currency_symbol">
-
-You can use this filter to modify currency symbol of accepted currencies.
-
-**Parameters**
-
-- `$currency_symbol` (array) Currency Symbols
-- `$currency` (string) Currency Name
-
-**Usage**
-
-```php
-add_filter('fluentform/currency_symbol', function ($currency_symbol, $currency) {
-    // Do your stuff here
-    
-    return $currency_symbol;
+    return $secretKey;
 }, 10, 2);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/currency_symbol', $currency_symbol, $currency);`
+`apply_filters('fluentform/payment_stripe_secret_key', $secretKey, $formId);`
 
-This filter is located in FluentFormPro\src\PaymentsHelper -> getCurrencies()
+This filter is located in FluentFormPro\src\PaymentMethods\Stripe\API\Customer -> createCustomer($customerArgs, $formId)
 
 </explain-block>
 
-<explain-block title="fluentform/currencies_symbols">
+<explain-block title="fluentform/payment_submission_data">
 
-You can use this filter to modify all available currency symbols.
+You can use this filter to modify payment form submission data.
 
 **Parameters**
 
-- `$symbols` (array) Currency Symbols Array
+- `$submission` (string) Form Submission Data
+- `$form` (object) Form Object
 
 **Usage**
 
 ```php
-add_filter('fluentform/currencies_symbols', function ($symbols) {
+add_filter('fluentform/payment_submission_data', function ($submission, $form) {
     // Do your stuff here
     
-    return $symbols;
-}, 10, 1);
+    return $submission;
+}, 10, 2);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/currencies_symbols', $symbols);`
+`apply_filters('fluentform/payment_submission_data', $submission, $this->form);`
 
-This filter is located in FluentFormPro\src\PaymentsHelper -> getCurrencySymbols()
+This filter is located in FluentFormPro\src\Payments\Classes\PaymentAction -> draftFormEntry()
 
 </explain-block>
 
-<explain-block title="fluentform/zero_decimal_currencies">
+<explain-block title="fluentform/payment_success_title">
 
-You can use this filter to modify all available zero decimal currencies.
+<Badge type="tip" vertical="top" text="Pro" />
 
 **Parameters**
 
-- `$zeroDecimalCurrencies` (array) Zero Decimal Currencies
+- `$title` — see source
+- `$this` — see source
+- `$form` — see source
 
 **Usage**
 
 ```php
-add_filter('fluentform/zero_decimal_currencies', function ($zeroDecimalCurrencies) {
-    // Do your stuff here
-    
-    return $zeroDecimalCurrencies;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/zero_decimal_currencies', $zeroDecimalCurrencies);`
-
-This filter is located in FluentFormPro\src\PaymentsHelper -> zeroDecimalCurrencies()
-
-</explain-block>
-
-<explain-block title="fluentform/available_payment_statuses">
-
-You can use this filter to modify payment statuses.
-
-**Parameters**
-
-- `$paymentStatuses` (array) Payment Statuses
-
-**Usage**
-
-```php
-add_filter('fluentform/available_payment_statuses', function ($paymentStatuses) {
-    // Do your stuff here
-    
-    return $paymentStatuses;
-}, 10, 1);
-
-```
-```php
-$paymentStatuses = [
-    'paid'               => __('Paid', 'fluentformpro'),
-    'processing'         => __('Processing', 'fluentformpro'),
-    'pending'            => __('Pending', 'fluentformpro'),
-    'failed'             => __('Failed', 'fluentformpro'),
-    'refunded'           => __('Refunded', 'fluentformpro'),
-    'partially-refunded' => __('Partial Refunded', 'fluentformpro'),
-    'cancelled'          => __('Cancelled', 'fluentformpro'),
-    'requires_review'    => __('Requires Review', 'fluentformpro')
-];
-```
-
-**Reference**
-
-`apply_filters('fluentform/available_payment_statuses', $paymentStatuses);`
-
-This filter is located in FluentFormPro\src\Payments\PaymentHelper -> getPaymentStatuses()
-
-</explain-block>
-
-<explain-block title="fluentform/payment_receipt_template_base_path">
-
-You can use this filter to change payment receipt template base path.
-
-**Parameters**
-
-- `$basePath` (string) Base Path
-- `$fileName` (string) File Name
-- `$data` (array) Payment Receipt Data
-
-**Usage**
-
-```php
-add_filter('fluentform/payment_receipt_template_base_path', function ($basePath, $fileName, $data) {
-    // Do your stuff here
-    
-    return $basePath;
+add_filter('fluentform/payment_success_title', function ($title, $this, $form) {
+    return $title;
 }, 10, 3);
-
 ```
 
 **Reference**
 
-`apply_filters('fluentform/payment_receipt_template_base_path',  FLUENTFORMPRO_DIR_PATH . 'src/views/receipt/', $fileName, $data);`
+`$title = apply_filters('fluentform/payment_success_title', $title, $this->getSubmission(), $form);`
 
-This filter is located in FluentFormPro\src\PaymentsHelper -> loadView($fileName, $data)
+This filter is located in `src/Payments/PaymentMethods/BaseProcessor.php` (line 533).
 
 </explain-block>
 
-<explain-block title="fluentform/recurring_payment_summary_texts">
+<explain-block title="fluentform/payment_verification_error">
 
-You can use this filter to modify payment subscription summary text.
+<Badge type="tip" vertical="top" text="Pro" />
 
 **Parameters**
 
-- `$paymentSummaryText` (string) Payment Summary
-- `$plan` (array) Subscription Plan
-- `$formId` (int) Form ID
+- `$verificationError` — see source
+- `$submission` — see source
+- `$form` — see source
 
 **Usage**
 
 ```php
-add_filter('fluentform/recurring_payment_summary_texts', function ($paymentSummaryText, $plan, $formId) {
-    // Do your stuff here
-    
-    return $paymentSummaryText;
+add_filter('fluentform/payment_verification_error', function ($verificationError, $submission, $form) {
+    return $verificationError;
 }, 10, 3);
-
-```
-```php
-$paymentSummaryText = [
-    'has_signup_fee' => __('{first_interval_total} for first {billing_interval} then {subscription_amount} for each {billing_interval}', 'fluentformpro'),
-    'has_trial'      => __('Free for {trial_days} days then {subscription_amount} for each {billing_interval}', 'fluentformpro'),
-    'onetime_only'   => __('One time payment of {first_interval_total}', 'fluentformpro'),
-    'normal'         => __('{subscription_amount} for each {billing_interval}', 'fluentformpro'),
-    'bill_times'     => __(', for {bill_times} installments', 'fluentformpro'),
-    'single_trial'   => __('Free for {trial_days} days then {subscription_amount} one time')
-];
 ```
 
 **Reference**
 
-`apply_filters('fluentform/recurring_payment_summary_texts',  FLUENTFORMPRO_DIR_PATH . 'src/views/receipt/', $fileName, $data);`
+`'errors'      => apply_filters('fluentform/payment_verification_error', $verificationError, $submission, $form),`
 
-This filter is located in FluentFormPro\src\PaymentsHelper -> getPaymentSummaryText($plan, $formId, $currency, $withMarkup = true)
-
-</explain-block>
-
-<explain-block title="fluentform/transaction_view_url">
-
-You can use this filter to modify transaction file URL.
-
-**Parameters**
-
-- `$urlBase` (string) Transaction File URL
-
-**Usage**
-
-```php
-add_filter('fluentform/transaction_view_url', function ($urlBase) {
-    // Do your stuff here
-    
-    return $urlBase;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/transaction_view_url',  $urlBase);`
-
-This filter is located in FluentFormPro\src\TransactionShortcodes -> getViewConfig()
+This filter is located in `src/Payments/PaymentMethods/Paystack/PaystackProcessor.php` (line 322).
 
 </explain-block>
 
@@ -876,133 +1264,6 @@ This filter is located in FluentFormPro\src\TransactionShortcodes -> getViewConf
 
 </explain-block>
 
-<explain-block title="'fluentform/pay_method_has_sub_cancel_' . $method">
-
-You can use this filter to modify payment method if subscription has been canceled.
-
-**Parameters**
-
-- `$hasCancel` (boolean) Whether Payment Subscription Has Been Canceled
-
-**Usage**
-
-```php
-add_filter('fluentform/pay_method_has_sub_cancel_' . $method, function ($hasCancel) {
-    // Do your stuff here
-    
-    return $hasCancel;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/pay_method_has_sub_cancel_' . $method,  false);`
-
-This filter is located in FluentFormPro\src\TransactionShortcodes -> canCancelSubscription($subscription)
-
-</explain-block>
-
-<explain-block title="'fluentform/payment_manager_class_' . $submission->payment_method">
-
-You can use this filter to modify a certain payment if subscription has been canceled.
-
-**Parameters**
-
-- `$handler` (boolean) Whether Payment Subscription Has Been Canceled
-
-**Usage**
-
-```php
-add_filter('fluentform/payment_manager_class_' . $submission->payment_method, function ($handler) {
-    // Do your stuff here
-    
-    return $handler;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/payment_manager_class_' . $submission->payment_method,  false);`
-
-This filter is located in FluentFormPro\src\TransactionShortcodes -> cancelSubscriptionAjax()
-
-</explain-block>
-
-<explain-block title="fluentform/mollie_payment_args">
-
-You can use this filter to modify payment arguments of mollie payment method.
-
-**Parameters**
-
-- `$paymentArgs` (array) Mollie Payment Arguments
-- `$submission` (array) Form Submission
-- `$transaction` (array) Payment Transaction
-- `$form` (object) Form Object
-
-**Usage**
-
-```php
-add_filter('fluentform/mollie_payment_args', function ($paymentArgs, $submission, $transaction, $form) {
-    // Do your stuff here
-    
-    return $paymentArgs;
-}, 10, 4);
-
-```
-```php
-$paymentArgs = [
-    'amount' => [
-        'currency' => $transaction->currency,
-        'value' => number_format((float) $transaction->payment_total / 100, 2, '.', '')
-    ],
-    'description' => $form->title,
-    'redirectUrl' => $successUrl,
-    'webhookUrl' => $listener_url,
-    'metadata' => json_encode([
-        'form_id' => $form->id,
-        'submission_id' => $submission->id
-    ]),
-    'sequenceType' => 'oneoff'
-];
-```
-
-**Reference**
-
-`apply_filters('fluentform/mollie_payment_args',  $paymentArgs, $submission, $transaction, $form);`
-
-This filter is located in FluentFormPro\src\PaymentMethods\Mollie\MollieProcessor -> handleRedirect($transaction, $submission, $form, $methodSettings)
-
-</explain-block>
-
-<explain-block title="'fluentform/payment_method_public_name_' . $paymentMethod">
-
-You can use this filter to modify payment method to before showing payment info.
-
-**Parameters**
-
-- `$paymentMethod` (array) Payment Method Details
-
-**Usage**
-
-```php
-add_filter('fluentform/payment_method_public_name_' . $paymentMethod, function ($paymentMethod) {
-    // Do your stuff here
-    
-    return $paymentMethod;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/payment_method_public_name_' . $paymentMethod',  $paymentMethod);`
-
-This filter is located in FluentFormPro\src\views\receipt\payment-info.php
-
-</explain-block>
-
 <explain-block title="fluentform/paypal_checkout_args">
 
 You can use this filter to modify payment arguments of PayPal payment method before checkout.
@@ -1033,6 +1294,163 @@ This filter is located in FluentFormPro\src\PaymentMethods\PayPal\PayPalProcesso
 
 </explain-block>
 
+<explain-block title="fluentform/paypal_delayed_check_vars">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$delayedCheckVars` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/paypal_delayed_check_vars', function ($delayedCheckVars) {
+    return $delayedCheckVars;
+}, 10, 1);
+```
+
+**Reference**
+
+`wp_localize_script('ff_paypal', 'ff_paypal_vars',apply_filters('fluentform/paypal_delayed_check_vars',  $delayedCheckVars));`
+
+This filter is located in `src/Payments/PaymentMethods/PayPal/PayPalProcessor.php` (line 1322).
+
+</explain-block>
+
+<explain-block title="fluentform/paypal_orders_api_args">
+
+<Badge type="tip" vertical="top" text="Pro" /> <Badge type="warning" vertical="top" text="Added in 6.2.3" />
+
+Filter the payload sent to PayPal's Orders API v2 before the order is created. Use this to inject additional metadata, override line-item descriptions, attach `application_context` overrides, or augment the `purchase_units` array.
+
+**Parameters**
+
+- `$args` (array) Request body about to be POSTed to `/v2/checkout/orders`
+- `$submission` (object) Current submission row
+- `$form` (object) Form being processed
+
+**Usage**
+
+```php
+add_filter('fluentform/paypal_orders_api_args', function ($args, $submission, $form) {
+    $args['application_context']['brand_name'] = 'My Brand';
+    return $args;
+}, 10, 3);
+```
+
+**Reference**
+
+`apply_filters('fluentform/paypal_orders_api_args', $args, $submission, $form);`
+
+This filter is located in `FluentFormPro\Payments\PaymentMethods\PayPal\PayPalProcessor`.
+
+</explain-block>
+
+<explain-block title="fluentform/paypal_payment_cancelled_message">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$cancelledMessage` — see source
+- `$submission` — see source
+- `$this` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/paypal_payment_cancelled_message', function ($cancelledMessage, $submission, $this) {
+    return $cancelledMessage;
+}, 10, 3);
+```
+
+**Reference**
+
+`'error'     => apply_filters('fluentform/paypal_payment_cancelled_message', $cancelledMessage, $submission, $this->form)`
+
+This filter is located in `src/Payments/PaymentMethods/PayPal/PayPalProcessor.php` (line 785).
+
+</explain-block>
+
+<explain-block title="fluentform/paypal_payment_cancelled_title">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$cancelledTitle` — see source
+- `$submission` — see source
+- `$this` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/paypal_payment_cancelled_title', function ($cancelledTitle, $submission, $this) {
+    return $cancelledTitle;
+}, 10, 3);
+```
+
+**Reference**
+
+`'title'     => apply_filters('fluentform/paypal_payment_cancelled_title', $cancelledTitle, $submission, $this->form),`
+
+This filter is located in `src/Payments/PaymentMethods/PayPal/PayPalProcessor.php` (line 783).
+
+</explain-block>
+
+<explain-block title="fluentform/paypal_payment_processing_message">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$messageTxt` — see source
+- `$submission` — see source
+- `$this` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/paypal_payment_processing_message', function ($messageTxt, $submission, $this) {
+    return $messageTxt;
+}, 10, 3);
+```
+
+**Reference**
+
+`$messageTxt = apply_filters('fluentform/paypal_payment_processing_message', $messageTxt, $submission, $this->form);`
+
+This filter is located in `src/Payments/PaymentMethods/PayPal/PayPalProcessor.php` (line 747).
+
+</explain-block>
+
+<explain-block title="fluentform/paypal_payment_sandbox_message">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$sandboxMessage` — see source
+- `$submission` — see source
+- `$this` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/paypal_payment_sandbox_message', function ($sandboxMessage, $submission, $this) {
+    return $sandboxMessage;
+}, 10, 3);
+```
+
+**Reference**
+
+`$message = apply_filters('fluentform/paypal_payment_sandbox_message', $sandboxMessage, $submission, $this->form);`
+
+This filter is located in `src/Payments/PaymentMethods/PayPal/PayPalProcessor.php` (line 753).
+
+</explain-block>
+
 <explain-block title="fluentform/paypal_pending_message">
 
 You can use this filter to modify PayPal payment method default pending message.
@@ -1058,6 +1476,60 @@ add_filter('fluentform/paypal_pending_message', function ($message, $submission)
 `apply_filters('fluentform/paypal_pending_message', $message, $submission);`
 
 This filter is located in FluentFormPro\src\PaymentMethods\PayPal\PayPalProcessor -> handleSessionRedirectBack($data)
+
+</explain-block>
+
+<explain-block title="fluentform/paypal_pending_message_title">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$messageTitle` — see source
+- `$submission` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/paypal_pending_message_title', function ($messageTitle, $submission) {
+    return $messageTitle;
+}, 10, 2);
+```
+
+**Reference**
+
+`'title'     => apply_filters('fluentform/paypal_pending_message_title', $messageTitle, $submission),`
+
+This filter is located in `src/Payments/PaymentMethods/PayPal/PayPalProcessor.php` (line 771).
+
+</explain-block>
+
+<explain-block title="fluentform/paypal_subscription_api_args">
+
+<Badge type="tip" vertical="top" text="Pro" /> <Badge type="warning" vertical="top" text="Added in 6.2.3" />
+
+Filter the payload sent to PayPal's Subscriptions API before a subscription is created.
+
+**Parameters**
+
+- `$args` (array) Subscription request body
+- `$submission` (object) Current submission row
+- `$form` (object) Form being processed
+
+**Usage**
+
+```php
+add_filter('fluentform/paypal_subscription_api_args', function ($args, $submission, $form) {
+    $args['custom_id'] = 'ff-' . $submission->id;
+    return $args;
+}, 10, 3);
+```
+
+**Reference**
+
+`apply_filters('fluentform/paypal_subscription_api_args', $args, $submission, $form);`
+
+This filter is located in `FluentFormPro\Payments\PaymentMethods\PayPal\PayPalProcessor`.
 
 </explain-block>
 
@@ -1091,6 +1563,54 @@ This filter is located in FluentFormPro\src\PaymentMethods\PayPal\PayPalProcesso
 
 </explain-block>
 
+<explain-block title="fluentform/paypal_verify_ipn">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$value` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/paypal_verify_ipn', function ($value) {
+    return $value;
+}, 10, 1);
+```
+
+**Reference**
+
+`$shouldVerifyIpn = apply_filters('fluentform/paypal_verify_ipn', true);`
+
+This filter is located in `src/Payments/PaymentMethods/PayPal/API/IPN.php` (line 158).
+
+</explain-block>
+
+<explain-block title="fluentform/paystack_amount_mismatch_strict">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$value` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/paystack_amount_mismatch_strict', function ($value) {
+    return $value;
+}, 10, 1);
+```
+
+**Reference**
+
+`$strict = apply_filters('fluentform/paystack_amount_mismatch_strict', true);`
+
+This filter is located in `src/Payments/PaymentMethods/Paystack/PaystackProcessor.php` (line 93).
+
+</explain-block>
+
 <explain-block title="fluentform/process_paypal_ipn_data">
 
 You can use this filter to modify PayPal payment method Instant Payment Notification (IPN) data.
@@ -1115,6 +1635,30 @@ add_filter('fluentform/process_paypal_ipn_data', function ($encoded_data_array) 
 `apply_filters('fluentform/process_paypal_ipn_data', $encoded_data_array);`
 
 This filter is located in FluentFormPro\src\Payments\PaymentMethods\PayPal\API\IPN -> verifyIPN()
+
+</explain-block>
+
+<explain-block title="fluentform/razorpay_amount_mismatch_strict">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$value` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/razorpay_amount_mismatch_strict', function ($value) {
+    return $value;
+}, 10, 1);
+```
+
+**Reference**
+
+`$strict = apply_filters('fluentform/razorpay_amount_mismatch_strict', true);`
+
+This filter is located in `src/Payments/PaymentMethods/RazorPay/RazorPayProcessor.php` (line 267).
 
 </explain-block>
 
@@ -1176,306 +1720,94 @@ This filter is located in FluentFormPro\src\PaymentMethods\RazorPay\RazorPayProc
 
 </explain-block>
 
-<explain-block title="fluentform/stripe_request_headers">
+<explain-block title="fluentform/recurring_payment_message">
 
-You can use this filter to modify stripe API request header.
+<Badge type="tip" vertical="top" text="Pro" />
 
 **Parameters**
 
-- `$headers` (array) Stripe API Request Headers
+- `$message` — see source
+- `$args` — see source
+- `$this` — see source
 
 **Usage**
 
 ```php
-add_filter('fluentform/stripe_request_headers', function ($headers) {
-    // Do your stuff here
-    
-    return $headers;
-}, 10, 1);
-
-```
-```php
-$headers = [
-    'Authorization' => 'Basic ' . base64_encode(self::get_secret_key() . ':'),
-    'Stripe-Version' => self::STRIPE_API_VERSION,
-    'User-Agent' => $app_info['name'] . '/' . $app_info['version'] . ' (' . $app_info['url'] . ')',
-    'X-Stripe-Client-User-Agent' => json_encode($user_agent),
-];
+add_filter('fluentform/recurring_payment_message', function ($message, $args, $this) {
+    return $message;
+}, 10, 3);
 ```
 
 **Reference**
 
-`apply_filters('fluentform/stripe_request_headers', $headers);`
+`'title'            => apply_filters('fluentform/recurring_payment_message', __('Subscription Status changed to ', 'fluentformpro') . $newStatus, [], $this->getForm()),`
 
-This filter is located in FluentFormPro\src\PaymentMethods\Stripe\API\ApiRequest -> get_headers()
-
-</explain-block>
-
-<explain-block title="fluentform/stripe_idempotency_key">
-
-You can use this filter to modify stripe payment method idempotency key. Stripe use idempotency key for safely retrying requests without accidentally performing the same operation twice.
-
-**Parameters**
-
-- `$key` (string) Stripe Idempotency Key
-- `$request` (array) Stripe API Request
-
-**Usage**
-
-```php
-add_filter('fluentform/stripe_idempotency_key', function ($key, $request) {
-    // Do your stuff here
-    
-    return $key;
-}, 10, 2);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/stripe_idempotency_key', $key, $request);`
-
-This filter is located in FluentFormPro\src\PaymentMethods\Stripe\API\ApiRequest -> request($request, $api = 'charges', $method = 'POST')
+This filter is located in `src/Payments/PaymentMethods/BaseProcessor.php` (line 1169).
 
 </explain-block>
 
-<explain-block title="fluentform/stripe_request_body">
+<explain-block title="fluentform/recurring_payment_summary_texts">
 
-You can use this filter to modify stripe payment method API request.
-
-**Parameters**
-
-- `$request` (array) Stripe API Request
-- `$api` (string) Stripe Idempotency Key
-
-**Usage**
-
-```php
-add_filter('fluentform/stripe_request_body', function ($request, $api) {
-    // Do your stuff here
-    
-    return $request;
-}, 10, 2);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/stripe_request_body', $request, $api);`
-
-This filter is located in FluentFormPro\src\PaymentMethods\Stripe\API\ApiRequest -> request($request, $api = 'charges', $method = 'POST')
-
-</explain-block>
-
-<explain-block title="fluentform/payment_stripe_secret_key">
-
-You can use this filter to modify stripe payment method API secret key.
+You can use this filter to modify payment subscription summary text.
 
 **Parameters**
 
-- `$secretKey` (string) Stripe API Secret Key
+- `$paymentSummaryText` (string) Payment Summary
+- `$plan` (array) Subscription Plan
 - `$formId` (int) Form ID
 
 **Usage**
 
 ```php
-add_filter('fluentform/payment_stripe_secret_key', function ($secretKey, $formId) {
+add_filter('fluentform/recurring_payment_summary_texts', function ($paymentSummaryText, $plan, $formId) {
     // Do your stuff here
     
-    return $secretKey;
-}, 10, 2);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/payment_stripe_secret_key', $secretKey, $formId);`
-
-This filter is located in FluentFormPro\src\PaymentMethods\Stripe\API\Customer -> createCustomer($customerArgs, $formId)
-
-</explain-block>
-
-<explain-block title="fluentform/stripe_plan_name_generated">
-
-You can use this filter to modify stripe payment method plan subscription ID before generating plan name.
-
-**Parameters**
-
-- `$subscriptionId` (string) Stripe Subscription ID
-- `$subscription` (array) Stripe Subscription Data
-- `$currency` (string) Selected Currency, By Default USD
-
-**Usage**
-
-```php
-add_filter('fluentform/stripe_plan_name_generated', function ($subscriptionId, $subscription, $currency) {
-    // Do your stuff here
-    
-    return $subscriptionId;
+    return $paymentSummaryText;
 }, 10, 3);
 
 ```
-
-**Reference**
-
-`apply_filters('fluentform/stripe_plan_name_generated', $subscriptionId, $subscription, $currency);`
-
-This filter is located in FluentFormPro\src\PaymentMethods\Stripe\API\Plan -> getGeneratedSubscriptionId($subscription, $currency = 'USD')
-
-</explain-block>
-
-<explain-block title="fluentform/stripe_plan_name">
-
-You can use this filter to modify stripe payment method plan name.
-
-**Parameters**
-
-- `$planName` (string) Stripe Plan Name
-- `$subscription` (array) Stripe Subscription Data
-
-**Usage**
-
 ```php
-add_filter('fluentform/stripe_plan_name', function ($planName, $subscription) {
-    // Do your stuff here
-    
-    return $planName;
-}, 10, 2);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/stripe_plan_name', $planName, $subscription);`
-
-This filter is located in FluentFormPro\src\PaymentMethods\Stripe\API\Plan -> getSubscriptionPlanBySubscription($subscription, $currency)
-
-</explain-block>
-
-<explain-block title="fluentform/stripe_checkout_args">
-
-You can use this filter to modify stripe checkout arguments.
-
-**Parameters**
-
-- `$checkoutArgs` (string) Stripe Checkout Arguments
-- `$submission` (array) Form Submission Data
-- `$transaction` (array) Transaction Details
-- `$form` (object) Form Object
-
-**Usage**
-
-```php
-add_filter('fluentform/stripe_checkout_args', function ($checkoutArgs, $submission, $transaction, $form) {
-    // Do your stuff here
-    
-    return $checkoutArgs;
-}, 10, 4);
-
-```
-```php
-$checkoutArgs = [
-    'cancel_url'                 => wp_sanitize_redirect($cancelUrl),
-    'success_url'                => wp_sanitize_redirect($successUrl),
-    'locale'                     => 'auto',
-    'billing_address_collection' => 'auto',
-    'client_reference_id'        => $submission->id,
-    'customer_email'             => $transaction->payer_email,
-    'metadata'                   => [
-        'submission_id'  => $submission->id,
-        'form_id'        => $form->id,
-        'transaction_id' => ($transaction) ? $transaction->id : ''
-    ]
+$paymentSummaryText = [
+    'has_signup_fee' => __('{first_interval_total} for first {billing_interval} then {subscription_amount} for each {billing_interval}', 'fluentformpro'),
+    'has_trial'      => __('Free for {trial_days} days then {subscription_amount} for each {billing_interval}', 'fluentformpro'),
+    'onetime_only'   => __('One time payment of {first_interval_total}', 'fluentformpro'),
+    'normal'         => __('{subscription_amount} for each {billing_interval}', 'fluentformpro'),
+    'bill_times'     => __(', for {bill_times} installments', 'fluentformpro'),
+    'single_trial'   => __('Free for {trial_days} days then {subscription_amount} one time')
 ];
 ```
 
 **Reference**
 
-`apply_filters('fluentform/stripe_checkout_args', $checkoutArgs, $submission, $transaction, $form);`
+`apply_filters('fluentform/recurring_payment_summary_texts',  FLUENTFORMPRO_DIR_PATH . 'src/views/receipt/', $fileName, $data);`
 
-This filter is located in FluentFormPro\src\PaymentMethods\Stripe\StripeProcessor -> handleCheckoutSession($transaction, $submission, $form, $methodSettings)
+This filter is located in FluentFormPro\src\PaymentsHelper -> getPaymentSummaryText($plan, $formId, $currency, $withMarkup = true)
 
 </explain-block>
 
-<explain-block title="fluentform/disable_stripe_connect">
+<explain-block title="fluentform/single_payment_item_fallback_value">
 
-You can use this filter to toggle stripe connection.
+<Badge type="tip" vertical="top" text="Pro" />
 
 **Parameters**
 
-- `$isDisableStripeConnect` (boolean) Whether Stripe Connection is disabled, By Default false
+- `$value` — see source
+- `$data` — see source
+- `$form` — see source
 
 **Usage**
 
 ```php
-add_filter('fluentform/disable_stripe_connect', function ($isDisableStripeConnect) {
-    // Do your stuff here
-    
-    return $isDisableStripeConnect;
-}, 10, 1);
-
+add_filter('fluentform/single_payment_item_fallback_value', function ($value, $data, $form) {
+    return $value;
+}, 10, 3);
 ```
 
 **Reference**
 
-`apply_filters('fluentform/disable_stripe_connect', $isDisableStripeConnect);`
+`$productPrice = apply_filters('fluentform/single_payment_item_fallback_value', 0, $data, $form);`
 
-This filter is located in FluentFormPro\src\PaymentMethods\Stripe\StripeSettings -> getSettings()
-
-</explain-block>
-
-<explain-block title="fluentform/stripe_supported_shipping_countries">
-
-You can use this filter to modify stripe supported shipping countries list.
-
-**Parameters**
-
-- `$countries` (array) Stripe Supported Shipping Countries
-
-**Usage**
-
-```php
-add_filter('fluentform/stripe_supported_shipping_countries', function ($countries) {
-    // Do your stuff here
-    
-    return $countries;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/stripe_supported_shipping_countries', $countries);`
-
-This filter is located in FluentFormPro\src\PaymentMethods\Stripe\StripeSettings -> supportedShippingCountries()
-
-</explain-block>
-
-
-<explain-block title="fluentform/stripe_strong_customer_verify_waiting_message">
-
-You can use this filter to modify stripe strong customer verify waiting message
-
-**Parameters**
-
-- `$message` (string) Waiting Message
-
-**Usage**
-
-```php
-add_filter('fluentform/stripe_strong_customer_verify_waiting_message', function ($message) {
-    // replace message if you need
-    
-    return $message;
-});
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/stripe_strong_customer_verify_waiting_message', $message);`
-
-This filter is located in FluentFormPro\src\Payments\PaymentMethods\Stripe\StripeInlineProcessor.php -> handlePaymentIntent()
+This filter is located in `src/Payments/Components/MultiPaymentComponent.php` (line 153).
 
 </explain-block>
 
@@ -1539,112 +1871,565 @@ This filter is located in FluentFormPro\src\PaymentMethods\Square\SquareProcesso
 
 </explain-block>
 
-<explain-block title="fluentform/payment_methods_global_settings">
+<explain-block title="fluentform/stripe_checkout_args">
 
-You can use this filter to modify payment methods global settings.
+You can use this filter to modify stripe checkout arguments.
 
 **Parameters**
 
-- `$globalSettings` (array) Base Payment Method Global Settings
+- `$checkoutArgs` (string) Stripe Checkout Arguments
+- `$submission` (array) Form Submission Data
+- `$transaction` (array) Transaction Details
+- `$form` (object) Form Object
 
 **Usage**
 
 ```php
-add_filter('fluentform/payment_methods_global_settings', function ($globalSettings) {
+add_filter('fluentform/stripe_checkout_args', function ($checkoutArgs, $submission, $transaction, $form) {
     // Do your stuff here
     
-    return $globalSettings;
-}, 10, 1);
+    return $checkoutArgs;
+}, 10, 4);
 
+```
+```php
+$checkoutArgs = [
+    'cancel_url'                 => wp_sanitize_redirect($cancelUrl),
+    'success_url'                => wp_sanitize_redirect($successUrl),
+    'locale'                     => 'auto',
+    'billing_address_collection' => 'auto',
+    'client_reference_id'        => $submission->id,
+    'customer_email'             => $transaction->payer_email,
+    'metadata'                   => [
+        'submission_id'  => $submission->id,
+        'form_id'        => $form->id,
+        'transaction_id' => ($transaction) ? $transaction->id : ''
+    ]
+];
 ```
 
 **Reference**
 
-`apply_filters('fluentform/payment_methods_global_settings', $globalSettings);`
+`apply_filters('fluentform/stripe_checkout_args', $checkoutArgs, $submission, $transaction, $form);`
 
-This filter is located in FluentFormPro\src\Payments\PaymentHandler -> renderPaymentSettings()
+This filter is located in FluentFormPro\src\PaymentMethods\Stripe\StripeProcessor -> handleCheckoutSession($transaction, $submission, $form, $methodSettings)
 
 </explain-block>
 
-<explain-block title="fluentform/accepted_currencies">
+<explain-block title="fluentform/stripe_checkout_args_inline">
 
-You can use this filter to modify payment methods accepted currencies list.
+<Badge type="tip" vertical="top" text="Pro" />
 
 **Parameters**
 
-- `$currencies` (array) Base Payment Method Currencies
+- `$intentArgs` — see source
+- `$submission` — see source
+- `$transaction` — see source
+- `$form` — see source
 
 **Usage**
 
 ```php
-add_filter('fluentform/accepted_currencies', function ($currencies) {
-    // Do your stuff here
-    
-    return $currencies;
-}, 10, 1);
-
+add_filter('fluentform/stripe_checkout_args_inline', function ($intentArgs, $submission, $transaction, $form) {
+    return $intentArgs;
+}, 10, 4);
 ```
 
 **Reference**
 
-`apply_filters('fluentform/accepted_currencies', $currencies);`
+`$intentArgs = apply_filters('fluentform/stripe_checkout_args_inline', $intentArgs, $submission, $transaction, $form);`
 
-This filter is located in FluentFormPro\src\Payments\PaymentHandler -> getCurrencies()
+This filter is located in `src/Payments/PaymentMethods/Stripe/StripeInlineProcessor.php` (line 83).
 
 </explain-block>
 
-<explain-block title="fluentform/currency_symbol">
+<explain-block title="fluentform/stripe_idempotency_key">
 
-You can use this filter to modify currency symbols of payment methods accepted currencies.
+You can use this filter to modify stripe payment method idempotency key. Stripe use idempotency key for safely retrying requests without accidentally performing the same operation twice.
 
 **Parameters**
 
-- `$currency_symbol` (string) Currency Symbol in Unicode
-- `$currency` (string) Currency Name
+- `$key` (string) Stripe Idempotency Key
+- `$request` (array) Stripe API Request
 
 **Usage**
 
 ```php
-add_filter('fluentform/currency_symbol', function ($currency_symbol, $currency) {
+add_filter('fluentform/stripe_idempotency_key', function ($key, $request) {
     // Do your stuff here
     
-    return $currency_symbol;
+    return $key;
 }, 10, 2);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/currency_symbol', $currency_symbol, $currency);`
+`apply_filters('fluentform/stripe_idempotency_key', $key, $request);`
 
-This filter is located in FluentFormPro\src\Payments\PaymentHandler -> getCurrencySymbol($currency = '')
+This filter is located in FluentFormPro\src\PaymentMethods\Stripe\API\ApiRequest -> request($request, $api = 'charges', $method = 'POST')
 
 </explain-block>
 
-<explain-block title="fluentform/currencies_symbols">
+<explain-block title="fluentform/stripe_inline_custom_css">
 
-You can use this filter to modify currency symbols of payment methods accepted currencies.
+<Badge type="tip" vertical="top" text="Pro" />
 
 **Parameters**
 
-- `$symbols` (array) Currency Symbols List in Unicode
+- `$stripeCustomCss` — see source
+- `$form` — see source
 
 **Usage**
 
 ```php
-add_filter('fluentform/currencies_symbols', function ($symbols) {
+add_filter('fluentform/stripe_inline_custom_css', function ($stripeCustomCss, $form) {
+    return $stripeCustomCss;
+}, 10, 2);
+```
+
+**Reference**
+
+`'custom_style'    => apply_filters('fluentform/stripe_inline_custom_css', $stripeCustomCss, $form->id),`
+
+This filter is located in `src/Payments/PaymentHandler.php` (line 238).
+
+</explain-block>
+
+<explain-block title="fluentform/stripe_payment_cancelled_message">
+
+**Parameters**
+
+- `$message` — see source
+- `$submission` — see source
+- `$this` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/stripe_payment_cancelled_message', function ($message, $submission, $this) {
+    return $message;
+}, 10, 3);
+```
+
+**Reference**
+
+`'error'     => apply_filters('fluentform/stripe_payment_cancelled_message', __('Looks like you have cancelled the payment. Please try again!', 'fluentform'), $submission, $this->form)`
+
+This filter is located in `app/Modules/Payments/PaymentMethods/Stripe/StripeProcessor.php` (line 377).
+
+</explain-block>
+
+<explain-block title="fluentform/stripe_plan_name">
+
+You can use this filter to modify stripe payment method plan name.
+
+**Parameters**
+
+- `$planName` (string) Stripe Plan Name
+- `$subscription` (array) Stripe Subscription Data
+
+**Usage**
+
+```php
+add_filter('fluentform/stripe_plan_name', function ($planName, $subscription) {
     // Do your stuff here
     
-    return $symbols;
+    return $planName;
+}, 10, 2);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/stripe_plan_name', $planName, $subscription);`
+
+This filter is located in FluentFormPro\src\PaymentMethods\Stripe\API\Plan -> getSubscriptionPlanBySubscription($subscription, $currency)
+
+</explain-block>
+
+<explain-block title="fluentform/stripe_plan_name_generated">
+
+You can use this filter to modify stripe payment method plan subscription ID before generating plan name.
+
+**Parameters**
+
+- `$subscriptionId` (string) Stripe Subscription ID
+- `$subscription` (array) Stripe Subscription Data
+- `$currency` (string) Selected Currency, By Default USD
+
+**Usage**
+
+```php
+add_filter('fluentform/stripe_plan_name_generated', function ($subscriptionId, $subscription, $currency) {
+    // Do your stuff here
+    
+    return $subscriptionId;
+}, 10, 3);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/stripe_plan_name_generated', $subscriptionId, $subscription, $currency);`
+
+This filter is located in FluentFormPro\src\PaymentMethods\Stripe\API\Plan -> getGeneratedSubscriptionId($subscription, $currency = 'USD')
+
+</explain-block>
+
+<explain-block title="fluentform/stripe_request_body">
+
+You can use this filter to modify stripe payment method API request.
+
+**Parameters**
+
+- `$request` (array) Stripe API Request
+- `$api` (string) Stripe Idempotency Key
+
+**Usage**
+
+```php
+add_filter('fluentform/stripe_request_body', function ($request, $api) {
+    // Do your stuff here
+    
+    return $request;
+}, 10, 2);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/stripe_request_body', $request, $api);`
+
+This filter is located in FluentFormPro\src\PaymentMethods\Stripe\API\ApiRequest -> request($request, $api = 'charges', $method = 'POST')
+
+</explain-block>
+
+<explain-block title="fluentform/stripe_request_headers">
+
+You can use this filter to modify stripe API request header.
+
+**Parameters**
+
+- `$headers` (array) Stripe API Request Headers
+
+**Usage**
+
+```php
+add_filter('fluentform/stripe_request_headers', function ($headers) {
+    // Do your stuff here
+    
+    return $headers;
+}, 10, 1);
+
+```
+```php
+$headers = [
+    'Authorization' => 'Basic ' . base64_encode(self::get_secret_key() . ':'),
+    'Stripe-Version' => self::STRIPE_API_VERSION,
+    'User-Agent' => $app_info['name'] . '/' . $app_info['version'] . ' (' . $app_info['url'] . ')',
+    'X-Stripe-Client-User-Agent' => json_encode($user_agent),
+];
+```
+
+**Reference**
+
+`apply_filters('fluentform/stripe_request_headers', $headers);`
+
+This filter is located in FluentFormPro\src\PaymentMethods\Stripe\API\ApiRequest -> get_headers()
+
+</explain-block>
+
+<explain-block title="fluentform/stripe_sca_strict_security">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$value` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/stripe_sca_strict_security', function ($value) {
+    return $value;
+}, 10, 1);
+```
+
+**Reference**
+
+`$strictMode = apply_filters('fluentform/stripe_sca_strict_security', true);`
+
+This filter is located in `src/Payments/PaymentMethods/Stripe/StripeInlineProcessor.php` (line 384).
+
+</explain-block>
+
+<explain-block title="fluentform/stripe_strong_customer_verify_waiting_message">
+
+You can use this filter to modify stripe strong customer verify waiting message
+
+**Parameters**
+
+- `$message` (string) Waiting Message
+
+**Usage**
+
+```php
+add_filter('fluentform/stripe_strong_customer_verify_waiting_message', function ($message) {
+    // replace message if you need
+    
+    return $message;
+});
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/stripe_strong_customer_verify_waiting_message', $message);`
+
+This filter is located in FluentFormPro\src\Payments\PaymentMethods\Stripe\StripeInlineProcessor.php -> handlePaymentIntent()
+
+</explain-block>
+
+<explain-block title="fluentform/stripe_subscription_args_inline">
+
+**Parameters**
+
+- `$subscriptionArgs` — see source
+- `$submission` — see source
+- `$transaction` — see source
+- `$this` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/stripe_subscription_args_inline', function ($subscriptionArgs, $submission, $transaction, $this) {
+    return $subscriptionArgs;
+}, 10, 4);
+```
+
+**Reference**
+
+`$subscriptionArgs = apply_filters('fluentform/stripe_subscription_args_inline', $subscriptionArgs, $submission, $transaction, $this->getForm());`
+
+This filter is located in `app/Modules/Payments/PaymentMethods/Stripe/StripeInlineProcessor.php` (line 139).
+
+</explain-block>
+
+<explain-block title="fluentform/stripe_supported_shipping_countries">
+
+You can use this filter to modify stripe supported shipping countries list.
+
+**Parameters**
+
+- `$countries` (array) Stripe Supported Shipping Countries
+
+**Usage**
+
+```php
+add_filter('fluentform/stripe_supported_shipping_countries', function ($countries) {
+    // Do your stuff here
+    
+    return $countries;
 }, 10, 1);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/currencies_symbols', $symbols);`
+`apply_filters('fluentform/stripe_supported_shipping_countries', $countries);`
 
-This filter is located in FluentFormPro\src\Payments\PaymentHelper -> getCurrencySymbols()
+This filter is located in FluentFormPro\src\PaymentMethods\Stripe\StripeSettings -> supportedShippingCountries()
+
+</explain-block>
+
+<explain-block title="fluentform/submission_order_items">
+
+You can use this filter to modify payment order items data.
+
+**Parameters**
+
+- `$orderItems` (array) Payment Order Items
+- `$submissionData` (array) Form Submission Data
+- `$form` (object) Form Object
+
+**Usage**
+
+```php
+add_filter('fluentform/submission_order_items', function ($orderItems, $submissionData, $form) {
+    // Do your stuff here
+
+    return $orderItems;
+}, 10, 3);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/submission_order_items', $this->orderItems, $this->submissionData, $this->form);`
+
+This filter is located in FluentFormPro\src\Payments\Classes\PaymentAction -> getOrderItems($forced = false)
+
+</explain-block>
+
+<explain-block title="fluentform/submission_subscription_items">
+
+You can use this filter to modify payment subscription items data.
+
+**Parameters**
+
+- `$subscriptionItems` (array) Payment Subscription Items
+- `$submissionData` (array) Form Submission Data
+- `$form` (object) Form Object
+
+**Usage**
+
+```php
+add_filter('fluentform/submission_subscription_items', function ($subscriptionItems, $submissionData, $form) {
+    // Do your stuff here
+
+    return $subscriptionItems;
+}, 10, 3);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/submission_subscription_items', $this->subscriptionItems, $this->submissionData, $this->form);`
+
+This filter is located in FluentFormPro\src\Payments\Classes\PaymentAction -> getSubscriptionItems()
+
+</explain-block>
+
+<explain-block title="fluentform/subscription_confirmation_message">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$note` — see source
+- `$args` — see source
+- `$this` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/subscription_confirmation_message', function ($note, $args, $this) {
+    return $note;
+}, 10, 3);
+```
+
+**Reference**
+
+`$note = apply_filters('fluentform/subscription_confirmation_message', $note, [], $this->getForm());`
+
+This filter is located in `src/Payments/PaymentMethods/BaseProcessor.php` (line 1147).
+
+</explain-block>
+
+<explain-block title="fluentform/subscription_items_">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- See source
+
+**Usage**
+
+```php
+add_filter('fluentform/subscription_items_', function ($value) {
+    return $value;
+}, 10, 1);
+```
+
+**Reference**
+
+`$transaction->items = apply_filters('fluentform/subscription_items_'.$transaction->payment_method, [], $transaction);`
+
+This filter is located in `src/Payments/Orders/OrderData.php` (line 184).
+
+</explain-block>
+
+<explain-block title="fluentform/subscription_transactions">
+
+You can use this filter to modify payment subscription's transaction.
+
+**Parameters**
+
+- `$transactions` (array) Transaction Data
+- `$subscriptionId` (int) Payment Subscription ID
+
+**Usage**
+
+```php
+add_filter('fluentform/subscription_transactions', function ($transactions, $subscriptionId) {
+    // Do your stuff here
+    
+    return $transactions;
+}, 10, 2);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/subscription_transactions', $transactions, $subscriptionId);`
+
+This filter is located in FluentFormPro\src\Payments\Orders\OrderData -> getSubscriptionTransactions($subscriptionId)
+
+</explain-block>
+
+<explain-block title="'fluentform/transaction_data_' . $transaction->payment_method">
+
+You can use this filter to modify payment method of transaction which has already been completed.
+
+**Parameters**
+
+- `$transaction` (array) Transaction Data
+
+**Usage**
+
+```php
+add_filter('fluentform/transaction_data_' . $transaction->payment_method, function ($transaction) {
+    // Do your stuff here
+    
+    return $transaction;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/transaction_data_' . $transaction->payment_method, $transaction);`
+
+This filter is located in FluentFormPro\src\Payments\Order\OrderData -> getRefunds($submissionId)
+
+</explain-block>
+
+<explain-block title="fluentform/transaction_view_url">
+
+You can use this filter to modify transaction file URL.
+
+**Parameters**
+
+- `$urlBase` (string) Transaction File URL
+
+**Usage**
+
+```php
+add_filter('fluentform/transaction_view_url', function ($urlBase) {
+    // Do your stuff here
+    
+    return $urlBase;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/transaction_view_url',  $urlBase);`
+
+This filter is located in FluentFormPro\src\TransactionShortcodes -> getViewConfig()
 
 </explain-block>
 
@@ -1675,4 +2460,29 @@ This filter is located in FluentFormPro\src\Payments\PaymentHelper -> zeroDecima
 
 </explain-block>
 
+<explain-block title="'fluentform_subscription_items_' . $transaction->payment_method">
 
+You can use this filter to modify subscription payments which has already been completed.
+
+**Parameters**
+
+- `$transaction` (array) Transaction Data
+
+**Usage**
+
+```php
+add_filter('fluentform_subscription_items_' . $transaction->payment_method, function ($transaction) {
+    // Do your stuff here
+    
+    return $transaction;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/transaction_data_' . $transaction->payment_method, [], $transaction);`
+
+This filter is located in FluentFormPro\src\Payments\Order\OrderData -> getSubscriptionTransactions($subscriptionId)
+
+</explain-block>

--- a/src/hooks/filters/pdf.md
+++ b/src/hooks/filters/pdf.md
@@ -1,0 +1,155 @@
+# PDF Filters
+
+<Badge type="tip" vertical="top" text="Filter Hooks" /> <Badge type="tip" vertical="top" text="Add-on" /> <Badge type="warning" vertical="top" text="6 Filters" />
+
+Filters exposed by the **Fluent Forms PDF** add-on (`fluentforms-pdf`). Use these to customize mPDF configuration, the PDF body / CSS, template list, and watermark behavior. Source repo: `fluentforms-pdf`.
+
+<explain-block title="fluentform/mpdf_config">
+
+<Badge type="tip" vertical="top" text="Add-on" />
+
+**Parameters**
+
+- See source for parameters and types
+
+**Usage**
+
+```php
+add_filter('fluentform/mpdf_config', function ($value) {
+    // modify and return
+    return $value;
+}}, 10, 1);
+```
+
+**Reference**
+
+`$mpdfConfig = apply_filters('fluentform/mpdf_config', $mpdfConfig);`
+
+This filter is located in `fluentforms-pdf/Modules/FluentForms/Templates/TemplateManager.php` (line 101).
+
+</explain-block>
+
+<explain-block title="fluentform/pdf_body_parse">
+
+<Badge type="tip" vertical="top" text="Add-on" />
+
+**Parameters**
+
+- See source for parameters and types
+
+**Usage**
+
+```php
+add_filter('fluentform/pdf_body_parse', function ($value) {
+    // modify and return
+    return $value;
+}}, 10, 1);
+```
+
+**Reference**
+
+`$htmlBody = apply_filters('fluentform/pdf_body_parse', $htmlBody, $submissionId, $formData, $form);`
+
+This filter is located in `fluentforms-pdf/Modules/FluentForms/Templates/GeneralTemplate.php` (line 94).
+
+</explain-block>
+
+<explain-block title="fluentform/pdf_generator_css">
+
+<Badge type="tip" vertical="top" text="Add-on" />
+
+**Parameters**
+
+- See source for parameters and types
+
+**Usage**
+
+```php
+add_filter('fluentform/pdf_generator_css', function ($value) {
+    // modify and return
+    return $value;
+}}, 10, 1);
+```
+
+**Reference**
+
+`return apply_filters('fluentform/pdf_generator_css', $pdfGeneratorCss, $appearance);`
+
+This filter is located in `fluentforms-pdf/Modules/FluentForms/Templates/TemplateManager.php` (line 293).
+
+</explain-block>
+
+<explain-block title="fluentform/pdf_templates">
+
+<Badge type="tip" vertical="top" text="Add-on" />
+
+**Parameters**
+
+- See source for parameters and types
+
+**Usage**
+
+```php
+add_filter('fluentform/pdf_templates', function ($value) {
+    // modify and return
+    return $value;
+}}, 10, 1);
+```
+
+**Reference**
+
+`return apply_filters('fluentform/pdf_templates', $templates, $form);`
+
+This filter is located in `fluentforms-pdf/Modules/FluentForms/FluentFormsIntegration.php` (line 593).
+
+</explain-block>
+
+<explain-block title="fluentform/pdf_watermark_image_position">
+
+<Badge type="tip" vertical="top" text="Add-on" />
+
+**Parameters**
+
+- See source for parameters and types
+
+**Usage**
+
+```php
+add_filter('fluentform/pdf_watermark_image_position', function ($value) {
+    // modify and return
+    return $value;
+}}, 10, 1);
+```
+
+**Reference**
+
+`$watermarkImagePosition = apply_filters('fluentform/pdf_watermark_image_position', 'F', $feedId);`
+
+This filter is located in `fluentforms-pdf/Modules/FluentForms/Templates/TemplateManager.php` (line 183).
+
+</explain-block>
+
+<explain-block title="fluentform/pdf_watermark_image_size">
+
+<Badge type="tip" vertical="top" text="Add-on" />
+
+**Parameters**
+
+- See source for parameters and types
+
+**Usage**
+
+```php
+add_filter('fluentform/pdf_watermark_image_size', function ($value) {
+    // modify and return
+    return $value;
+}}, 10, 1);
+```
+
+**Reference**
+
+`$watermarkImageSize = apply_filters('fluentform/pdf_watermark_image_size', 'D', $feedId);`
+
+This filter is located in `fluentforms-pdf/Modules/FluentForms/Templates/TemplateManager.php` (line 182).
+
+</explain-block>

--- a/src/hooks/filters/post-creation.md
+++ b/src/hooks/filters/post-creation.md
@@ -1,0 +1,422 @@
+# Post Creation Filters
+
+<Badge type="tip" vertical="top" text="Filter Hooks" /> <Badge type="warning" vertical="top" text="17 Filters" />
+
+<explain-block title="fluentform/create_post_before_form_actions_processing">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$value` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/create_post_before_form_actions_processing', function ($value) {
+    return $value;
+}, 10, 1);
+```
+
+**Reference**
+
+`$createPostBeforeFormActions = apply_filters('fluentform/create_post_before_form_actions_processing', true);`
+
+This filter is located in `src/Components/Post/Bootstrap.php` (line 85).
+
+</explain-block>
+
+<explain-block title="fluentform/disable_acf_post_meta_revision">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$value` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/disable_acf_post_meta_revision', function ($value) {
+    return $value;
+}, 10, 1);
+```
+
+**Reference**
+
+`if (function_exists('acf_save_post_revision') && !apply_filters('fluentform/disable_acf_post_meta_revision', false)) {`
+
+This filter is located in `src/Components/Post/PostFormHandler.php` (line 386).
+
+</explain-block>
+
+<explain-block title="fluentform/get_post_type_on_form_create">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$args` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/get_post_type_on_form_create', function ($args) {
+    return $args;
+}, 10, 1);
+```
+
+**Reference**
+
+`$publicPostTypes = get_post_types(apply_filters('fluentform/get_post_type_on_form_create', $args));`
+
+This filter is located in `src/Components/Post/PostFeedSettings.php` (line 22).
+
+</explain-block>
+
+<explain-block title="fluentform/post_acf_accepted_advanced_fields">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$advancedFields` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/post_acf_accepted_advanced_fields', function ($advancedFields) {
+    return $advancedFields;
+}, 10, 1);
+```
+
+**Reference**
+
+`return apply_filters('fluentform/post_acf_accepted_advanced_fields', $advancedFields);`
+
+This filter is located in `src/Components/Post/AcfHelper.php` (line 248).
+
+</explain-block>
+
+<explain-block title="fluentform/post_acf_accepted_fields">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$acceptedFields` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/post_acf_accepted_fields', function ($acceptedFields) {
+    return $acceptedFields;
+}, 10, 1);
+```
+
+**Reference**
+
+`$acceptedFields = apply_filters('fluentform/post_acf_accepted_fields', $acceptedFields);`
+
+This filter is located in `src/Components/Post/AcfHelper.php` (line 394).
+
+</explain-block>
+
+<explain-block title="fluentform/post_acf_accepted_general_fields">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$generalFields` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/post_acf_accepted_general_fields', function ($generalFields) {
+    return $generalFields;
+}, 10, 1);
+```
+
+**Reference**
+
+`return apply_filters('fluentform/post_acf_accepted_general_fields', $generalFields);`
+
+This filter is located in `src/Components/Post/AcfHelper.php` (line 196).
+
+</explain-block>
+
+<explain-block title="fluentform/post_feed_settings_data_response">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$data` — see source
+- `$formId` — see source
+- `$postSettings` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/post_feed_settings_data_response', function ($data, $formId, $postSettings) {
+    return $data;
+}, 10, 3);
+```
+
+**Reference**
+
+`return apply_filters('fluentform/post_feed_settings_data_response', $data, $formId, $postSettings);`
+
+This filter is located in `src/Components/Post/PostFeedSettings.php` (line 87).
+
+</explain-block>
+
+<explain-block title="fluentform/post_form_default_upload_path">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$path` — see source
+- `$postId` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/post_form_default_upload_path', function ($path, $postId) {
+    return $path;
+}, 10, 2);
+```
+
+**Reference**
+
+`$path = apply_filters('fluentform/post_form_default_upload_path', $path, $postId);`
+
+This filter is located in `src/Components/Post/PostFormHandler.php` (line 473).
+
+</explain-block>
+
+<explain-block title="fluentform/post_jetengine_accepted_advanced_fields">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$advancedFields` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/post_jetengine_accepted_advanced_fields', function ($advancedFields) {
+    return $advancedFields;
+}, 10, 1);
+```
+
+**Reference**
+
+`return apply_filters('fluentform/post_jetengine_accepted_advanced_fields', $advancedFields);`
+
+This filter is located in `src/Components/Post/JetEngineHelper.php` (line 576).
+
+</explain-block>
+
+<explain-block title="fluentform/post_jetengine_accepted_general_fields">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$generalFields` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/post_jetengine_accepted_general_fields', function ($generalFields) {
+    return $generalFields;
+}, 10, 1);
+```
+
+**Reference**
+
+`return apply_filters('fluentform/post_jetengine_accepted_general_fields', $generalFields);`
+
+This filter is located in `src/Components/Post/JetEngineHelper.php` (line 536).
+
+</explain-block>
+
+<explain-block title="fluentform/post_metabox_accepted_advanced_fields">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$acceptedFields` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/post_metabox_accepted_advanced_fields', function ($acceptedFields) {
+    return $acceptedFields;
+}, 10, 1);
+```
+
+**Reference**
+
+`return apply_filters('fluentform/post_metabox_accepted_advanced_fields', $acceptedFields);`
+
+This filter is located in `src/Components/Post/MetaboxHelper.php` (line 236).
+
+</explain-block>
+
+<explain-block title="fluentform/post_metabox_accepted_general_fields">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$acceptedFields` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/post_metabox_accepted_general_fields', function ($acceptedFields) {
+    return $acceptedFields;
+}, 10, 1);
+```
+
+**Reference**
+
+`return apply_filters('fluentform/post_metabox_accepted_general_fields', $acceptedFields);`
+
+This filter is located in `src/Components/Post/MetaboxHelper.php` (line 144).
+
+</explain-block>
+
+<explain-block title="fluentform/post_selection_label_by">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$postSelectLabelBy` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/post_selection_label_by', function ($postSelectLabelBy, $form) {
+    return $postSelectLabelBy;
+}, 10, 2);
+```
+
+**Reference**
+
+`$labelBy = apply_filters('fluentform/post_selection_label_by', $postSelectLabelBy, $form);`
+
+This filter is located in `src/Components/Post/PopulatePostForm.php` (line 138).
+
+</explain-block>
+
+<explain-block title="fluentform/post_selection_posts_per_page">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$value` — see source
+- `$data` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/post_selection_posts_per_page', function ($value, $data, $form) {
+    return $value;
+}, 10, 3);
+```
+
+**Reference**
+
+`'posts_per_page' => apply_filters('fluentform/post_selection_posts_per_page', -1, $data, $form)`
+
+This filter is located in `src/Components/Post/PopulatePostForm.php` (line 87).
+
+</explain-block>
+
+<explain-block title="fluentform/post_selection_posts_pre_data">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$postPreData` — see source
+- `$data` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/post_selection_posts_pre_data', function ($postPreData, $data, $form) {
+    return $postPreData;
+}, 10, 3);
+```
+
+**Reference**
+
+`$posts = apply_filters('fluentform/post_selection_posts_pre_data', $postPreData, $data, $form);`
+
+This filter is located in `src/Components/Post/PopulatePostForm.php` (line 82).
+
+</explain-block>
+
+<explain-block title="fluentform/post_selection_posts_query_args">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$extraParams` — see source
+- `$data` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/post_selection_posts_query_args', function ($extraParams, $data, $form) {
+    return $extraParams;
+}, 10, 3);
+```
+
+**Reference**
+
+`$extraParams = apply_filters('fluentform/post_selection_posts_query_args', $extraParams, $data, $form);`
+
+This filter is located in `src/Components/Post/PopulatePostForm.php` (line 102).
+
+</explain-block>
+
+<explain-block title="fluentform/post_selection_value_by">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$postSelectBy` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/post_selection_value_by', function ($postSelectBy, $form) {
+    return $postSelectBy;
+}, 10, 2);
+```
+
+**Reference**
+
+`$postValueBy = apply_filters('fluentform/post_selection_value_by', $postSelectBy, $form);`
+
+This filter is located in `src/Components/Post/PopulatePostForm.php` (line 127).
+
+</explain-block>

--- a/src/hooks/filters/quiz.md
+++ b/src/hooks/filters/quiz.md
@@ -4,6 +4,137 @@
 
 These filters let you modify quiz results, scoring, and display.
 
+<explain-block title="fluentform/quiz_case_sensitive_off">
+
+You can use this filter to toggle quiz case sensitivity.
+
+**Parameters**
+
+- `$status` (array) Whether Quiz Case Sensitivity is enabled
+
+**Usage**
+
+```php
+add_filter('fluentform/quiz_case_sensitive_off', function ($status) {
+    // Do your stuff here
+    
+    return $status;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/quiz_case_sensitive_off', __return_false());`
+
+This filter is located in FluentFormPro\src\classes\Quiz\QuizController -> isCorrect($settings, $userValue,
+$correctValue = '', $options = [])
+
+</explain-block>
+
+<explain-block title="fluentform/quiz_no_grade_label">
+
+You can use this filter to change text of quiz result grade label.
+
+**Parameters**
+
+- `$gradeLabel` (string) Grade Label Name
+
+**Usage**
+
+```php
+add_filter('fluentform/quiz_no_grade_label', function ($gradeLabel) {
+    // Do your stuff here
+    
+    return $gradeLabel;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/quiz_no_grade_label', __('Not Graded', 'fluentformpro'));`
+
+This filter is located in FluentFormPro\src\classes\Quiz\QuizScoreComponent -> addScoreToSubmission($value, $field, $submissionData, $form)
+
+</explain-block>
+
+<explain-block title="fluentform/quiz_personality_label">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$message` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/quiz_personality_label', function ($message, $form) {
+    return $message;
+}, 10, 2);
+```
+
+**Reference**
+
+`$personalityLabel = apply_filters('fluentform/quiz_personality_label',__('Personality', 'fluentformpro'),$form);`
+
+This filter is located in `src/classes/Quiz/QuizController.php` (line 390).
+
+</explain-block>
+
+<explain-block title="fluentform/quiz_personality_test_fallback_label">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$message` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/quiz_personality_test_fallback_label', function ($message, $form) {
+    return $message;
+}, 10, 2);
+```
+
+**Reference**
+
+`$fallbackLabel = apply_filters('fluentform/quiz_personality_test_fallback_label', __('Did not match any options!', 'fluentformpro'), $form);`
+
+This filter is located in `src/classes/Quiz/QuizScoreComponent.php` (line 240).
+
+</explain-block>
+
+<explain-block title="fluentform/quiz_result_message">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$resultHtml` — see source
+- `$submission` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/quiz_result_message', function ($resultHtml, $submission, $form) {
+    return $resultHtml;
+}, 10, 3);
+```
+
+**Reference**
+
+`'content' => apply_filters('fluentform/quiz_result_message', $resultHtml, $submission, $form)`
+
+This filter is located in `src/classes/Quiz/QuizController.php` (line 789).
+
+</explain-block>
+
 <explain-block title="fluentform/quiz_result_table_html">
 
 You can use this filter to modify quiz result table HTML.
@@ -36,58 +167,29 @@ ShortCodeParser $parser)
 
 </explain-block>
 
-<explain-block title="fluentform/quiz_case_sensitive_off">
+<explain-block title="fluentform/quiz_result_title">
 
-You can use this filter to toggle quiz case sensitivity.
+<Badge type="tip" vertical="top" text="Pro" />
 
 **Parameters**
 
-- `$status` (array) Whether Quiz Case Sensitivity is enabled
+- `$title` — see source
+- `$submission` — see source
+- `$form` — see source
 
 **Usage**
 
 ```php
-add_filter('fluentform/quiz_case_sensitive_off', function ($status) {
-    // Do your stuff here
-    
-    return $status;
-}, 10, 1);
-
+add_filter('fluentform/quiz_result_title', function ($title, $submission, $form) {
+    return $title;
+}, 10, 3);
 ```
 
 **Reference**
 
-`apply_filters('fluentform/quiz_case_sensitive_off', __return_false());`
+`$title = apply_filters('fluentform/quiz_result_title', $title, $submission, $form);`
 
-This filter is located in FluentFormPro\src\classes\Quiz\QuizController -> isCorrect($settings, $userValue,
-$correctValue = '', $options = [])
-
-</explain-block>
-
-<explain-block title="fluentform/quiz_wrong_ans_icon">
-
-You can use this filter to change quiz wrong answer icon.
-
-**Parameters**
-
-- `$icon` (string) Icon Link in SVG Format
-
-**Usage**
-
-```php
-add_filter('fluentform/quiz_wrong_ans_icon', function ($icon) {
-    // Do your stuff here
-    
-    return $status;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/quiz_wrong_ans_icon', $icon);`
-
-This filter is located in FluentFormPro\src\classes\Quiz\QuizController -> getWrongIcon()
+This filter is located in `src/classes/Quiz/QuizController.php` (line 785).
 
 </explain-block>
 
@@ -118,33 +220,6 @@ This filter is located in FluentFormPro\src\classes\Quiz\QuizController -> getRi
 
 </explain-block>
 
-<explain-block title="fluentform/quiz_no_grade_label">
-
-You can use this filter to change text of quiz result grade label.
-
-**Parameters**
-
-- `$gradeLabel` (string) Grade Label Name
-
-**Usage**
-
-```php
-add_filter('fluentform/quiz_no_grade_label', function ($gradeLabel) {
-    // Do your stuff here
-    
-    return $gradeLabel;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/quiz_no_grade_label', __('Not Graded', 'fluentformpro'));`
-
-This filter is located in FluentFormPro\src\classes\Quiz\QuizScoreComponent -> addScoreToSubmission($value, $field, $submissionData, $form)
-
-</explain-block>
-
 <explain-block title="fluentform/quiz_score_value">
 
 You can use this filter to modify quiz score value.
@@ -172,5 +247,82 @@ add_filter('fluentform/quiz_score_value', function ($result, $formId, $scoreType
 `apply_filters('fluentform/quiz_score_value', $result, $formId, $scoreType, $quizResults);`
 
 This filter is located in FluentFormPro\src\classes\Quiz\QuizScoreComponent -> addScoreToSubmission($value, $field, $submissionData, $form)
+
+</explain-block>
+
+<explain-block title="fluentform/quiz_wrong_ans_icon">
+
+You can use this filter to change quiz wrong answer icon.
+
+**Parameters**
+
+- `$icon` (string) Icon Link in SVG Format
+
+**Usage**
+
+```php
+add_filter('fluentform/quiz_wrong_ans_icon', function ($icon) {
+    // Do your stuff here
+    
+    return $status;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/quiz_wrong_ans_icon', $icon);`
+
+This filter is located in FluentFormPro\src\classes\Quiz\QuizController -> getWrongIcon()
+
+</explain-block>
+
+<explain-block title="fluentform/survey_field_label">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$data` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/survey_field_label', function ($data, $form) {
+    return $data;
+}, 10, 2);
+```
+
+**Reference**
+
+`<div class="ff-poll-label"><?php echo apply_filters('fluentform/survey_field_label', $data['label'], $form); ?></div>`
+
+This filter is located in `src/classes/SurveyResultProcessor.php` (line 119).
+
+</explain-block>
+
+<explain-block title="fluentform/survey_votes_text">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$message` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/survey_votes_text', function ($message, $form) {
+    return $message;
+}, 10, 2);
+```
+
+**Reference**
+
+`<div class="ff-poll-answer-count">(<?php echo $report['count'] . apply_filters('fluentform/survey_votes_text', __(' votes', 'fluentformpro'), $form) ; ?>)</div>`
+
+This filter is located in `src/classes/SurveyResultProcessor.php` (line 127).
 
 </explain-block>

--- a/src/hooks/filters/reports.md
+++ b/src/hooks/filters/reports.md
@@ -1,0 +1,185 @@
+# Reports Filters
+
+<Badge type="tip" vertical="top" text="Filter Hooks" /> <Badge type="warning" vertical="top" text="8 Filters" />
+
+<explain-block title="fluentform/report_migration_batch_size">
+
+**Parameters**
+
+- `$value` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/report_migration_batch_size', function ($value) {
+    return $value;
+}, 10, 1);
+```
+
+**Reference**
+
+`$batchSize = apply_filters('fluentform/report_migration_batch_size', 200);`
+
+This filter is located in `app/Services/Report/ReportHelper.php` (line 359).
+
+</explain-block>
+
+<explain-block title="fluentform/report_migration_max_batches">
+
+**Parameters**
+
+- `$value` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/report_migration_max_batches', function ($value) {
+    return $value;
+}, 10, 1);
+```
+
+**Reference**
+
+`$maxBatches = apply_filters('fluentform/report_migration_max_batches', 50);`
+
+This filter is located in `app/Services/Report/ReportHelper.php` (line 360).
+
+</explain-block>
+
+<explain-block title="fluentform/reports/completion_rate">
+
+**Parameters**
+
+- `$args` — see source
+- `$this` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/reports/completion_rate', function ($args, $this) {
+    return $args;
+}, 10, 2);
+```
+
+**Reference**
+
+`$data = apply_filters('fluentform/reports/completion_rate', [], $this->sanitizeReportAttributes());`
+
+This filter is located in `app/Http/Controllers/ReportController.php` (line 163).
+
+</explain-block>
+
+<explain-block title="fluentform/reports/country_heatmap">
+
+**Parameters**
+
+- `$args` — see source
+- `$this` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/reports/country_heatmap', function ($args, $this) {
+    return $args;
+}, 10, 2);
+```
+
+**Reference**
+
+`$data = apply_filters('fluentform/reports/country_heatmap', [], $this->sanitizeReportAttributes());`
+
+This filter is located in `app/Http/Controllers/ReportController.php` (line 212).
+
+</explain-block>
+
+<explain-block title="fluentform/reports/heatmap_data">
+
+**Parameters**
+
+- `$args` — see source
+- `$this` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/reports/heatmap_data', function ($args, $this) {
+    return $args;
+}, 10, 2);
+```
+
+**Reference**
+
+`$data = apply_filters('fluentform/reports/heatmap_data', [], $this->sanitizeReportAttributes());`
+
+This filter is located in `app/Http/Controllers/ReportController.php` (line 196).
+
+</explain-block>
+
+<explain-block title="fluentform/reports/revenue_analysis">
+
+**Parameters**
+
+- `$args` — see source
+- `$this` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/reports/revenue_analysis', function ($args, $this) {
+    return $args;
+}, 10, 2);
+```
+
+**Reference**
+
+`$data = apply_filters('fluentform/reports/revenue_analysis', [], $this->sanitizeReportAttributes());`
+
+This filter is located in `app/Http/Controllers/ReportController.php` (line 96).
+
+</explain-block>
+
+<explain-block title="fluentform/reports/submissions_analysis">
+
+**Parameters**
+
+- `$args` — see source
+- `$this` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/reports/submissions_analysis', function ($args, $this) {
+    return $args;
+}, 10, 2);
+```
+
+**Reference**
+
+`$data = apply_filters('fluentform/reports/submissions_analysis', [], $this->sanitizeReportAttributes());`
+
+This filter is located in `app/Http/Controllers/ReportController.php` (line 113).
+
+</explain-block>
+
+<explain-block title="fluentform/reports/subscriptions">
+
+**Parameters**
+
+- `$args` — see source
+- `$this` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/reports/subscriptions', function ($args, $this) {
+    return $args;
+}, 10, 2);
+```
+
+**Reference**
+
+`$data = apply_filters('fluentform/reports/subscriptions', [], $this->sanitizeReportAttributes());`
+
+This filter is located in `app/Http/Controllers/ReportController.php` (line 262).
+
+</explain-block>

--- a/src/hooks/filters/settings.md
+++ b/src/hooks/filters/settings.md
@@ -4,137 +4,140 @@
 
 These filters let you modify admin settings, global configuration, and permissions.
 
-<explain-block title="fluentform/is_admin_page">
+<explain-block title="fluentform/addOnModule_i18n">
 
-You can toggle the rendering page as an admin page by using this filter.
+You can alter or added more internationalize (i18n) for addon module string using this filter.
 
 **Parameters**
 
-- `$status` (boolean) Whether the rendering page is an Admin Page
+- `$i18n` (array) All the i18n Strings
 
 **Usage**
 
 ```php
-add_filter('fluentform/is_admin_page', function($status) {
+add_filter('fluentform/addOnModule_i18n', function ($i18n) {
    // Do your stuff here
 
-  return $staus;
+   return $i18n;
 }, 10, 1);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/is_admin_page', $status);`
+`apply_filters('fluentform/addOnModule_i18n', $i18n);`
 
-This filter is located in FluentForm\App\Helpers\Helper -> isFluentAdminPage()
+This filter is located in FluentForm\App\Modules\Registerer\TranslationString -> getAddOnModuleI18n()
 
 </explain-block>
 
-<explain-block title="fluentform/advanced_validation_settings">
+<explain-block title="fluentform/addons_extra_menu">
 
-You can modify Advanced Validation Settings using this filter.
+You can modify addon modules menus using this filter.
 
 **Parameters**
 
-- `$settings` (array) Form Advanced Validation Settings
+- `$extraMenus` (array) Addon Modules Menus
 
 **Usage**
 
 ```php
-add_filter('fluentform/advanced_validation_settings', function($settings) {
-   // Do your stuff here
+add_filter('fluentform/addons_extra_menu', function ($menus) {
+    $menus['fluentform_pdf'] = __('Fluent Forms PDF', 'fluentform');
 
-   return $settings;
-}, 10, 1);
+    return $menus;
+}, 99, 1);
 
 ```
-
 **Reference**
 
-`apply_filters('fluentform/advanced_validation_settings', $settings);`
+`apply_filters('fluentform/addons_extra_menu', $extraMenus);`
 
-This filter is located in FluentForm\App\Models\Form -> getAdvancedValidationSettings($formId)
+This filter is located in FluentForm\App\Modules\Widgets\AddOnModule -> render()
 
 </explain-block>
 
-<explain-block title="fluentform/get_meta_key_settings_response">
+<explain-block title="fluentform/admin_approval_confirmation_message">
 
-This filter returns settings responses meta key.
+<Badge type="tip" vertical="top" text="Pro" /> <Badge type="warning" vertical="top" text="Added in 6.2.2" />
+
+Filter the HTML content shown to a user after their submission state changes through Pro's Admin Approval flow (approved, rejected, or awaiting moderation). Lets you rewrite or localize the public-facing confirmation message without overriding the underlying templates.
 
 **Parameters**
 
-- `$result` (array) Responses
-- `$formId` (int) Form ID
-- `$metaKey` (string) Form ID
+- `$landingContent` (string) The HTML message about to be rendered
+- `$status` (string) Submission status — typically `'approved'`, `'rejected'`, or `'pending'`
+- `$form` (object) The form being processed
 
 **Usage**
 
 ```php
-add_filter('fluentform/get_meta_key_settings_response', function ($result, $formId, $metaKey) {
-   // Do your stuff here
-
-   return $result;
+add_filter('fluentform/admin_approval_confirmation_message', function ($content, $status, $form) {
+    if ($status === 'rejected') {
+        return '<p>' . esc_html__('Thanks for submitting. We were unable to accept this entry.', 'your-textdomain') . '</p>';
+    }
+    return $content;
 }, 10, 3);
-
 ```
+
 **Reference**
 
-`apply_filters('fluentform/get_meta_key_settings_response', $result, $formId, $metaKey);`
+`apply_filters('fluentform/admin_approval_confirmation_message', $landingContent, $submission->status, $form);`
 
-This filter is located in FluentForm\App\Services\Settings\SettingsService -> get($attributes = [])
+This filter is located in `FluentFormPro\classes\AdminApproval\AdminApproval`.
 
 </explain-block>
 
-<explain-block title="fluentform/dashboard_capability">
+<explain-block title="fluentform/admin_approval_messages">
 
-You can modify Fluent Forms Dashboard Capability using this filter.
+<Badge type="tip" vertical="top" text="Pro" />
 
 **Parameters**
 
-- `$roleName` (string) Role Name. By Default, 'fluentform_dashboard_access'
+- `$approvalMessages` — see source
+- `$formData` — see source
+- `$form` — see source
 
 **Usage**
 
 ```php
-add_filter('fluentform/dashboard_capability', function($roleName) {
-   // Do your stuff here
-
-   return $roleName;
-}, 10, 1);
-
+add_filter('fluentform/admin_approval_messages', function ($approvalMessages, $formData, $form) {
+    return $approvalMessages;
+}, 10, 3);
 ```
+
 **Reference**
 
-`apply_filters('fluentform/dashboard_capability', 'fluentform_dashboard_access');`
+`$approvalMessages = apply_filters('fluentform/admin_approval_messages', $approvalMessages, $formData, $form);`
 
-This filter is located in FluentForm\App\Modules\Registerer\Menu -> register()
+This filter is located in `src/classes/AdminApproval/AdminApproval.php` (line 139).
 
 </explain-block>
 
-<explain-block title="fluentform/settings_capability">
+<explain-block title="fluentform/admin_i18n">
 
-You can modify Fluent Forms Settings Capability using this filter.
+You can alter or added more internationalize (i18n) for admin side string using this filter.
 
 **Parameters**
 
-- `$roleName` (string) Role Name. By Default, 'fluentform_settings_manager'
+- `$i18n` (array) All the i18n Strings
 
 **Usage**
 
 ```php
-add_filter('fluentform/settings_capability', function($roleName) {
+add_filter('fluentform/admin_i18n', function ($i18n) {
    // Do your stuff here
 
-   return $roleName;
+   return $i18n;
 }, 10, 1);
 
 ```
+
 **Reference**
 
-`apply_filters('fluentform/settings_capability', 'fluentform_dashboard_access');`
+`apply_filters('fluentform/admin_i18n', $i18n);`
 
-This filter is located in FluentForm\App\Modules\Registerer\Menu -> register()
+This filter is located in FluentForm\App\Modules\Registerer\TranslationString -> getAdminI18n()
 
 </explain-block>
 
@@ -165,119 +168,57 @@ This filter is located in FluentForm\App\Modules\Registerer\AdminBar -> getMenuI
 
 </explain-block>
 
-<explain-block title="fluentform/form_inner_route_permission_set">
+<explain-block title="fluentform/advanced_validation_settings">
 
-You can modify Admin Menu Route with permission using this filter.
+You can modify Advanced Validation Settings using this filter.
 
 **Parameters**
 
-- `$permission` (array) Admin Permission Set
+- `$settings` (array) Form Advanced Validation Settings
 
 **Usage**
 
 ```php
-add_filter('fluentform/form_inner_route_permission_set', function($permissions) {
+add_filter('fluentform/advanced_validation_settings', function($settings) {
    // Do your stuff here
 
-   return $permissions;
+   return $settings;
 }, 10, 1);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/form_inner_route_permission_set', [
-'editor'   => 'fluentform_forms_manager',
-'settings' => 'fluentform_forms_manager',
-'entries'  => 'fluentform_entries_viewer'
-]);`
+`apply_filters('fluentform/advanced_validation_settings', $settings);`
 
-This filter is located in FluentForm\App\Modules\Registerer\AdminBar -> getMenuItems()
+This filter is located in FluentForm\App\Models\Form -> getAdvancedValidationSettings($formId)
 
 </explain-block>
 
-<explain-block title="fluentform/inner_route_has_permission">
+<explain-block title="fluentform/all_editor_shortcodes">
 
-You can check admin menu route has proper permission using this filter.
-
-**Parameters**
-
-- `$hasPermission` (boolean) Whether the current route has permission
-- `$route` (string) Route Name
-- `$formId` (int) Form ID
-
-**Usage**
-
-```php
-add_filter('fluentform/inner_route_has_permission', function($hasPermission, $route, $formId) {
-   // Do your stuff here
-
-   return $hasPermission;
-}, 10, 3);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/form_inner_route_permission_set', Acl::hasPermission($toVerifyPermission), $route, $formId);`
-
-This filter is located in FluentForm\App\Modules\Registerer\Menu -> renderFormAdminRoute()
-
-</explain-block>
-
-<explain-block title="fluentform/form_admin_menu">
-
-You can modify admin menu items using this filter.
+You can use this filter to modify all the editor shortcodes.
 
 **Parameters**
 
-- `$permission` (array) Admin Permission Set
-- `$form_id` (int) Form ID
+- `$generalShortCodes` (array) All General Shortcodes
 - `$form` (object) Form Object
 
 **Usage**
 
 ```php
-add_filter('fluentform/form_admin_menu', function($formAdminMenus, $form_id, $form) {
-   // Do your stuff here
-
-   return $formAdminMenus;
-}, 10, 3);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/form_admin_menu', $formAdminMenus, $form_id, $form);`
-
-This filter is located in FluentForm\App\Modules\Registerer\Menu -> renderFormInnerPages()
-
-</explain-block>
-
-<explain-block title="fluentform/form_settings_menu">
-
-You can modify form settings menu items using this filter.
-
-**Parameters**
-
-- `$permission` (array) Admin Permission Set
-
-**Usage**
-
-```php
-add_filter('fluentform/form_settings_menu', function ($settingsMenus, $form_id) {
-   // Do your stuff here
-
-   return $settingsMenus;
+add_filter('fluentform/all_editor_shortcodes', function ($editorShortCodes, $form) {
+    // Do your stuff here
+    
+    return $editorShortCodes;
 }, 10, 2);
 
 ```
-
 **Reference**
 
-`apply_filters('fluentform/form_settings_menu', $settingsMenus, $form_id);`
+`apply_filters('fluentform/all_editor_shortcodes', $editorShortCodes, $form);`
 
-This filter is located in FluentForm\App\Modules\Registerer\Menu -> renderSettings($form_id)
+This filter is located in FluentForm\boot\globals.php -> fluentFormGetAllEditorShortCodes($form)
 
 </explain-block>
 
@@ -321,138 +262,355 @@ This filter is located in FluentForm\App\Modules\Registerer\Menu -> renderForms(
 
 </explain-block>
 
-<explain-block title="fluentform/editor_vars">
+<explain-block title="fluentform/allowed_css_properties">
 
-You can modify editor variables using this filter.
+<Badge type="tip" vertical="top" text="Pro" />
 
 **Parameters**
 
-- `$data` (array) Editor variables
+- `$style_tags` — see source
 
 **Usage**
 
 ```php
-add_filter('fluentform/editor_vars', function ($data) {
-   // Do your stuff here
-
-   return $data;
+add_filter('fluentform/allowed_css_properties', function ($style_tags) {
+    return $style_tags;
 }, 10, 1);
-
 ```
 
 **Reference**
 
-`apply_filters('fluentform/editor_vars', $data);`
+`$style_tags = apply_filters('fluentform/allowed_css_properties', $style_tags);`
 
-This filter is located in FluentForm\App\Modules\Registerer\Menu -> enqueueEditorAssets()
+This filter is located in `src/classes/Quiz/QuizController.php` (line 49).
 
 </explain-block>
 
-<explain-block title="fluentform/global_settings_current_component">
+<explain-block title="fluentform/available_date_formats">
 
-You can modify selected global setting component using this filter.
+You can modify date formats using the filter.
 
 **Parameters**
 
-- `$currentComponent` (array) Selected Global Setting Component
+- `$dateFormats` (array) Date formats
 
 **Usage**
 
 ```php
-add_filter('fluentform/global_settings_current_component', function ($currentComponent) {
-   // Do your stuff here
-
-   return $currentComponent;
+add_filter('fluentform/available_date_formats', function ($dateFormats) {
+    // Do your stuff here
+    
+    return $dateFormats;
 }, 10, 1);
 
+```
+Date formats to filter:
+```php
+[
+    'm/d/Y'       => 'm/d/Y - (Ex: 04/28/2018)', // USA
+    'd/m/Y'       => 'd/m/Y - (Ex: 28/04/2018)', // Canada, UK
+    'd.m.Y'       => 'd.m.Y - (Ex: 28.04.2019)', // Germany
+    'n/j/y'       => 'n/j/y - (Ex: 4/28/18)',
+    'm/d/y'       => 'm/d/y - (Ex: 04/28/18)',
+    'M/d/Y'       => 'M/d/Y - (Ex: Apr/28/2018)',
+    'y/m/d'       => 'y/m/d - (Ex: 18/04/28)',
+    'Y-m-d'       => 'Y-m-d - (Ex: 2018-04-28)',
+    'd-M-y'       => 'd-M-y - (Ex: 28-Apr-18)',
+    'm/d/Y h:i K' => 'm/d/Y h:i K - (Ex: 04/28/2018 08:55 PM)', // USA
+    'm/d/Y H:i'   => 'm/d/Y H:i - (Ex: 04/28/2018 20:55)', // USA
+    'd/m/Y h:i K' => 'd/m/Y h:i K - (Ex: 28/04/2018 08:55 PM)', // Canada, UK
+    'd/m/Y H:i'   => 'd/m/Y H:i - (Ex: 28/04/2018 20:55)', // Canada, UK
+    'd.m.Y h:i K' => 'd.m.Y h:i K - (Ex: 28.04.2019 08:55 PM)', // Germany
+    'd.m.Y H:i'   => 'd.m.Y H:i - (Ex: 28.04.2019 20:55)', // Germany
+    'h:i K'       => 'h:i K (Only Time Ex: 08:55 PM)',
+    'H:i'         => 'H:i (Only Time Ex: 20:55)',
+];
 ```
 
 **Reference**
 
-`apply_filters('fluentform/global_settings_current_component', $currentComponent);`
+`apply_filters('fluentform/available_date_formats', $dateFormats);`
 
-This filter is located in FluentForm\App\Modules\Registerer\Menu -> renderGlobalSettings()
+This filter is located in FluentForm\App\Services\FormBuilder\Components\DateTime -> getAvailableDateFormats()
 
 </explain-block>
 
-<explain-block title="fluentform/global_settings_components">
-
-You can modify all global setting components using this filter.
+<explain-block title="fluentform/block_editor_style_presets">
 
 **Parameters**
 
-- `$components` (array) All Global Setting Component
+- `$presets` — see source
 
 **Usage**
 
 ```php
-add_filter('fluentform/global_settings_components', function ($components) {
-   // Do your stuff here
-
-   return $components;
+add_filter('fluentform/block_editor_style_presets', function ($presets) {
+    return $presets;
 }, 10, 1);
-
 ```
 
 **Reference**
 
-`apply_filters('fluentform/global_settings_components', $components);`
+`$presets = apply_filters('fluentform/block_editor_style_presets', $presets);`
 
-This filter is located in FluentForm\App\Modules\Registerer\Menu -> renderGlobalSettings()
+This filter is located in `app/Hooks/actions.php` (line 1177).
 
 </explain-block>
 
-<explain-block title="fluentform/admin_i18n">
-
-You can alter or added more internationalize (i18n) for admin side string using this filter.
+<explain-block title="fluentform/build_style_from_theme">
 
 **Parameters**
 
-- `$i18n` (array) All the i18n Strings
+- `$value` — see source
+- `$formId` — see source
+- `$style` — see source
 
 **Usage**
 
 ```php
-add_filter('fluentform/admin_i18n', function ($i18n) {
-   // Do your stuff here
-
-   return $i18n;
-}, 10, 1);
-
+add_filter('fluentform/build_style_from_theme', function ($value, $formId, $style) {
+    return $value;
+}, 10, 3);
 ```
 
 **Reference**
 
-`apply_filters('fluentform/admin_i18n', $i18n);`
+`$loadCss = apply_filters('fluentform/build_style_from_theme', '', $formId, $style);`
 
-This filter is located in FluentForm\App\Modules\Registerer\TranslationString -> getAdminI18n()
+This filter is located in `app/Modules/Form/Settings/FormCssJs.php` (line 77).
 
 </explain-block>
 
-<explain-block title="fluentform/global_settings_i18n">
+<explain-block title="fluentform/calculation_field_messages">
 
-You can alter or added more internationalize (i18n) for global settings string using this filter.
+<Badge type="tip" vertical="top" text="Pro" />
 
 **Parameters**
 
-- `$i18n` (array) All the i18n Strings
+- `$calculationMessages` — see source
+- `$form` — see source
 
 **Usage**
 
 ```php
-add_filter('fluentform/global_settings_i18n', function ($i18n) {
+add_filter('fluentform/calculation_field_messages', function ($calculationMessages, $form) {
+    return $calculationMessages;
+}, 10, 2);
+```
+
+**Reference**
+
+`$calculationMessages = apply_filters('fluentform/calculation_field_messages', $calculationMessages, $form);`
+
+This filter is located in `src/classes/Calculation.php` (line 25).
+
+</explain-block>
+
+<explain-block title="fluentform/conditional_content">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$content` — see source
+- `$value` — see source
+- `$value_2` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/conditional_content', function ($content, $value, $value_2) {
+    return $content;
+}, 10, 3);
+```
+
+**Reference**
+
+`$content = apply_filters('fluentform/conditional_content', $content, static::$formData, static::$form);`
+
+This filter is located in `src/classes/ConditionalContent.php` (line 75).
+
+</explain-block>
+
+<explain-block title="fluentform/coupon_general_failure_message">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$value` — see source
+- `$formId` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/coupon_general_failure_message', function ($value, $formId) {
+    return $value;
+}, 10, 2);
+```
+
+**Reference**
+
+`'message' => wp_kses_post(__(apply_filters('fluentform/coupon_general_failure_message', 'The provided coupon is not valid', $formId), 'fluentformpro'))`
+
+This filter is located in `src/Payments/Classes/CouponController.php` (line 26).
+
+</explain-block>
+
+<explain-block title="fluentform/dashboard_capability">
+
+You can modify Fluent Forms Dashboard Capability using this filter.
+
+**Parameters**
+
+- `$roleName` (string) Role Name. By Default, 'fluentform_dashboard_access'
+
+**Usage**
+
+```php
+add_filter('fluentform/dashboard_capability', function($roleName) {
    // Do your stuff here
 
-   return $i18n;
+   return $roleName;
+}, 10, 1);
+
+```
+**Reference**
+
+`apply_filters('fluentform/dashboard_capability', 'fluentform_dashboard_access');`
+
+This filter is located in FluentForm\App\Modules\Registerer\Menu -> register()
+
+</explain-block>
+
+<explain-block title="fluentform/dashboard_notices">
+
+You can use this filter to add dashboard notices.
+
+**Parameters**
+
+- `$notices` (array) Notices
+
+**Usage**
+
+```php
+add_filter('fluentform/dashboard_notices', function ($notices) {
+    // Do your stuff here
+    
+    return $notices;
+}, 10, 1);
+
+```
+**Reference**
+
+`apply_filters('fluentform/dashboard_notices', $notices);`
+
+This filter is located in FluentForm\app\views\admin\all_entries.php
+
+</explain-block>
+
+<explain-block title="fluentform/display_add_form_button">
+
+You can toggle to support pages for showing media button using this filter.
+
+**Parameters**
+
+- `$isEligiblePage` (array) User Guide Links
+
+**Usage**
+
+```php
+add_filter('fluentform/display_add_form_button', function ($isEligiblePage) {
+    // Do your stuff here
+    
+    return $isEligiblePage;
+}, 10, 1);
+
+```
+**Reference**
+
+`apply_filters('fluentform/display_add_form_button', $isEligiblePage);`
+
+This filter is located in FluentForm\App\Modules\Widgets\EditorButtonModule -> pageSupportedMediaButtons()
+
+</explain-block>
+
+<explain-block title="fluentform/double_optin_confirmation_message">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$defaults` — see source
+- `$args` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/double_optin_confirmation_message', function ($defaults, $args, $form) {
+    return $defaults;
+}, 10, 3);
+```
+
+**Reference**
+
+`$defaults['confirmation_message'] = apply_filters('fluentform/double_optin_confirmation_message', $defaults['confirmation_message'], [], $form);`
+
+This filter is located in `src/classes/DoubleOptin.php` (line 111).
+
+</explain-block>
+
+<explain-block title="fluentform/double_optin_messages">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$optinMessages` — see source
+- `$args` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/double_optin_messages', function ($optinMessages, $args, $form) {
+    return $optinMessages;
+}, 10, 3);
+```
+
+**Reference**
+
+`$optinMessages = apply_filters('fluentform/double_optin_messages', $optinMessages, [], $form);`
+
+This filter is located in `src/classes/DoubleOptin.php` (line 121).
+
+</explain-block>
+
+<explain-block title="fluentform/editor_countries">
+
+You can modify or add more countries using the filter.
+
+**Parameters**
+
+- `$country_names` (array) Country Names List
+
+**Usage**
+
+```php
+add_filter('fluentform/editor_countries', function ($country_names) {
+   // Do your stuff here
+
+   return $country_names;
 }, 10, 1);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/global_settings_i18n', $i18n);`
+`apply_filters('fluentform/editor_countries', $country_names);`
 
-This filter is located in FluentForm\App\Modules\Registerer\TranslationString -> getGlobalSettingsI18n()
+This filter is located in FluentForm\App\Services\FormBuilder\CountryNames.php
 
 </explain-block>
 
@@ -483,6 +641,130 @@ This filter is located in FluentForm\App\Modules\Registerer\TranslationString ->
 
 </explain-block>
 
+<explain-block title="fluentform/editor_shortcodes">
+
+You can use this filter to modify all the general shortcodes.
+
+**Parameters**
+
+- `$generalShortCodes` (array) All General Shortcodes
+
+**Usage**
+
+```php
+add_filter('fluentform/editor_shortcodes', function ($generalShortCodes) {
+    // Do your stuff here
+    
+    return $generalShortCodes;
+}, 10, 1);
+
+```
+```php
+[
+    'title'      => 'General SmartCodes',
+    'shortcodes' => [
+        '{wp.admin_email}'            => __('Admin Email', 'fluentform'),
+        '{wp.site_url}'               => __('Site URL', 'fluentform'),
+        '{wp.site_title}'             => __('Site Title', 'fluentform'),
+        '{ip}'                        => __('IP Address', 'fluentform'),
+        '{date.m/d/Y}'                => __('Date (mm/dd/yyyy)', 'fluentform'),
+        '{date.d/m/Y}'                => __('Date (dd/mm/yyyy)', 'fluentform'),
+        '{embed_post.ID}'             => __('Embedded Post/Page ID', 'fluentform'),
+        '{embed_post.post_title}'     => __('Embedded Post/Page Title', 'fluentform'),
+        '{embed_post.permalink}'      => __('Embedded URL', 'fluentform'),
+        '{http_referer}'              => __('HTTP Referer URL', 'fluentform'),
+        '{user.ID}'                   => __('User ID', 'fluentform'),
+        '{user.display_name}'         => __('User Display Name', 'fluentform'),
+        '{user.first_name}'           => __('User First Name', 'fluentform'),
+        '{user.last_name}'            => __('User Last Name', 'fluentform'),
+        '{user.user_email}'           => __('User Email', 'fluentform'),
+        '{user.user_login}'           => __('User Username', 'fluentform'),
+        '{browser.name}'              => __('User Browser Client', 'fluentform'),
+        '{browser.platform}'          => __('User Operating System', 'fluentform'),
+        '{random_string.your_prefix}' => __('Random String with Prefix', 'fluentform'),
+    ],
+];
+
+```
+**Reference**
+
+`apply_filters('fluentform/editor_shortcodes', $generalShortCodes);`
+
+This filter is located in FluentForm\boot\globals.php -> fluentFormEditorShortCodes()
+
+</explain-block>
+
+<explain-block title="fluentform/editor_vars">
+
+You can modify editor variables using this filter.
+
+**Parameters**
+
+- `$data` (array) Editor variables
+
+**Usage**
+
+```php
+add_filter('fluentform/editor_vars', function ($data) {
+   // Do your stuff here
+
+   return $data;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/editor_vars', $data);`
+
+This filter is located in FluentForm\App\Modules\Registerer\Menu -> enqueueEditorAssets()
+
+</explain-block>
+
+<explain-block title="fluentform/email_summary_body_view_api_logs">
+
+**Parameters**
+
+- `$viewAllApiLogs` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/email_summary_body_view_api_logs', function ($viewAllApiLogs) {
+    return $viewAllApiLogs;
+}, 10, 1);
+```
+
+**Reference**
+
+`$viewAllApiLogs = apply_filters('fluentform/email_summary_body_view_api_logs', $viewAllApiLogs);`
+
+This filter is located in `app/Views/email/failedIntegration/body.php` (line 193).
+
+</explain-block>
+
+<explain-block title="fluentform/email_summary_settings">
+
+**Parameters**
+
+- `$settings` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/email_summary_settings', function ($settings) {
+    return $settings;
+}, 10, 1);
+```
+
+**Reference**
+
+`$settings = apply_filters('fluentform/email_summary_settings', $settings);`
+
+This filter is located in `app/Services/Scheduler/Scheduler.php` (line 27).
+
+</explain-block>
+
 <explain-block title="fluentform/entries_i18n">
 
 You can alter or added more internationalize (i18n) for form submission string using this filter.
@@ -510,36 +792,439 @@ This filter is located in FluentForm\App\Modules\Registerer\TranslationString ->
 
 </explain-block>
 
-<explain-block title="fluentform/addOnModule_i18n">
+<explain-block title="fluentform/entry_migration_max_limit">
 
-You can alter or added more internationalize (i18n) for addon module string using this filter.
+You can use this filter to set the submission migration limit.
 
 **Parameters**
 
-- `$i18n` (array) All the i18n Strings
+- `$maxLimit` (int) Submission Migration Max Limit, By Default 1000;
+- `$key` (string) Migration Key Name
+- `$totalEntries` (array) Total Submissions
+- `$formId` (int) Form ID
 
 **Usage**
 
 ```php
-add_filter('fluentform/addOnModule_i18n', function ($i18n) {
-   // Do your stuff here
-
-   return $i18n;
-}, 10, 1);
+add_filter('fluentform/entry_migration_max_limit', function ($maxLimit, $key, $totalEntries, $formId) {
+    // Do your stuff here
+    
+    return $maxLimit;
+}, 10, 4);
 
 ```
-
 **Reference**
 
-`apply_filters('fluentform/addOnModule_i18n', $i18n);`
+`apply_filters('fluentform/entry_migration_max_limit', static::DEFAULT_ENTRY_MIGRATION_MAX_LIMIT, $this->key, $totalEntries, $formId);`
 
-This filter is located in FluentForm\App\Modules\Registerer\TranslationString -> getAddOnModuleI18n()
+This filter is located in FluentForm\App\Services\Migrator\Classes\CalderaMigrator -> getEntries($formId)
 
 </explain-block>
 
-<explain-block title="fluentform/transfer_i18n">
+<explain-block title="fluentform/file_type_options">
 
-You can alter or added more internationalize (i18n) for form transfer string using this filter.
+You can modify file types for upload files.
+
+**Parameters**
+
+- `$fileTypeOptions` (array) Supported File Type Options
+
+**Usage**
+
+```php
+add_filter('fluentform/file_type_options', function ($fileTypeOptions) {
+    // Do your stuff here
+    
+    return $fileTypeOptions;
+}, 10, 1);
+
+```
+File Type Options Array:
+```php
+$fileTypeOptions = [
+    [
+        'label' => __('Images (jpg, jpeg, gif, png, bmp)', 'fluentform'),
+        'value' => 'jpg|jpeg|gif|png|bmp',
+    ],
+    [
+        'label' => __('Audio (mp3, wav, ogg, oga, wma, mka, m4a, ra, mid, midi)', 'fluentform'),
+        'value' => 'mp3|wav|ogg|oga|wma|mka|m4a|ra|mid|midi|mpga',
+    ],
+    [
+        'label' => __('Video (avi, divx, flv, mov, ogv, mkv, mp4, m4v, divx, mpg, mpeg, mpe)', 'fluentform'),
+        'value' => 'avi|divx|flv|mov|ogv|mkv|mp4|m4v|divx|mpg|mpeg|mpe|video/quicktime|qt',
+    ],
+    [
+        'label' => __('PDF (pdf)', 'fluentform'),
+        'value' => 'pdf',
+    ],
+    [
+        'label' => __('Docs (doc, ppt, pps, xls, mdb, docx, xlsx, pptx, odt, odp, ods, odg, odc, odb, odf, rtf, txt)', 'fluentform'),
+        'value' => 'doc|ppt|pps|xls|mdb|docx|xlsx|pptx|odt|odp|ods|odg|odc|odb|odf|rtf|txt',
+    ],
+    [
+        'label' => __('Zip Archives (zip, gz, gzip, rar, 7z)', 'fluentform'),
+        'value' => 'zip|gz|gzip|rar|7z',
+    ],
+    [
+        'label' => __('Executable Files (exe)', 'fluentform'),
+        'value' => 'exe',
+    ],
+    [
+        'label' => __('CSV (csv)', 'fluentform'),
+        'value' => 'csv',
+    ],
+];
+```
+**Reference**
+
+`apply_filters('fluentform/file_type_options', $fileTypeOptions);`
+
+This filter is located in FluentForm\App\Services\FormBuilder\ValidationRuleSettings
+
+</explain-block>
+
+<explain-block title="fluentform/form_admin_menu">
+
+You can modify admin menu items using this filter.
+
+**Parameters**
+
+- `$permission` (array) Admin Permission Set
+- `$form_id` (int) Form ID
+- `$form` (object) Form Object
+
+**Usage**
+
+```php
+add_filter('fluentform/form_admin_menu', function($formAdminMenus, $form_id, $form) {
+   // Do your stuff here
+
+   return $formAdminMenus;
+}, 10, 3);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/form_admin_menu', $formAdminMenus, $form_id, $form);`
+
+This filter is located in FluentForm\App\Modules\Registerer\Menu -> renderFormInnerPages()
+
+</explain-block>
+
+<explain-block title="fluentform/form_inner_route_permission_set">
+
+You can modify Admin Menu Route with permission using this filter.
+
+**Parameters**
+
+- `$permission` (array) Admin Permission Set
+
+**Usage**
+
+```php
+add_filter('fluentform/form_inner_route_permission_set', function($permissions) {
+   // Do your stuff here
+
+   return $permissions;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/form_inner_route_permission_set', [
+'editor'   => 'fluentform_forms_manager',
+'settings' => 'fluentform_forms_manager',
+'entries'  => 'fluentform_entries_viewer'
+]);`
+
+This filter is located in FluentForm\App\Modules\Registerer\AdminBar -> getMenuItems()
+
+</explain-block>
+
+<explain-block title="fluentform/form_settings_menu">
+
+You can modify form settings menu items using this filter.
+
+**Parameters**
+
+- `$permission` (array) Admin Permission Set
+
+**Usage**
+
+```php
+add_filter('fluentform/form_settings_menu', function ($settingsMenus, $form_id) {
+   // Do your stuff here
+
+   return $settingsMenus;
+}, 10, 2);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/form_settings_menu', $settingsMenus, $form_id);`
+
+This filter is located in FluentForm\App\Modules\Registerer\Menu -> renderSettings($form_id)
+
+</explain-block>
+
+<explain-block title="fluentform/form_settings_smartcodes">
+
+You can modify or add more smartcodes for form settings using the filter.
+
+**Parameters**
+
+- `$groups` (array) All Shortcode Group
+- `$form` (object) Form Object
+
+**Usage**
+
+```php
+add_filter('fluentform/form_settings_smartcodes', function ($groups, $form) {
+   // Do your stuff here
+
+   return $groups;
+}, 10, 2);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/form_settings_smartcodes', $groups, $form);`
+
+This filter is located in FluentForm\App\Services\FormBuilder\EditorShortcode -> getShortCodes($form)
+
+</explain-block>
+
+<explain-block title="fluentform/frameless_page_data">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$data` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/frameless_page_data', function ($data) {
+    return $data;
+}, 10, 1);
+```
+
+**Reference**
+
+`$data = apply_filters('fluentform/frameless_page_data', $data);`
+
+This filter is located in `src/Payments/PaymentMethods/BaseProcessor.php` (line 569).
+
+</explain-block>
+
+<explain-block title="fluentform/get_global_settings_values">
+
+You can modify global settings using the filter.
+
+**Parameters**
+
+- `$values` (array) All Global Settings Values
+- `$key` (string) Key Name
+
+**Usage**
+
+```php
+add_filter('fluentform/get_global_settings_values', function ($values, $key) {
+   // Do your stuff here
+
+   return $values;
+}, 10, 2);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/get_global_settings_values', $values, $key);`
+
+This filter is located in FluentForm\App\Services\GlobalSettings\GlobalSettingsService -> get($attributes = [])
+
+</explain-block>
+
+<explain-block title="fluentform/get_meta_key_settings_response">
+
+This filter returns settings responses meta key.
+
+**Parameters**
+
+- `$result` (array) Responses
+- `$formId` (int) Form ID
+- `$metaKey` (string) Form ID
+
+**Usage**
+
+```php
+add_filter('fluentform/get_meta_key_settings_response', function ($result, $formId, $metaKey) {
+   // Do your stuff here
+
+   return $result;
+}, 10, 3);
+
+```
+**Reference**
+
+`apply_filters('fluentform/get_meta_key_settings_response', $result, $formId, $metaKey);`
+
+This filter is located in FluentForm\App\Services\Settings\SettingsService -> get($attributes = [])
+
+</explain-block>
+
+<explain-block title="fluentform/global_default_message">
+
+**Parameters**
+
+- `$value` — see source
+- `$key` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/global_default_message', function ($value, $key) {
+    return $value;
+}, 10, 2);
+```
+
+**Reference**
+
+`return apply_filters('fluentform/global_default_message', Arr::get(static::$globalDefaultMessages, $key , ''), $key);`
+
+This filter is located in `app/Helpers/Traits/GlobalDefaultMessages.php` (line 23).
+
+</explain-block>
+
+<explain-block title="fluentform/global_default_message_setting_fields">
+
+**Parameters**
+
+- `$default_message_setting_fields` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/global_default_message_setting_fields', function ($default_message_setting_fields) {
+    return $default_message_setting_fields;
+}, 10, 1);
+```
+
+**Reference**
+
+`return apply_filters('fluentform/global_default_message_setting_fields', $default_message_setting_fields);`
+
+This filter is located in `app/Helpers/Traits/GlobalDefaultMessages.php` (line 114).
+
+</explain-block>
+
+<explain-block title="fluentform/global_default_messages">
+
+**Parameters**
+
+- `$default_messages` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/global_default_messages', function ($default_messages) {
+    return $default_messages;
+}, 10, 1);
+```
+
+**Reference**
+
+`static::$globalDefaultMessages = apply_filters('fluentform/global_default_messages', $default_messages);`
+
+This filter is located in `app/Helpers/Traits/GlobalDefaultMessages.php` (line 42).
+
+</explain-block>
+
+<explain-block title="fluentform/global_settings_component_settings_data">
+
+**Parameters**
+
+- `$globalSettingAppData` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/global_settings_component_settings_data', function ($globalSettingAppData) {
+    return $globalSettingAppData;
+}, 10, 1);
+```
+
+**Reference**
+
+`$globalSettingAppData = apply_filters('fluentform/global_settings_component_settings_data', $globalSettingAppData);`
+
+This filter is located in `app/Modules/Renderer/GlobalSettings/Settings.php` (line 61).
+
+</explain-block>
+
+<explain-block title="fluentform/global_settings_components">
+
+You can modify all global setting components using this filter.
+
+**Parameters**
+
+- `$components` (array) All Global Setting Component
+
+**Usage**
+
+```php
+add_filter('fluentform/global_settings_components', function ($components) {
+   // Do your stuff here
+
+   return $components;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/global_settings_components', $components);`
+
+This filter is located in FluentForm\App\Modules\Registerer\Menu -> renderGlobalSettings()
+
+</explain-block>
+
+<explain-block title="fluentform/global_settings_current_component">
+
+You can modify selected global setting component using this filter.
+
+**Parameters**
+
+- `$currentComponent` (array) Selected Global Setting Component
+
+**Usage**
+
+```php
+add_filter('fluentform/global_settings_current_component', function ($currentComponent) {
+   // Do your stuff here
+
+   return $currentComponent;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/global_settings_current_component', $currentComponent);`
+
+This filter is located in FluentForm\App\Modules\Registerer\Menu -> renderGlobalSettings()
+
+</explain-block>
+
+<explain-block title="fluentform/global_settings_i18n">
+
+You can alter or added more internationalize (i18n) for global settings string using this filter.
 
 **Parameters**
 
@@ -548,7 +1233,7 @@ You can alter or added more internationalize (i18n) for form transfer string usi
 **Usage**
 
 ```php
-add_filter('fluentform/transfer_i18n', function ($i18n) {
+add_filter('fluentform/global_settings_i18n', function ($i18n) {
    // Do your stuff here
 
    return $i18n;
@@ -558,9 +1243,402 @@ add_filter('fluentform/transfer_i18n', function ($i18n) {
 
 **Reference**
 
-`apply_filters('fluentform/transfer_i18n', $i18n);`
+`apply_filters('fluentform/global_settings_i18n', $i18n);`
 
-This filter is located in FluentForm\App\Modules\Registerer\TranslationString -> getTransferModuleI18n()
+This filter is located in FluentForm\App\Modules\Registerer\TranslationString -> getGlobalSettingsI18n()
+
+</explain-block>
+
+<explain-block title="fluentform/global_settings_menu">
+
+**Parameters**
+
+- `$args` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/global_settings_menu', function ($args) {
+    return $args;
+}, 10, 1);
+```
+
+**Reference**
+
+`$customLinks = apply_filters('fluentform/global_settings_menu', []);`
+
+This filter is located in `app/Modules/Registerer/Menu.php` (line 1138).
+
+</explain-block>
+
+<explain-block title="fluentform/inner_route_has_permission">
+
+You can check admin menu route has proper permission using this filter.
+
+**Parameters**
+
+- `$hasPermission` (boolean) Whether the current route has permission
+- `$route` (string) Route Name
+- `$formId` (int) Form ID
+
+**Usage**
+
+```php
+add_filter('fluentform/inner_route_has_permission', function($hasPermission, $route, $formId) {
+   // Do your stuff here
+
+   return $hasPermission;
+}, 10, 3);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/form_inner_route_permission_set', Acl::hasPermission($toVerifyPermission), $route, $formId);`
+
+This filter is located in FluentForm\App\Modules\Registerer\Menu -> renderFormAdminRoute()
+
+</explain-block>
+
+<explain-block title="fluentform/inventory_field_messages">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$inventoryMessages` — see source
+- `$this` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/inventory_field_messages', function ($inventoryMessages, $this) {
+    return $inventoryMessages;
+}, 10, 2);
+```
+
+**Reference**
+
+`$inventoryMessages = apply_filters('fluentform/inventory_field_messages', $inventoryMessages, $this->form);`
+
+This filter is located in `src/classes/Inventory/InventoryValidation.php` (line 492).
+
+</explain-block>
+
+<explain-block title="fluentform/ip_provider">
+
+This filter returns the IP provider used in the phone field.
+
+**Parameters**
+
+- `$url` (array) IP provider URL
+
+**Usage**
+
+```php
+add_filter('fluentform/ip_provider', function ($url) {
+    // Do your stuff here
+    
+    return $url;
+}, 10, 1);
+
+```
+**Reference**
+
+`apply_filters('fluentform/ip_provider', $url);`
+
+This filter is located in FluentForm\App\Services\FluentConversational\Classes\Converter\Converter -> getPhoneFieldSettings($data, $form)
+
+</explain-block>
+
+<explain-block title="fluentform/is_admin_page">
+
+You can toggle the rendering page as an admin page by using this filter.
+
+**Parameters**
+
+- `$status` (boolean) Whether the rendering page is an Admin Page
+
+**Usage**
+
+```php
+add_filter('fluentform/is_admin_page', function($status) {
+   // Do your stuff here
+
+  return $staus;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/is_admin_page', $status);`
+
+This filter is located in FluentForm\App\Helpers\Helper -> isFluentAdminPage()
+
+</explain-block>
+
+<explain-block title="'fluentform/item_rules_' . $item['element']">
+
+You can use this filter to modify the rules of an element.
+
+**Parameters**
+
+- `$message` (string) Validation Message
+- `$item` (object) Current Item
+
+**Usage**
+
+```php
+add_filter('fluentform/item_rules_' . $item['element'], function ($rules, $item) {
+    // Do your stuff here
+    
+    return $rules;
+}, 10, 2);
+
+```
+**Reference**
+
+`apply_filters('fluentform/item_rules_' . $item['element'], $rule['message'], $item);`
+
+This filter is located in FluentForm\App\Services\FormBuilder\FormBuilder -> extractValidationRule($item)
+
+</explain-block>
+
+<explain-block title="fluentform/itl_options">
+
+You can use this filter to modify the JavaScript options object that is passed to the intl-tel-input library for the phone field. This allows for deep customization of the field's behavior, validation, and appearance.
+
+**Parameters**
+
+- `$itlOptions` (array) The configuration options for the intl-tel-input library.
+- `$data` (array) (array) The configuration data for the specific phone field being rendered.
+- `$form` (object) Form Object
+
+The default configuration in Fluent Forms is:
+```php
+$itlOptions = [
+    'separateDialCode' => false,
+    'nationalMode'     => true,
+    'autoPlaceholder'  => 'aggressive',
+    'formatOnDisplay'  => true,
+    'validationNumberTypes' => [
+        'MOBILE',
+        'FIXED_LINE_OR_MOBILE',
+        'FIXED_LINE',
+        'TOLL_FREE', //  >= Fluent Forms 6.1.10
+    ]
+];
+```
+
+**Common Use Cases & Examples**
+1. Expand Validation to Accept Voicemails, VoIP, etc.
+
+    By default, Fluent Forms validates against standard `MOBILE` and `FIXED_LINE` numbers. As of Fluent Forms 6.1.10, it also validates against `TOLL_FREE`. But you can expand this to include other types of validation numbers:
+
+   - Allowed Validation Number Types
+     - `FIXED_LINE` - A standard landline number.
+     - `MOBILE` - A mobile (cell) phone number.
+     - `FIXED_LINE_OR_MOBILE` - Used for regions where it's not possible to distinguish between fixed-line and mobile numbers from the number alone.
+     - `TOLL_FREE` - Numbers that are free for the caller to dial (e.g., 800, 888 in the US).
+     - `PREMIUM_RATE` - High-cost numbers for services, typically charged at a higher rate.
+     - `SHARED_COST` - The cost of the call is shared between the caller and the receiver.
+     - `VOIP` - Voice over IP numbers.
+     - `PERSONAL_NUMBER` - A location-independent "follow-me" number that can be routed to different physical phones.
+     - `PAGER` - A number for a paging service.
+     - `UAN` - A Universal Access Number, used by businesses to be reachable on a single number across a country.
+     - `VOICEMAIL` - A number that goes directly to a voicemail service.
+```php
+add_filter('fluentform/itl_options', function ($itlOptions) {
+    // A list of all possible validation types that support.
+    $itlOptions['validationNumberTypes'] = [
+        'MOBILE',
+        'FIXED_LINE_OR_MOBILE',
+        'FIXED_LINE',
+        'TOLL_FREE',
+        'VOIP'
+    ];
+    return $itlOptions;
+});
+```
+2. Display the Dial Code in a Separate Field.
+
+   For a different UI style, you can have the country dial code appear next to the main input field instead of inside it.
+```php
+add_filter('fluentform/itl_options', function ($itlOptions) {
+    // This splits the flag dropdown and the number input.
+    $itlOptions['separateDialCode'] = true;
+    return $itlOptions;
+});
+```
+
+3. Use Full-Screen Dropdown
+
+   To improve the user experience on screens, you can make the country dropdown open in a full-screen modal.
+```php
+add_filter('fluentform/itl_options', function ($itlOptions) {
+    // The default is false. Set to true to enable.
+    $itlOptions['useFullscreenPopup'] = true;
+    return $itlOptions;
+});
+```
+    
+**Reference**
+
+`apply_filters('fluentform/itl_options', $itlOptions, $data, $form);`
+
+This filter is located in `FluentForm\App\Services\FluentConversational\Classes\Converter\Converter -> getPhoneFieldSettings($data, $form)`, `FluentFormPro\Components\PhoneField.php:273`
+
+</explain-block>
+
+<explain-block title="fluentform/landing_content_wrapper">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$template` — see source
+- `$submission` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/landing_content_wrapper', function ($template, $submission) {
+    return $template;
+}, 10, 2);
+```
+
+**Reference**
+
+`return apply_filters('fluentform/landing_content_wrapper', $template, $submission);`
+
+This filter is located in `src/classes/FrontEndEntryView.php` (line 224).
+
+</explain-block>
+
+<explain-block title="fluentform/landing_vars">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$data` — see source
+- `$formId` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/landing_vars', function ($data, $formId) {
+    return $data;
+}, 10, 2);
+```
+
+**Reference**
+
+`$landingVars = apply_filters('fluentform/landing_vars', $data, $formId);`
+
+This filter is located in `src/classes/SharePage/SharePage.php` (line 267).
+
+</explain-block>
+
+<explain-block title="fluentform/load_theme_style">
+
+**Parameters**
+
+- `$value` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/load_theme_style', function ($value) {
+    return $value;
+}, 10, 1);
+```
+
+**Reference**
+
+`'theme_style'             => apply_filters('fluentform/load_theme_style', false) ? 'ffs_inherit_theme' : '',`
+
+This filter is located in `app/Hooks/actions.php` (line 1183).
+
+</explain-block>
+
+<explain-block title="fluentform/partial_entry_admin_email_body">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$emailBody` — see source
+- `$form` — see source
+- `$link` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/partial_entry_admin_email_body', function ($emailBody, $form, $link) {
+    return $emailBody;
+}, 10, 3);
+```
+
+**Reference**
+
+`$emailBody = apply_filters('fluentform/partial_entry_admin_email_body', $emailBody, $form, $link);`
+
+This filter is located in `src/classes/DraftSubmissionsManager.php` (line 1007).
+
+</explain-block>
+
+<explain-block title="fluentform/partial_entry_admin_email_format">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$emailFormat` — see source
+- `$entry` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/partial_entry_admin_email_format', function ($emailFormat, $entry) {
+    return $emailFormat;
+}, 10, 2);
+```
+
+**Reference**
+
+`$emailFormat = apply_filters('fluentform/partial_entry_admin_email_format', $emailFormat, $entry,`
+
+This filter is located in `src/classes/DraftSubmissionsManager.php` (line 105).
+
+</explain-block>
+
+<explain-block title="fluentform/payment_smartcode">
+
+You can use this filter to modify smartcodes for Payment.
+
+**Parameters**
+
+- `$value` (string) Form Data
+- `$property` (array) Substring after {payment.
+- `$instance` (Object) Shortcode Parser Instance
+
+**Usage**
+
+```php
+add_filter('fluentform/payment_smartcode', function ($value, $property, $instance) {
+    // Do your stuff here
+    
+    return $item;
+}, 10, 2);
+
+```
+**Reference**
+
+`apply_filters('fluentform/payment_smartcode', $value, $property, self::getInstance());`
+
+This filter is located in FluentForm\App\Services\FormBuilder\ShortcodeParser -> parseShortCodeFromString($parsable, $isUrl = false, $isHtml = false)
 
 </explain-block>
 
@@ -591,81 +1669,56 @@ This filter is located in FluentForm\App\Modules\Registerer\TranslationString ->
 
 </explain-block>
 
-<explain-block title="fluentform/addons_extra_menu">
+<explain-block title="fluentform/permission_callback">
 
-You can modify addon modules menus using this filter.
+This filter checks the permission callback status. You can check the current permission and change the permission status.
 
 **Parameters**
 
-- `$extraMenus` (array) Addon Modules Menus
+- `$status` (boolean) Permission Status
+- `$permission` (string) Permission Name
 
 **Usage**
 
 ```php
-add_filter('fluentform/addons_extra_menu', function ($menus) {
-    $menus['fluentform_pdf'] = __('Fluent Forms PDF', 'fluentform');
+add_filter('fluentform/permission_callback', function($status, $permission) {
+    // Do your staff
 
-    return $menus;
-}, 99, 1);
+    return $status;
+}, 10, 2);
 
 ```
+
 **Reference**
+`apply_filters('fluentform/permission_callback', $status, $permission);`
 
-`apply_filters('fluentform/addons_extra_menu', $extraMenus);`
-
-This filter is located in FluentForm\App\Modules\Widgets\AddOnModule -> render()
+This filter is located in FluentForm\app\Hooks\filters.php
 
 </explain-block>
 
-<explain-block title="fluentform/user_guide_links">
+<explain-block title="fluentform/phone_field_strict_validation">
 
-You can modify documentation module user guide links using this filter.
+<Badge type="tip" vertical="top" text="Pro" />
 
 **Parameters**
 
-- `$guides` (array) User Guide Links
+- `$value` — see source
+- `$data` — see source
+- `$form` — see source
 
 **Usage**
 
 ```php
-add_filter('fluentform/user_guide_links', function ($guides) {
-    // Do your stuff here
-    
-    return $guides;
-}, 10, 1);
-
+add_filter('fluentform/phone_field_strict_validation', function ($value, $data, $form) {
+    return $value;
+}, 10, 3);
 ```
+
 **Reference**
 
-`apply_filters('fluentform/user_guide_links', $guides);`
+`$strictValidation = apply_filters('fluentform/phone_field_strict_validation', true, $data, $form) ? 'yes' : 'no';`
 
-This filter is located in FluentForm\App\Modules\Widgets\DocumentationModule -> getUserGuides()
-
-</explain-block>
-
-<explain-block title="fluentform/display_add_form_button">
-
-You can toggle to support pages for showing media button using this filter.
-
-**Parameters**
-
-- `$isEligiblePage` (array) User Guide Links
-
-**Usage**
-
-```php
-add_filter('fluentform/display_add_form_button', function ($isEligiblePage) {
-    // Do your stuff here
-    
-    return $isEligiblePage;
-}, 10, 1);
-
-```
-**Reference**
-
-`apply_filters('fluentform/display_add_form_button', $isEligiblePage);`
-
-This filter is located in FluentForm\App\Modules\Widgets\EditorButtonModule -> pageSupportedMediaButtons()
+This filter is located in `src/Components/PhoneField.php` (line 275).
 
 </explain-block>
 
@@ -759,246 +1812,206 @@ This filter is located in FluentForm\App\Services\FormBuilder\Components\Text ->
 
 </explain-block>
 
-<explain-block title="fluentform/itl_options">
+<explain-block title="fluentform/save_progress_button_text">
 
-You can use this filter to modify the JavaScript options object that is passed to the intl-tel-input library for the phone field. This allows for deep customization of the field's behavior, validation, and appearance.
-
-**Parameters**
-
-- `$itlOptions` (array) The configuration options for the intl-tel-input library.
-- `$data` (array) (array) The configuration data for the specific phone field being rendered.
-- `$form` (object) Form Object
-
-The default configuration in Fluent Forms is:
-```php
-$itlOptions = [
-    'separateDialCode' => false,
-    'nationalMode'     => true,
-    'autoPlaceholder'  => 'aggressive',
-    'formatOnDisplay'  => true,
-    'validationNumberTypes' => [
-        'MOBILE',
-        'FIXED_LINE_OR_MOBILE',
-        'FIXED_LINE',
-        'TOLL_FREE', //  >= Fluent Forms 6.1.10
-    ]
-];
-```
-
-**Common Use Cases & Examples**
-1. Expand Validation to Accept Voicemails, VoIP, etc.
-
-    By default, Fluent Forms validates against standard `MOBILE` and `FIXED_LINE` numbers. As of Fluent Forms 6.1.10, it also validates against `TOLL_FREE`. But you can expand this to include other types of validation numbers:
-
-   - Allowed Validation Number Types
-     - `FIXED_LINE` - A standard landline number.
-     - `MOBILE` - A mobile (cell) phone number.
-     - `FIXED_LINE_OR_MOBILE` - Used for regions where it's not possible to distinguish between fixed-line and mobile numbers from the number alone.
-     - `TOLL_FREE` - Numbers that are free for the caller to dial (e.g., 800, 888 in the US).
-     - `PREMIUM_RATE` - High-cost numbers for services, typically charged at a higher rate.
-     - `SHARED_COST` - The cost of the call is shared between the caller and the receiver.
-     - `VOIP` - Voice over IP numbers.
-     - `PERSONAL_NUMBER` - A location-independent "follow-me" number that can be routed to different physical phones.
-     - `PAGER` - A number for a paging service.
-     - `UAN` - A Universal Access Number, used by businesses to be reachable on a single number across a country.
-     - `VOICEMAIL` - A number that goes directly to a voicemail service.
-```php
-add_filter('fluentform/itl_options', function ($itlOptions) {
-    // A list of all possible validation types that support.
-    $itlOptions['validationNumberTypes'] = [
-        'MOBILE',
-        'FIXED_LINE_OR_MOBILE',
-        'FIXED_LINE',
-        'TOLL_FREE',
-        'VOIP'
-    ];
-    return $itlOptions;
-});
-```
-2. Display the Dial Code in a Separate Field.
-
-   For a different UI style, you can have the country dial code appear next to the main input field instead of inside it.
-```php
-add_filter('fluentform/itl_options', function ($itlOptions) {
-    // This splits the flag dropdown and the number input.
-    $itlOptions['separateDialCode'] = true;
-    return $itlOptions;
-});
-```
-
-3. Use Full-Screen Dropdown
-
-   To improve the user experience on screens, you can make the country dropdown open in a full-screen modal.
-```php
-add_filter('fluentform/itl_options', function ($itlOptions) {
-    // The default is false. Set to true to enable.
-    $itlOptions['useFullscreenPopup'] = true;
-    return $itlOptions;
-});
-```
-    
-**Reference**
-
-`apply_filters('fluentform/itl_options', $itlOptions, $data, $form);`
-
-This filter is located in `FluentForm\App\Services\FluentConversational\Classes\Converter\Converter -> getPhoneFieldSettings($data, $form)`, `FluentFormPro\Components\PhoneField.php:273`
-
-</explain-block>
-
-<explain-block title="fluentform/ip_provider">
-
-This filter returns the IP provider used in the phone field.
+<Badge type="tip" vertical="top" text="Pro" />
 
 **Parameters**
 
-- `$url` (array) IP provider URL
+- `$data` — see source
+- `$form` — see source
 
 **Usage**
 
 ```php
-add_filter('fluentform/ip_provider', function ($url) {
-    // Do your stuff here
-    
-    return $url;
+add_filter('fluentform/save_progress_button_text', function ($data, $form) {
+    return $data;
+}, 10, 2);
+```
+
+**Reference**
+
+`$buttonText = apply_filters('fluentform/save_progress_button_text', $data['settings']['button_ui']['text'], $form);`
+
+This filter is located in `src/Components/SaveProgressButton.php` (line 439).
+
+</explain-block>
+
+<explain-block title="fluentform/save_progress_vars">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$args` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/save_progress_vars', function ($args) {
+    return $args;
 }, 10, 1);
-
-```
-**Reference**
-
-`apply_filters('fluentform/ip_provider', $url);`
-
-This filter is located in FluentForm\App\Services\FluentConversational\Classes\Converter\Converter -> getPhoneFieldSettings($data, $form)
-
-</explain-block>
-
-<explain-block title="fluentform/available_date_formats">
-
-You can modify date formats using the filter.
-
-**Parameters**
-
-- `$dateFormats` (array) Date formats
-
-**Usage**
-
-```php
-add_filter('fluentform/available_date_formats', function ($dateFormats) {
-    // Do your stuff here
-    
-    return $dateFormats;
-}, 10, 1);
-
-```
-Date formats to filter:
-```php
-[
-    'm/d/Y'       => 'm/d/Y - (Ex: 04/28/2018)', // USA
-    'd/m/Y'       => 'd/m/Y - (Ex: 28/04/2018)', // Canada, UK
-    'd.m.Y'       => 'd.m.Y - (Ex: 28.04.2019)', // Germany
-    'n/j/y'       => 'n/j/y - (Ex: 4/28/18)',
-    'm/d/y'       => 'm/d/y - (Ex: 04/28/18)',
-    'M/d/Y'       => 'M/d/Y - (Ex: Apr/28/2018)',
-    'y/m/d'       => 'y/m/d - (Ex: 18/04/28)',
-    'Y-m-d'       => 'Y-m-d - (Ex: 2018-04-28)',
-    'd-M-y'       => 'd-M-y - (Ex: 28-Apr-18)',
-    'm/d/Y h:i K' => 'm/d/Y h:i K - (Ex: 04/28/2018 08:55 PM)', // USA
-    'm/d/Y H:i'   => 'm/d/Y H:i - (Ex: 04/28/2018 20:55)', // USA
-    'd/m/Y h:i K' => 'd/m/Y h:i K - (Ex: 28/04/2018 08:55 PM)', // Canada, UK
-    'd/m/Y H:i'   => 'd/m/Y H:i - (Ex: 28/04/2018 20:55)', // Canada, UK
-    'd.m.Y h:i K' => 'd.m.Y h:i K - (Ex: 28.04.2019 08:55 PM)', // Germany
-    'd.m.Y H:i'   => 'd.m.Y H:i - (Ex: 28.04.2019 20:55)', // Germany
-    'h:i K'       => 'h:i K (Only Time Ex: 08:55 PM)',
-    'H:i'         => 'H:i (Only Time Ex: 20:55)',
-];
 ```
 
 **Reference**
 
-`apply_filters('fluentform/available_date_formats', $dateFormats);`
+`$vars = apply_filters('fluentform/save_progress_vars', [`
 
-This filter is located in FluentForm\App\Services\FormBuilder\Components\DateTime -> getAvailableDateFormats()
+This filter is located in `src/classes/DraftSubmissionsManager.php` (line 778).
 
 </explain-block>
 
-<explain-block title="fluentform/editor_countries">
+<explain-block title="fluentform/settings_capability">
 
-You can modify or add more countries using the filter.
+You can modify Fluent Forms Settings Capability using this filter.
 
 **Parameters**
 
-- `$country_names` (array) Country Names List
+- `$roleName` (string) Role Name. By Default, 'fluentform_settings_manager'
 
 **Usage**
 
 ```php
-add_filter('fluentform/editor_countries', function ($country_names) {
+add_filter('fluentform/settings_capability', function($roleName) {
    // Do your stuff here
 
-   return $country_names;
+   return $roleName;
+}, 10, 1);
+
+```
+**Reference**
+
+`apply_filters('fluentform/settings_capability', 'fluentform_dashboard_access');`
+
+This filter is located in FluentForm\App\Modules\Registerer\Menu -> register()
+
+</explain-block>
+
+<explain-block title="fluentform/step_form_navigation_title">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$stepTitles` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/step_form_navigation_title', function ($stepTitles, $form) {
+    return $stepTitles;
+}, 10, 2);
+```
+
+**Reference**
+
+`$stepTitles = (array) apply_filters('fluentform/step_form_navigation_title', $stepTitles, $form);`
+
+This filter is located in `src/Components/FormStep.php` (line 100).
+
+</explain-block>
+
+<explain-block title="fluentform/step_next_button_class">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$value` — see source
+- `$data` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/step_next_button_class', function ($value, $data) {
+    return $value;
+}, 10, 2);
+```
+
+**Reference**
+
+`$btnClass = apply_filters('fluentform/step_next_button_class', 'ff-float-right ff-btn ff-btn-next ff-btn-secondary', $data);`
+
+This filter is located in `src/Components/FormStep.php` (line 232).
+
+</explain-block>
+
+<explain-block title="fluentform/step_prev_button_class">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$value` — see source
+- `$data` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/step_prev_button_class', function ($value, $data) {
+    return $value;
+}, 10, 2);
+```
+
+**Reference**
+
+`$btnClass = apply_filters('fluentform/step_prev_button_class', 'ff-btn ff-btn-prev ff-btn-secondary', $data);`
+
+This filter is located in `src/Components/FormStep.php` (line 214).
+
+</explain-block>
+
+<explain-block title="fluentform/transfer_i18n">
+
+You can alter or added more internationalize (i18n) for form transfer string using this filter.
+
+**Parameters**
+
+- `$i18n` (array) All the i18n Strings
+
+**Usage**
+
+```php
+add_filter('fluentform/transfer_i18n', function ($i18n) {
+   // Do your stuff here
+
+   return $i18n;
 }, 10, 1);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/editor_countries', $country_names);`
+`apply_filters('fluentform/transfer_i18n', $i18n);`
 
-This filter is located in FluentForm\App\Services\FormBuilder\CountryNames.php
+This filter is located in FluentForm\App\Modules\Registerer\TranslationString -> getTransferModuleI18n()
 
 </explain-block>
 
-<explain-block title="fluentform/form_settings_smartcodes">
+<explain-block title="fluentform/user_guide_links">
 
-You can modify or add more smartcodes for form settings using the filter.
+You can modify documentation module user guide links using this filter.
 
 **Parameters**
 
-- `$groups` (array) All Shortcode Group
-- `$form` (object) Form Object
+- `$guides` (array) User Guide Links
 
 **Usage**
 
 ```php
-add_filter('fluentform/form_settings_smartcodes', function ($groups, $form) {
-   // Do your stuff here
-
-   return $groups;
-}, 10, 2);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/form_settings_smartcodes', $groups, $form);`
-
-This filter is located in FluentForm\App\Services\FormBuilder\EditorShortcode -> getShortCodes($form)
-
-</explain-block>
-
-<explain-block title="'fluentform/validation_message_' . $ruleName">
-
-You can use this filter to modify the validation message of a specific rule.
-
-**Parameters**
-
-- `$message` (string) Validation Message
-- `$item` (object) Current Item
-
-**Usage**
-
-```php
-add_filter('fluentform/validation_message_' . $ruleName, function ($message, $item) {
+add_filter('fluentform/user_guide_links', function ($guides) {
     // Do your stuff here
     
-    return $message;
-}, 10, 2);
+    return $guides;
+}, 10, 1);
 
 ```
 **Reference**
 
-`apply_filters('fluentform/validation_message_' . $ruleName, $rule['message'], $item);`
+`apply_filters('fluentform/user_guide_links', $guides);`
 
-This filter is located in FluentForm\App\Services\FormBuilder\FormBuilder -> extractValidationRule($item)
+This filter is located in FluentForm\App\Modules\Widgets\DocumentationModule -> getUserGuides()
 
 </explain-block>
 
@@ -1029,30 +2042,29 @@ This filter is located in FluentForm\App\Services\FormBuilder\FormBuilder -> ext
 
 </explain-block>
 
-<explain-block title="'fluentform/item_rules_' . $item['element']">
-
-You can use this filter to modify the rules of an element.
+<explain-block title="fluentform/will_encode_url_value">
 
 **Parameters**
 
-- `$message` (string) Validation Message
-- `$item` (object) Current Item
+- `$value` — see source
+- `$redirectUrl` — see source
+- `$insertId` — see source
+- `$form` — see source
+- `$formData` — see source
 
 **Usage**
 
 ```php
-add_filter('fluentform/item_rules_' . $item['element'], function ($rules, $item) {
-    // Do your stuff here
-    
-    return $rules;
-}, 10, 2);
-
+add_filter('fluentform/will_encode_url_value', function ($value, $redirectUrl, $insertId, $form, $formData) {
+    return $value;
+}, 10, 5);
 ```
+
 **Reference**
 
-`apply_filters('fluentform/item_rules_' . $item['element'], $rule['message'], $item);`
+`$encodeUrl = apply_filters('fluentform/will_encode_url_value', false, $redirectUrl, $insertId, $form, $formData);`
 
-This filter is located in FluentForm\App\Services\FormBuilder\FormBuilder -> extractValidationRule($item)
+This filter is located in `app/Services/Form/SubmissionHandlerService.php` (line 383).
 
 </explain-block>
 
@@ -1081,286 +2093,5 @@ add_filter('fluentform/will_return_html', function ($isHtml, $isProvider, $key) 
 `apply_filters('fluentform/will_return_html', $isHtml, $isProvider, $key);`
 
 This filter is located in FluentForm\App\Services\FormBuilder -> buildFormBody($form)
-
-</explain-block>
-
-<explain-block title="fluentform/payment_smartcode">
-
-You can use this filter to modify smartcodes for Payment.
-
-**Parameters**
-
-- `$value` (string) Form Data
-- `$property` (array) Substring after {payment.
-- `$instance` (Object) Shortcode Parser Instance
-
-**Usage**
-
-```php
-add_filter('fluentform/payment_smartcode', function ($value, $property, $instance) {
-    // Do your stuff here
-    
-    return $item;
-}, 10, 2);
-
-```
-**Reference**
-
-`apply_filters('fluentform/payment_smartcode', $value, $property, self::getInstance());`
-
-This filter is located in FluentForm\App\Services\FormBuilder\ShortcodeParser -> parseShortCodeFromString($parsable, $isUrl = false, $isHtml = false)
-
-</explain-block>
-
-<explain-block title="fluentform/file_type_options">
-
-You can modify file types for upload files.
-
-**Parameters**
-
-- `$fileTypeOptions` (array) Supported File Type Options
-
-**Usage**
-
-```php
-add_filter('fluentform/file_type_options', function ($fileTypeOptions) {
-    // Do your stuff here
-    
-    return $fileTypeOptions;
-}, 10, 1);
-
-```
-File Type Options Array:
-```php
-$fileTypeOptions = [
-    [
-        'label' => __('Images (jpg, jpeg, gif, png, bmp)', 'fluentform'),
-        'value' => 'jpg|jpeg|gif|png|bmp',
-    ],
-    [
-        'label' => __('Audio (mp3, wav, ogg, oga, wma, mka, m4a, ra, mid, midi)', 'fluentform'),
-        'value' => 'mp3|wav|ogg|oga|wma|mka|m4a|ra|mid|midi|mpga',
-    ],
-    [
-        'label' => __('Video (avi, divx, flv, mov, ogv, mkv, mp4, m4v, divx, mpg, mpeg, mpe)', 'fluentform'),
-        'value' => 'avi|divx|flv|mov|ogv|mkv|mp4|m4v|divx|mpg|mpeg|mpe|video/quicktime|qt',
-    ],
-    [
-        'label' => __('PDF (pdf)', 'fluentform'),
-        'value' => 'pdf',
-    ],
-    [
-        'label' => __('Docs (doc, ppt, pps, xls, mdb, docx, xlsx, pptx, odt, odp, ods, odg, odc, odb, odf, rtf, txt)', 'fluentform'),
-        'value' => 'doc|ppt|pps|xls|mdb|docx|xlsx|pptx|odt|odp|ods|odg|odc|odb|odf|rtf|txt',
-    ],
-    [
-        'label' => __('Zip Archives (zip, gz, gzip, rar, 7z)', 'fluentform'),
-        'value' => 'zip|gz|gzip|rar|7z',
-    ],
-    [
-        'label' => __('Executable Files (exe)', 'fluentform'),
-        'value' => 'exe',
-    ],
-    [
-        'label' => __('CSV (csv)', 'fluentform'),
-        'value' => 'csv',
-    ],
-];
-```
-**Reference**
-
-`apply_filters('fluentform/file_type_options', $fileTypeOptions);`
-
-This filter is located in FluentForm\App\Services\FormBuilder\ValidationRuleSettings
-
-</explain-block>
-
-<explain-block title="fluentform/get_global_settings_values">
-
-You can modify global settings using the filter.
-
-**Parameters**
-
-- `$values` (array) All Global Settings Values
-- `$key` (string) Key Name
-
-**Usage**
-
-```php
-add_filter('fluentform/get_global_settings_values', function ($values, $key) {
-   // Do your stuff here
-
-   return $values;
-}, 10, 2);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/get_global_settings_values', $values, $key);`
-
-This filter is located in FluentForm\App\Services\GlobalSettings\GlobalSettingsService -> get($attributes = [])
-
-</explain-block>
-
-<explain-block title="fluentform/entry_migration_max_limit">
-
-You can use this filter to set the submission migration limit.
-
-**Parameters**
-
-- `$maxLimit` (int) Submission Migration Max Limit, By Default 1000;
-- `$key` (string) Migration Key Name
-- `$totalEntries` (array) Total Submissions
-- `$formId` (int) Form ID
-
-**Usage**
-
-```php
-add_filter('fluentform/entry_migration_max_limit', function ($maxLimit, $key, $totalEntries, $formId) {
-    // Do your stuff here
-    
-    return $maxLimit;
-}, 10, 4);
-
-```
-**Reference**
-
-`apply_filters('fluentform/entry_migration_max_limit', static::DEFAULT_ENTRY_MIGRATION_MAX_LIMIT, $this->key, $totalEntries, $formId);`
-
-This filter is located in FluentForm\App\Services\Migrator\Classes\CalderaMigrator -> getEntries($formId)
-
-</explain-block>
-
-<explain-block title="fluentform/editor_shortcodes">
-
-You can use this filter to modify all the general shortcodes.
-
-**Parameters**
-
-- `$generalShortCodes` (array) All General Shortcodes
-
-**Usage**
-
-```php
-add_filter('fluentform/editor_shortcodes', function ($generalShortCodes) {
-    // Do your stuff here
-    
-    return $generalShortCodes;
-}, 10, 1);
-
-```
-```php
-[
-    'title'      => 'General SmartCodes',
-    'shortcodes' => [
-        '{wp.admin_email}'            => __('Admin Email', 'fluentform'),
-        '{wp.site_url}'               => __('Site URL', 'fluentform'),
-        '{wp.site_title}'             => __('Site Title', 'fluentform'),
-        '{ip}'                        => __('IP Address', 'fluentform'),
-        '{date.m/d/Y}'                => __('Date (mm/dd/yyyy)', 'fluentform'),
-        '{date.d/m/Y}'                => __('Date (dd/mm/yyyy)', 'fluentform'),
-        '{embed_post.ID}'             => __('Embedded Post/Page ID', 'fluentform'),
-        '{embed_post.post_title}'     => __('Embedded Post/Page Title', 'fluentform'),
-        '{embed_post.permalink}'      => __('Embedded URL', 'fluentform'),
-        '{http_referer}'              => __('HTTP Referer URL', 'fluentform'),
-        '{user.ID}'                   => __('User ID', 'fluentform'),
-        '{user.display_name}'         => __('User Display Name', 'fluentform'),
-        '{user.first_name}'           => __('User First Name', 'fluentform'),
-        '{user.last_name}'            => __('User Last Name', 'fluentform'),
-        '{user.user_email}'           => __('User Email', 'fluentform'),
-        '{user.user_login}'           => __('User Username', 'fluentform'),
-        '{browser.name}'              => __('User Browser Client', 'fluentform'),
-        '{browser.platform}'          => __('User Operating System', 'fluentform'),
-        '{random_string.your_prefix}' => __('Random String with Prefix', 'fluentform'),
-    ],
-];
-
-```
-**Reference**
-
-`apply_filters('fluentform/editor_shortcodes', $generalShortCodes);`
-
-This filter is located in FluentForm\boot\globals.php -> fluentFormEditorShortCodes()
-
-</explain-block>
-
-<explain-block title="fluentform/all_editor_shortcodes">
-
-You can use this filter to modify all the editor shortcodes.
-
-**Parameters**
-
-- `$generalShortCodes` (array) All General Shortcodes
-- `$form` (object) Form Object
-
-**Usage**
-
-```php
-add_filter('fluentform/all_editor_shortcodes', function ($editorShortCodes, $form) {
-    // Do your stuff here
-    
-    return $editorShortCodes;
-}, 10, 2);
-
-```
-**Reference**
-
-`apply_filters('fluentform/all_editor_shortcodes', $editorShortCodes, $form);`
-
-This filter is located in FluentForm\boot\globals.php -> fluentFormGetAllEditorShortCodes($form)
-
-</explain-block>
-
-<explain-block title="fluentform/dashboard_notices">
-
-You can use this filter to add dashboard notices.
-
-**Parameters**
-
-- `$notices` (array) Notices
-
-**Usage**
-
-```php
-add_filter('fluentform/dashboard_notices', function ($notices) {
-    // Do your stuff here
-    
-    return $notices;
-}, 10, 1);
-
-```
-**Reference**
-
-`apply_filters('fluentform/dashboard_notices', $notices);`
-
-This filter is located in FluentForm\app\views\admin\all_entries.php
-
-</explain-block>
-
-<explain-block title="fluentform/permission_callback">
-
-This filter checks the permission callback status. You can check the current permission and change the permission status.
-
-**Parameters**
-
-- `$status` (boolean) Permission Status
-- `$permission` (string) Permission Name
-
-**Usage**
-
-```php
-add_filter('fluentform/permission_callback', function($status, $permission) {
-    // Do your staff
-
-    return $status;
-}, 10, 2);
-
-```
-
-**Reference**
-`apply_filters('fluentform/permission_callback', $status, $permission);`
-
-This filter is located in FluentForm\app\Hooks\filters.php
 
 </explain-block>

--- a/src/hooks/filters/spam-protection.md
+++ b/src/hooks/filters/spam-protection.md
@@ -1,0 +1,263 @@
+# Spam Protection Filters
+
+<Badge type="tip" vertical="top" text="Filter Hooks" /> <Badge type="warning" vertical="top" text="5 Filters" />
+
+These filters let you replace the default user-facing messages emitted when a spam protection mechanism rejects a submission. All five were introduced in **6.2.1**.
+
+<explain-block title="fluentform/akismet_spam_message">
+
+Replace the message returned when Akismet flags a submission as spam.
+
+**Parameters**
+
+- `$message` (string) Default message returned to the submitter
+
+**Usage**
+
+```php
+add_filter('fluentform/akismet_spam_message', function ($message) {
+    return __('We could not process your submission. Please try again or contact us directly.', 'your-textdomain');
+}, 10, 1);
+```
+
+**Reference**
+
+`apply_filters('fluentform/akismet_spam_message', __('Submission marked as spammed. Please try again', 'fluentform'));`
+
+This filter is located in `FluentForm\App\Modules\Form\FormHandler`.
+
+</explain-block>
+
+<explain-block title="fluentform/cleantalk_check_spam">
+
+**Parameters**
+
+- `$value` — see source
+- `$form` — see source
+- `$formData` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/cleantalk_check_spam', function ($value, $form, $formData) {
+    return $value;
+}, 10, 3);
+```
+
+**Reference**
+
+`$isSpamCheck = apply_filters('fluentform/cleantalk_check_spam', true, $form->id, $formData);`
+
+This filter is located in `app/Services/Form/FormValidationService.php` (line 519).
+
+</explain-block>
+
+<explain-block title="fluentform/cleantalk_fields">
+
+**Parameters**
+
+- `$cleanTalkRequest` — see source
+- `$formData` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/cleantalk_fields', function ($cleanTalkRequest, $formData, $form) {
+    return $cleanTalkRequest;
+}, 10, 3);
+```
+
+**Reference**
+
+`$cleanTalkRequest = apply_filters('fluentform/cleantalk_fields', $cleanTalkRequest, $formData, $form);`
+
+This filter is located in `app/Modules/Form/CleanTalkHandler.php` (line 118).
+
+</explain-block>
+
+<explain-block title="fluentform/cleantalk_spam_result">
+
+**Parameters**
+
+- `$isSpam` — see source
+- `$form` — see source
+- `$formData` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/cleantalk_spam_result', function ($isSpam, $form, $formData) {
+    return $isSpam;
+}, 10, 3);
+```
+
+**Reference**
+
+`return apply_filters('fluentform/cleantalk_spam_result', $isSpam, $form->id, $formData);`
+
+This filter is located in `app/Services/Form/FormValidationService.php` (line 526).
+
+</explain-block>
+
+<explain-block title="fluentform/hcaptcha_failed_message">
+
+Replace the message returned when hCaptcha verification fails.
+
+**Parameters**
+
+- `$message` (string) Default hCaptcha failure message
+
+**Usage**
+
+```php
+add_filter('fluentform/hcaptcha_failed_message', function ($message) {
+    return __('Captcha check failed. Please retry.', 'your-textdomain');
+}, 10, 1);
+```
+
+**Reference**
+
+`apply_filters('fluentform/hcaptcha_failed_message', __('hCaptcha verification failed, please try again.', 'fluentform'));`
+
+This filter is located in `FluentForm\App\Modules\Form\FormHandler`.
+
+</explain-block>
+
+<explain-block title="fluentform/hcaptcha_lang">
+
+**Parameters**
+
+- `$value` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/hcaptcha_lang', function ($value) {
+    return $value;
+}, 10, 1);
+```
+
+**Reference**
+
+`$locale = apply_filters('fluentform/hcaptcha_lang', '');`
+
+This filter is located in `app/Services/FormBuilder/Components/Hcaptcha.php` (line 44).
+
+</explain-block>
+
+<explain-block title="fluentform/honeypot_spam_message">
+
+Replace the message returned when the honeypot trap rejects a submission.
+
+**Parameters**
+
+- `$message` (string) Default honeypot rejection message
+
+**Usage**
+
+```php
+add_filter('fluentform/honeypot_spam_message', function ($message) {
+    return __('Your submission could not be accepted. Please reload the page and try again.', 'your-textdomain');
+}, 10, 1);
+```
+
+**Reference**
+
+`apply_filters('fluentform/honeypot_spam_message', __('Sorry! You can not submit this form at this moment!', 'fluentform'));`
+
+This filter is located in `FluentForm\App\Modules\Form\HoneyPot`.
+
+</explain-block>
+
+<explain-block title="fluentform/recaptcha_failed_message">
+
+Replace the message returned when Google reCAPTCHA verification fails.
+
+**Parameters**
+
+- `$message` (string) Default reCAPTCHA failure message
+
+**Usage**
+
+```php
+add_filter('fluentform/recaptcha_failed_message', function ($message) {
+    return __('Please confirm you are not a robot and try again.', 'your-textdomain');
+}, 10, 1);
+```
+
+**Reference**
+
+`apply_filters('fluentform/recaptcha_failed_message', __('reCaptcha verification failed, please try again.', 'fluentform'));`
+
+This filter is located in `FluentForm\App\Modules\Form\FormHandler`.
+
+</explain-block>
+
+<explain-block title="fluentform/recaptcha_lang">
+
+**Parameters**
+
+- `$value` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/recaptcha_lang', function ($value) {
+    return $value;
+}, 10, 1);
+```
+
+**Reference**
+
+`$locale = apply_filters('fluentform/recaptcha_lang', '');`
+
+This filter is located in `app/Services/FormBuilder/Components/Recaptcha.php` (line 56).
+
+</explain-block>
+
+<explain-block title="fluentform/turnstile_failed_message">
+
+Replace the message returned when Cloudflare Turnstile verification fails.
+
+**Parameters**
+
+- `$message` (string) Default Turnstile failure message
+
+**Usage**
+
+```php
+add_filter('fluentform/turnstile_failed_message', function ($message) {
+    return __('Verification did not complete. Please refresh and try again.', 'your-textdomain');
+}, 10, 1);
+```
+
+**Reference**
+
+`apply_filters('fluentform/turnstile_failed_message', __('Turnstile verification failed, please try again.', 'fluentform'));`
+
+This filter is located in `FluentForm\App\Modules\Form\FormHandler`.
+
+</explain-block>
+
+<explain-block title="fluentform/turnstile_lang">
+
+**Parameters**
+
+- `$value` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/turnstile_lang', function ($value) {
+    return $value;
+}, 10, 1);
+```
+
+**Reference**
+
+`$locale = apply_filters('fluentform/turnstile_lang', '');`
+
+This filter is located in `app/Services/FormBuilder/Components/Turnstile.php` (line 49).
+
+</explain-block>

--- a/src/hooks/filters/submission.md
+++ b/src/hooks/filters/submission.md
@@ -4,90 +4,314 @@
 
 These filters let you modify submission data, responses, and entry display.
 
-<explain-block title="fluentform/insert_response_data">
+<explain-block title="fluentform/all_entries">
 
-**Description**
-
-You can modify or format the submitted data using this filter. The returned data will be inserted as submission response.
-
-**Parameters**
-
-- `$formData` (array) Form Data
-- `$formId` (int) Form ID
-- `$inputConfigs` (array) Form Inputs
-
-**Usage**
-
-```php
-add_filter('fluentform/insert_response_data', function ($formData, $formId, $inputConfigs) {
-   // Do your stuff here
-   
-   return $formData;
-},10, 3);
-```
-
-**Reference**
-
-`apply_filters('fluentform/insert_response_data', $formData, $formId, $inputConfigs);`
-
-This filter is located in FluentForm\App\Services\Form\SubmissionHandlerService -> prepareInsertData()
-
-</explain-block>
-
-<explain-block title="fluentform/find_submission">
-
-**Description**
-
-You can modify a submission by using this filter.
+You can modify all submissions using the filter.
 
 **Parameters**
 
 - `$submission` (array) Form Submission
-- `$formId` (int) Form ID
 
 **Usage**
 
 ```php
-add_filter('fluentform/find_submission', function ($submission, $formId) {
-   // Do your stuff here
-   
-   return $submission;
-}, 10, 2);
+add_filter('fluentform/all_entries', function ($submission) {
+    // Do your stuff here
+    
+    return $submission;
+}, 10, 1);
+
 ```
 
 **Reference**
 
-`apply_filters('fluentform/find_submission', $submission, $this->form->id);`
+`apply_filters('fluentform/all_entries', $entries['submissions']);`
 
-This filter is located in FluentForm\App\Services\Submission\SubmissionService -> find($submissionId)
+This filter is located in FluentFormPro\src\classes\StepFormEntries -> getEntries()
 
 </explain-block>
 
-<explain-block title="fluentform/truncate_password_values">
+<explain-block title="fluentform/all_entry_labels">
 
-You can toggle password truncation before rendering on Submission by using this filter.
+This filter returns the input labels for the Submission on the Submission page.
 
 **Parameters**
 
-- `$isTurncate` (boolean) Whether Password is truncated
+- `$labels` (array) Form Input Labels
 - `$formId` (int) Form ID
 
 **Usage**
 
 ```php
-add_filter('fluentform/truncate_password_values', function ($isTruncate, $formId) {
+add_filter('fluentform/all_entry_labels', function ($labels, $formId) {
+    // Do your stuff here
+    
+    return $labels;
+}, 10, 2);
+
+```
+**Reference**
+
+`apply_filters('fluentform/all_entry_labels', $labels, $formId);`
+
+This filter is located in FluentForm\App\Services\Form\FormService -> getInputsAndLabels($formId, $with = ['admin_label', 'raw'])
+
+</explain-block>
+
+<explain-block title="fluentform/all_entry_labels_with_payment">
+
+This filter returns the input labels for the payment submission on the submission page.
+
+**Parameters**
+
+- `$labels` (array) Form Input Labels
+- `$isActive` (boolean) Whether Payment is active
+- `$form` (object) Form Object
+
+**Usage**
+
+```php
+add_filter('fluentform/all_entry_labels_with_payment', function ($labels, $isActive, $form) {
+    // Do your stuff here
+    
+    return $labels;
+}, 10, 3);
+
+```
+**Reference**
+
+`apply_filters('fluentform/all_entry_labels_with_payment',  $labels, false, $form);`
+
+This filter is located in FluentForm\App\Services\Form\FormService -> getInputsAndLabels($formId, $with = ['admin_label', 'raw'])
+
+</explain-block>
+
+<explain-block title="fluentform/all_logs">
+
+You can modify all logs by using this filter.
+
+**Parameters**
+
+- `$logs` (array) Logs
+
+**Usage**
+
+```php
+add_filter('fluentform/all_logs', function($logs) {
    // Do your stuff here
-   
-   return $isTruncate;
+
+   return $logs;
+}, 10, 1);
+
+```
+**Reference**
+
+`apply_filters('fluentform/get_logs', $logs);`
+
+This filter is located in FluentForm\App\Services\Logger\Logger -> get($attributes = [])
+
+</explain-block>
+
+<explain-block title="fluentform/api_all_logs">
+
+You can modify all API logs / integration logs using this filter.
+
+**Parameters**
+
+- `$logs` (array) Logs
+
+**Usage**
+
+```php
+add_filter('fluentform/api_all_logs', function($logs) {
+   // Do your stuff here
+
+   return $logs;
+}, 10, 1);
+
+```
+**Reference**
+
+`apply_filters('fluentform/api_all_logs', $logs);`
+
+This filter is located in FluentForm\App\Modules\Logger\DataLogger -> getApiLogs()
+
+</explain-block>
+
+<explain-block title="fluentform/auto_read_submission">
+
+You can use this filter to toggle submission status to read automatically.
+
+**Parameters**
+
+- `$autoRead` (boolean) Whether change submission status to read
+- `$form` (object) Form Object
+
+**Usage**
+
+```php
+add_filter('fluentform/auto_read_submission', function ($autoRead, $form) {
+    // Do your stuff here
+    
+    return $autoRead;
 }, 10, 2);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/truncate_password_values', true, $formId)`
+`apply_filters('fluentform/auto_read_submission', $autoRead, $form);`
 
-This filter is located in FluentForm\App\Helpers\Helper -> shouldHidePassword($formId)
+This filter is located in Fluentform\app\Services\Submission\SubmissionService -> find($submissionId)
+
+</explain-block>
+
+<explain-block title="fluentform/disable_ip_logging">
+
+You can toggle the IP logging of form submission using the the filter.
+
+**Parameters**
+
+- `$status` Check whether IP based logging is enabled
+- `$formId` (int) Form ID
+
+**Usage**
+
+```php
+add_filter('fluentform/disable_ip_logging', function($status, $formId) {
+   // Do your stuff here
+
+   return $status;
+}, 10, 1);
+
+```
+**Reference**
+
+`apply_filters('fluentform/disable_ip_logging', $disableIpLog, $formId);`
+
+This filter is located in FluentForm\App\Services\Form\SubmissionHandlerService -> prepareInsertData($formData = false)
+
+</explain-block>
+
+<explain-block title="fluentform/disable_submission_country_detection">
+
+**Parameters**
+
+- `$value` — see source
+- `$formId` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/disable_submission_country_detection', function ($value, $formId) {
+    return $value;
+}, 10, 2);
+```
+
+**Reference**
+
+`'country'       => apply_filters('fluentform/disable_submission_country_detection', false, $formId) ? null : Helper::getCountryCodeFromHeaders(),`
+
+This filter is located in `app/Services/Form/SubmissionHandlerService.php` (line 183).
+
+</explain-block>
+
+<explain-block title="fluentform/entries_default_sort_column">
+
+<Badge type="warning" vertical="top" text="Added in 6.2.3" />
+
+Change the column the entries table sorts by when no explicit sort is requested. Before 6.2.3 the table sorted by `id`; the default is now `created_at` (actual submission date) so re-imported entries appear in the right place. Use this filter to opt back into `id`-based ordering or to point at any other indexed column.
+
+**Parameters**
+
+- `$column` (string) Default `'created_at'`
+
+**Usage**
+
+```php
+add_filter('fluentform/entries_default_sort_column', function ($column) {
+    return 'id';
+}, 10, 1);
+```
+
+**Reference**
+
+`apply_filters('fluentform/entries_default_sort_column', 'created_at');`
+
+This filter is located in `FluentForm\App\Models\Submission`.
+
+</explain-block>
+
+<explain-block title="fluentform/entries_vars">
+
+You can use this filter to modify entries variables which has been localized.
+
+**Parameters**
+
+- `$data` (array) Entry Variables
+- `$form` (object) Form Object
+
+**Usage**
+
+```php
+add_filter('fluentform/entries_vars', function ($data, $form) {
+    // Do your stuff here
+    
+    return $status;
+}, 10, 1);
+
+```
+```php
+$data = [
+    'all_forms_url'       => admin_url('admin.php?page=fluent_forms'),
+    'forms'               => $forms,
+    'form_id'             => $form->id,
+    'enabled_auto_delete' => Helper::isEntryAutoDeleteEnabled($form_id),
+    'current_form_title'  => $form->title,
+    'entry_statuses'      => Helper::getEntryStatuses($form_id),
+    'entries_url_base'    => admin_url('admin.php?page=fluent_forms&route=entries&form_id='),
+    'no_found_text'       => __('Sorry! No entries found. All your entries will be shown here once you start getting form submissions', 'fluentform'),
+    'has_pro'             => defined('FLUENTFORMPRO'),
+    'printStyles'         => [fluentformMix('css/settings_global.css')],
+    'email_notifications' => $formattedNotification,
+    'available_countries' => getFluentFormCountryList(),
+    'upgrade_url'      => fluentform_upgrade_url(),
+    'form_entries_str' => TranslationString::getEntriesI18n(),
+];
+```
+
+**Reference**
+
+`apply_filters('fluentform/entries_vars', $data, $form);`
+
+This filter is located in FluentForm\app\Modules\Entries\Entries -> renderEntries($form_id)
+
+</explain-block>
+
+<explain-block title="fluentform/entry_lists_labels">
+
+This filter returns the input labels for the Submission on the Submission page.
+
+**Parameters**
+
+- `$labels` (array) Form Input Labels
+- `$form` (object) Form Object
+
+**Usage**
+
+```php
+add_filter('fluentform/entry_lists_labels', function ($labels, $form) {
+    // Do your stuff here
+    
+    return $labels;
+}, 10, 2);
+
+```
+**Reference**
+
+`apply_filters('fluentform/entry_lists_labels', $labels, $form);`
+
+This filter is located in FluentForm\App\Services\Form\FormService -> getInputsAndLabels($formId, $with = ['admin_label', 'raw'])
 
 </explain-block>
 
@@ -123,113 +347,187 @@ This filter is located in FluentForm\App\Helpers\Helper -> getEntryStatuses($for
 
 </explain-block>
 
-<explain-block title="fluentform/reportable_inputs">
+<explain-block title="fluentform/export_data">
 
-You can modify or add more inputs for making Submission Report by using this filter.
+You can use this filter to modify the exported submission.
 
 **Parameters**
 
-- `$reportableInputs` (array) Reportable Inputs
+- `$data` (array) Default Values
+- `$form` (object) Form Object
+- `$exportData` (array) Export Data
+- `$inputLabels` (array) Input Labels
 
 **Usage**
 
 ```php
-add_filter('fluentform/reportable_inputs', function($reportableInputs) {
+add_filter('fluentform/export_data', function($data, $form, $exportData, $inputLabels) {
    // Do your stuff here
 
-  return $reportableInputs;
-}, 10, 1);
+   return $data;
+}, 10, 4);
 
 ```
-
-
 **Reference**
 
-`apply_filters('fluentform/reportable_inputs', $reportableInputs);`
+`apply_filters('fluentform/export_data', $data, $form, $exportData, $inputLabels);`
 
-This filter is located in FluentForm\App\Helpers\Helper -> getReportableInputs()
+This filter is located in FluentForm\App\Services\Transfer\TransferService -> exportEntries($args)
 
 </explain-block>
 
-<explain-block title="fluentform/subfield_reportable_inputs">
+<explain-block title="fluentform/filter_insert_data">
 
-You can modify or add more inputs as subfield for making Submission Report by using this filter.
+This filter is available just before a submission inserted into the database. But If you want to change response data then you should use fluentform_insert_response_data filter hook.
 
 **Parameters**
 
-- `$subFieldReportableInputs` (array) Reportable Inputs as Subfield
+- `$response` (array) Submission Data
+```php
+$response = [
+    'form_id'       => 5, // Form ID
+    'serial_number' => 1, // Numeric Serial Number
+    'response'      => json_encode($response), // The submitted response as JSON
+    'source_url'    => $source_url, // source url eg: https://domain.com/contact-form
+    'user_id'       => 1, // current user id
+    'browser'       => 'Chrome',
+    'device'        => 'ipad',
+    'ip'            => '127.0.0.1',
+    'created_at'    => '2019-12-31 23:12:34',
+    'updated_at'    => '2019-12-31 23:12:34'
+];
+```
 
 **Usage**
 
 ```php
-add_filter('fluentform/subfield_reportable_inputs', function ($subFieldReportableInputs) {
-    // Do your stuff here
+add_filter('fluentform/filter_insert_data', function($response) {
+   // Do your stuff here
 
-    return $subFieldReportableInputs;
+   return $response;
 }, 10, 1);
 
 ```
-
 **Reference**
 
-`apply_filters('fluentform/subfield_reportable_inputs', ['tabular_grid']);`
+`apply_filters('fluentform/filter_insert_data', $response);`
 
-This filter is located in FluentForm\App\Helpers\Helper -> getSubFieldReportableInputs()
+This filter is located in FluentForm\App\Services\Form\SubmissionHandlerService -> prepareInsertData($formData = false)
 
 </explain-block>
 
-<explain-block title="fluentform/next_submission">
+<explain-block title="fluentform/find_submission">
 
-You can modify next or previous submission using this filter.
+**Description**
+
+You can modify a submission by using this filter.
 
 **Parameters**
 
-- `$submission` (array) Current Submission
-- `$entryId` (string) Form Submission ID
-- `$attributes` (array) Submission attributes
+- `$submission` (array) Form Submission
+- `$formId` (int) Form ID
 
 **Usage**
 
 ```php
-add_filter('fluentform/next_submission', function ($submission, $entryId, $attributes) {
+add_filter('fluentform/find_submission', function ($submission, $formId) {
    // Do your stuff here
-
+   
    return $submission;
+}, 10, 2);
+```
+
+**Reference**
+
+`apply_filters('fluentform/find_submission', $submission, $this->form->id);`
+
+This filter is located in FluentForm\App\Services\Submission\SubmissionService -> find($submissionId)
+
+</explain-block>
+
+<explain-block title="fluentform/format_{$element}_response_as_html">
+
+This filter allows you to determine whether a specific form element's response should be formatted as HTML. The `{$element}` in the filter name is dynamically replaced with the actual element type (supported elements: `select`, `input_checkbox`, `input_radio`, `address`, `select_country`, `gdpr_agreement`, `terms_and_condition`, `dynamic_field` and `multi_payment_component`).
+
+**Parameters**
+
+- `$isHtml` (boolean) Whether to format the response as HTML
+- `$response` (mixed) The form field response value
+- `$field` (array) The form field configuration
+
+**Usage**
+
+```php
+// Example for select element
+add_filter('fluentform/format_select_response_as_html', function($isHtml, $response, $field) {
+    // Always format select fields as HTML
+    return true;
 }, 10, 3);
 
+// Example for checkbox element
+add_filter('fluentform/format_input_checkbox_response_as_html', function($isHtml, $response, $field) {
+    // Custom logic to determine HTML formatting
+    return $isHtml;
+}, 10, 3);
 ```
+
 **Reference**
 
-`apply_filters('fluentform/next_submission', $submission, $entryId, $attributes);`
+`apply_filters("fluentform/format_{$element}_response_as_html", $isHtml, $response, $field);`
 
-This filter is located in FluentForm\App\Models\Form -> findAdjacentSubmission($attributes = []) and FluentForm\App\Models\Form -> findPreviousSubmission($attributes = []) and
+This filter is located in `FluentForm\app\Hooks\filters.php` within the response rendering filter for various elements.
 
 </explain-block>
 
-<explain-block title="fluentform/step_string">
+<explain-block title="fluentform/get_log_filters">
 
-This filter returns the input labels for the Submission on the submission page.
+You can use this filter to modify all the log filters.
 
 **Parameters**
 
-- `$stepText` (string) Active Step Text
+- `$filters` (array) All Log Filters
 
 **Usage**
 
 ```php
-add_filter('fluentform/step_string', function ($stepText) {
-   // Do your stuff here
-
-   return $stepText;
+add_filter('fluentform/get_log_filters', function ($filters) {
+    // Do your stuff here
+    
+    return $filters;
 }, 10, 1);
 
 ```
-
 **Reference**
 
-`apply_filters('fluentform/step_string', $stepText);`
+`apply_filters('fluentform/get_log_filters', ['statuses' => $statuses, 'components' => $components, 'forms' => $forms]);`
 
-This filter is located in FluentForm\App\Modules\Component\Component -> getEditorShortcodes()
+This filter is located in FluentForm\App\Services\Logger\Logger -> getFilters($attributes = [])
+
+</explain-block>
+
+<explain-block title="fluentform/get_logs">
+
+You can use this filter to get all the logs.
+
+**Parameters**
+
+- `$logs` (array) All Logs
+
+**Usage**
+
+```php
+add_filter('fluentform/get_logs', function ($logs) {
+    // Do your stuff here
+    
+    return $logs;
+}, 10, 1);
+
+```
+**Reference**
+
+`apply_filters('fluentform/get_logs', $logs);`
+
+This filter is located in FluentForm\App\Services\Logger\Logger -> get($attributes = [])
 
 </explain-block>
 
@@ -260,32 +558,25 @@ This filter is located in FluentForm\App\Models\Submission -> paginateEntries($a
 
 </explain-block>
 
-<explain-block title="fluentform/export_data">
-
-You can use this filter to modify the exported submission.
+<explain-block title="fluentform/get_submissions">
 
 **Parameters**
 
-- `$data` (array) Default Values
-- `$form` (object) Form Object
-- `$exportData` (array) Export Data
-- `$inputLabels` (array) Input Labels
+- `$entries` — see source
 
 **Usage**
 
 ```php
-add_filter('fluentform/export_data', function($data, $form, $exportData, $inputLabels) {
-   // Do your stuff here
-
-   return $data;
-}, 10, 4);
-
+add_filter('fluentform/get_submissions', function ($entries) {
+    return $entries;
+}, 10, 1);
 ```
+
 **Reference**
 
-`apply_filters('fluentform/export_data', $data, $form, $exportData, $inputLabels);`
+`return apply_filters('fluentform/get_submissions', $entries);`
 
-This filter is located in FluentForm\App\Services\Transfer\TransferService -> exportEntries($args)
+This filter is located in `app/Services/Submission/SubmissionService.php` (line 50).
 
 </explain-block>
 
@@ -330,70 +621,29 @@ This filter is located in FluentForm\App\Services\Form\SubmissionHandlerService 
 
 </explain-block>
 
-<explain-block title="fluentform/disable_ip_logging">
+<explain-block title="fluentform/is_handling_submission">
 
-You can toggle the IP logging of form submission using the the filter.
+You can use this filter to handle async submission request.
 
 **Parameters**
 
-- `$status` Check whether IP based logging is enabled
-- `$formId` (int) Form ID
+- `$status` (boolean) Whether handle submission is enabled
 
 **Usage**
 
 ```php
-add_filter('fluentform/disable_ip_logging', function($status, $formId) {
-   // Do your stuff here
-
-   return $status;
+add_filter('fluentform/is_handling_submission', function ($status) {
+    // Do your stuff here
+    
+    return $status;
 }, 10, 1);
 
 ```
 **Reference**
 
-`apply_filters('fluentform/disable_ip_logging', $disableIpLog, $formId);`
+`apply_filters('fluentform/is_handling_submission', $status);`
 
-This filter is located in FluentForm\App\Services\Form\SubmissionHandlerService -> prepareInsertData($formData = false)
-
-</explain-block>
-
-<explain-block title="fluentform/filter_insert_data">
-
-This filter is available just before a submission inserted into the database. But If you want to change response data then you should use fluentform_insert_response_data filter hook.
-
-**Parameters**
-
-- `$response` (array) Submission Data
-```php
-$response = [
-    'form_id'       => 5, // Form ID
-    'serial_number' => 1, // Numeric Serial Number
-    'response'      => json_encode($response), // The submitted response as JSON
-    'source_url'    => $source_url, // source url eg: https://domain.com/contact-form
-    'user_id'       => 1, // current user id
-    'browser'       => 'Chrome',
-    'device'        => 'ipad',
-    'ip'            => '127.0.0.1',
-    'created_at'    => '2019-12-31 23:12:34',
-    'updated_at'    => '2019-12-31 23:12:34'
-];
-```
-
-**Usage**
-
-```php
-add_filter('fluentform/filter_insert_data', function($response) {
-   // Do your stuff here
-
-   return $response;
-}, 10, 1);
-
-```
-**Reference**
-
-`apply_filters('fluentform/filter_insert_data', $response);`
-
-This filter is located in FluentForm\App\Services\Form\SubmissionHandlerService -> prepareInsertData($formData = false)
+This filter is located in FluentForm\boot\globals.php -> fluentFormIsHandlingSubmission()
 
 </explain-block>
 
@@ -461,188 +711,58 @@ This filter is located in FluentForm\App\Services\Form\FormValidationService -> 
 
 </explain-block>
 
-<explain-block title="fluentform/too_many_requests">
+<explain-block title="fluentform/next_submission">
 
-You can modify validation message for malicious attack prevention, maximum submission count and minimum submission interval using this filter.
+You can modify next or previous submission using this filter.
 
 **Parameters**
 
-- `$message` (string) Validation Message
-- `$formId` (int) Form ID
+- `$submission` (array) Current Submission
+- `$entryId` (string) Form Submission ID
+- `$attributes` (array) Submission attributes
 
 **Usage**
 
 ```php
-add_filter('fluentform/too_many_requests', function($message, $formId) {
+add_filter('fluentform/next_submission', function ($submission, $entryId, $attributes) {
    // Do your stuff here
 
-   return $message;
-}, 10, 2);
+   return $submission;
+}, 10, 3);
 
 ```
 **Reference**
 
-`apply_filters('fluentform/too_many_requests', 'Too Many Requests.', $this->form->id), 'fluentform');`
+`apply_filters('fluentform/next_submission', $submission, $entryId, $attributes);`
 
-This filter is located in FluentForm\App\Services\Form\FormValidationService -> preventMaliciousAttacks()
+This filter is located in FluentForm\App\Models\Form -> findAdjacentSubmission($attributes = []) and FluentForm\App\Models\Form -> findPreviousSubmission($attributes = []) and
 
 </explain-block>
 
-<explain-block title="fluentform/supported_conditional_fields">
+<explain-block title="fluentform/reportable_inputs">
 
-You can add or modify form fields as to support as conditional using this filter.
+You can modify or add more inputs for making Submission Report by using this filter.
 
 **Parameters**
 
-- `$supportedConditionalFields` (array) Form Field Names
+- `$reportableInputs` (array) Reportable Inputs
 
 **Usage**
 
 ```php
-add_filter('fluentform/supported_conditional_fields', function ($supportedConditionalFields) {
+add_filter('fluentform/reportable_inputs', function($reportableInputs) {
    // Do your stuff here
 
-   return $supportedConditionalFields;
+  return $reportableInputs;
 }, 10, 1);
 
 ```
+
 **Reference**
 
-`apply_filters('fluentform/supported_conditional_fields', $supportedConditionalFields);`
+`apply_filters('fluentform/reportable_inputs', $reportableInputs);`
 
-This filter is located in FluentForm\App\Modules\Form\Inputs -> supportedConditionalFields()
-
-</explain-block>
-
-<explain-block title="fluentform/submission_logs">
-
-You can modify submission logs of a submission using this Filter.
-
-**Parameters**
-
-- `$submissionLogs` (array) Submission Logs
-- `$submissionId` (int) Submission ID
-
-**Usage**
-
-```php
-add_filter('fluentform/submission_logs', function($submissionLogs, $submissionId) {
-   // Do your stuff here
-
-   return $submissionLogs;
-}, 10, 2);
-
-```
-**Reference**
-
-`apply_filters('fluentform/submission_logs', $logs, $submissionId);`
-
-This filter is located in FluentForm\App\Services\Logger\Logger -> getSubmissionLogs($submissionId, $attributes = [])
-
-</explain-block>
-
-<explain-block title="fluentform/submission_api_logs">
-
-You can modify submission API logs or integration logs of a submission using this Filter.
-
-**Parameters**
-
-- `$submissionLogs` (array) Submission Logs
-- `$submissionId` (int) Submission ID
-
-**Usage**
-
-```php
-add_filter('fluentform/submission_api_logs', function($submissionLogs, $submissionId) {
-   // Do your stuff here
-
-   return $submissionLogs;
-}, 10, 2);
-
-```
-**Reference**
-
-`apply_filters('fluentform/submission_api_logs', $logs, $submissionId);`
-
-This filter is located in FluentForm\App\Services\Logger\Logger -> getSubmissionLogs($submissionId, $attributes = [])
-
-</explain-block>
-
-<explain-block title="fluentform/all_logs">
-
-You can modify all logs by using this filter.
-
-**Parameters**
-
-- `$logs` (array) Logs
-
-**Usage**
-
-```php
-add_filter('fluentform/all_logs', function($logs) {
-   // Do your stuff here
-
-   return $logs;
-}, 10, 1);
-
-```
-**Reference**
-
-`apply_filters('fluentform/get_logs', $logs);`
-
-This filter is located in FluentForm\App\Services\Logger\Logger -> get($attributes = [])
-
-</explain-block>
-
-<explain-block title="fluentform/api_all_logs">
-
-You can modify all API logs / integration logs using this filter.
-
-**Parameters**
-
-- `$logs` (array) Logs
-
-**Usage**
-
-```php
-add_filter('fluentform/api_all_logs', function($logs) {
-   // Do your stuff here
-
-   return $logs;
-}, 10, 1);
-
-```
-**Reference**
-
-`apply_filters('fluentform/api_all_logs', $logs);`
-
-This filter is located in FluentForm\App\Modules\Logger\DataLogger -> getApiLogs()
-
-</explain-block>
-
-<explain-block title="fluentform/get_log_filters">
-
-You can use this filter to modify all the log filters.
-
-**Parameters**
-
-- `$filters` (array) All Log Filters
-
-**Usage**
-
-```php
-add_filter('fluentform/get_log_filters', function ($filters) {
-    // Do your stuff here
-    
-    return $filters;
-}, 10, 1);
-
-```
-**Reference**
-
-`apply_filters('fluentform/get_log_filters', ['statuses' => $statuses, 'components' => $components, 'forms' => $forms]);`
-
-This filter is located in FluentForm\App\Services\Logger\Logger -> getFilters($attributes = [])
+This filter is located in FluentForm\App\Helpers\Helper -> getReportableInputs()
 
 </explain-block>
 
@@ -669,349 +789,6 @@ add_filter('fluentform/show_payment_entries', function($status) {
 `apply_filters('fluentform/show_payment_entries', false);`
 
 This filter is located in FluentForm\App\Modules\Registerer\Menu -> register()
-
-</explain-block>
-
-<explain-block title="fluentform/entry_lists_labels">
-
-This filter returns the input labels for the Submission on the Submission page.
-
-**Parameters**
-
-- `$labels` (array) Form Input Labels
-- `$form` (object) Form Object
-
-**Usage**
-
-```php
-add_filter('fluentform/entry_lists_labels', function ($labels, $form) {
-    // Do your stuff here
-    
-    return $labels;
-}, 10, 2);
-
-```
-**Reference**
-
-`apply_filters('fluentform/entry_lists_labels', $labels, $form);`
-
-This filter is located in FluentForm\App\Services\Form\FormService -> getInputsAndLabels($formId, $with = ['admin_label', 'raw'])
-
-</explain-block>
-
-<explain-block title="fluentform/all_entry_labels">
-
-This filter returns the input labels for the Submission on the Submission page.
-
-**Parameters**
-
-- `$labels` (array) Form Input Labels
-- `$formId` (int) Form ID
-
-**Usage**
-
-```php
-add_filter('fluentform/all_entry_labels', function ($labels, $formId) {
-    // Do your stuff here
-    
-    return $labels;
-}, 10, 2);
-
-```
-**Reference**
-
-`apply_filters('fluentform/all_entry_labels', $labels, $formId);`
-
-This filter is located in FluentForm\App\Services\Form\FormService -> getInputsAndLabels($formId, $with = ['admin_label', 'raw'])
-
-</explain-block>
-
-<explain-block title="fluentform/all_entry_labels_with_payment">
-
-This filter returns the input labels for the payment submission on the submission page.
-
-**Parameters**
-
-- `$labels` (array) Form Input Labels
-- `$isActive` (boolean) Whether Payment is active
-- `$form` (object) Form Object
-
-**Usage**
-
-```php
-add_filter('fluentform/all_entry_labels_with_payment', function ($labels, $isActive, $form) {
-    // Do your stuff here
-    
-    return $labels;
-}, 10, 3);
-
-```
-**Reference**
-
-`apply_filters('fluentform/all_entry_labels_with_payment',  $labels, false, $form);`
-
-This filter is located in FluentForm\App\Services\Form\FormService -> getInputsAndLabels($formId, $with = ['admin_label', 'raw'])
-
-</explain-block>
-
-<explain-block title="fluentform/get_logs">
-
-You can use this filter to get all the logs.
-
-**Parameters**
-
-- `$logs` (array) All Logs
-
-**Usage**
-
-```php
-add_filter('fluentform/get_logs', function ($logs) {
-    // Do your stuff here
-    
-    return $logs;
-}, 10, 1);
-
-```
-**Reference**
-
-`apply_filters('fluentform/get_logs', $logs);`
-
-This filter is located in FluentForm\App\Services\Logger\Logger -> get($attributes = [])
-
-</explain-block>
-
-<explain-block title="fluentform/get_log_filters">
-
-You can use this filter to modify all the log filters.
-
-**Parameters**
-
-- `$filters` (array) All Log Filters
-
-**Usage**
-
-```php
-add_filter('fluentform/get_log_filters', function ($filters) {
-    // Do your stuff here
-    
-    return $filters;
-}, 10, 1);
-
-```
-**Reference**
-
-`apply_filters('fluentform/get_log_filters', ['statuses' => $statuses, 'components' => $components, 'forms' => $forms]);`
-
-This filter is located in FluentForm\App\Services\Logger\Logger -> getFilters($attributes = [])
-
-</explain-block>
-
-<explain-block title="fluentform/is_handling_submission">
-
-You can use this filter to handle async submission request.
-
-**Parameters**
-
-- `$status` (boolean) Whether handle submission is enabled
-
-**Usage**
-
-```php
-add_filter('fluentform/is_handling_submission', function ($status) {
-    // Do your stuff here
-    
-    return $status;
-}, 10, 1);
-
-```
-**Reference**
-
-`apply_filters('fluentform/is_handling_submission', $status);`
-
-This filter is located in FluentForm\boot\globals.php -> fluentFormIsHandlingSubmission()
-
-</explain-block>
-
-<explain-block title="fluentform/entries_vars">
-
-You can use this filter to modify entries variables which has been localized.
-
-**Parameters**
-
-- `$data` (array) Entry Variables
-- `$form` (object) Form Object
-
-**Usage**
-
-```php
-add_filter('fluentform/entries_vars', function ($data, $form) {
-    // Do your stuff here
-    
-    return $status;
-}, 10, 1);
-
-```
-```php
-$data = [
-    'all_forms_url'       => admin_url('admin.php?page=fluent_forms'),
-    'forms'               => $forms,
-    'form_id'             => $form->id,
-    'enabled_auto_delete' => Helper::isEntryAutoDeleteEnabled($form_id),
-    'current_form_title'  => $form->title,
-    'entry_statuses'      => Helper::getEntryStatuses($form_id),
-    'entries_url_base'    => admin_url('admin.php?page=fluent_forms&route=entries&form_id='),
-    'no_found_text'       => __('Sorry! No entries found. All your entries will be shown here once you start getting form submissions', 'fluentform'),
-    'has_pro'             => defined('FLUENTFORMPRO'),
-    'printStyles'         => [fluentformMix('css/settings_global.css')],
-    'email_notifications' => $formattedNotification,
-    'available_countries' => getFluentFormCountryList(),
-    'upgrade_url'      => fluentform_upgrade_url(),
-    'form_entries_str' => TranslationString::getEntriesI18n(),
-];
-```
-
-**Reference**
-
-`apply_filters('fluentform/entries_vars', $data, $form);`
-
-This filter is located in FluentForm\app\Modules\Entries\Entries -> renderEntries($form_id)
-
-</explain-block>
-
-<explain-block title="fluentform/submission_labels">
-
-You can use this filter to modify Submission labels.
-
-**Parameters**
-
-- `$labels` (array) Label Names
-- `$submission` (array) Current Form Submission
-- `$form` (object) Form Object
-
-**Usage**
-
-```php
-add_filter('fluentform/submission_labels', function ($labels, $submission, $form) {
-    // Do your stuff here
-    
-    return $labels;
-}, 10, 3);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/submission_labels', $resources['labels'], $submission, $submission->form);`
-
-This filter is located in FluentForm\app\Services\Form\FormServices -> getDisabledComponents()
-
-</explain-block>
-
-<explain-block title="fluentform/submission_vars">
-
-You can modify submission variables on double optin confirmation by using this filter.
-
-**Parameters**
-
-- `$submissionVars` (array) Submission Variable
-- `$formId` (int) Form ID
-
-**Usage**
-
-```php
-add_filter('fluentform/submission_vars', function ($submissionVars, $formId) {
-    // Do your stuff here
-    
-    return $submissionVars;
-}, 10, 2);
-
-```
-```php
-$submissionVars = [
-    'settings'        => $settings,
-    'title'           => 'Submission Confirmed - ' . $form->title,
-    'form_id'         => $formId,
-    'entry'           => $entry,
-    'form'            => $form,
-    'bg_color'        => $settings['custom_color'],
-    'landing_content' => $message,
-    'has_header'      => false,
-    'isEmbeded'       => !!ArrayHelper::get($_GET, 'embedded')
-];
-```
-
-**Reference**
-
-`apply_filters('fluentform/submission_vars', $submissionVars, $formId);`
-
-This filter is located in FluentFormPro\src\classes\DoubleOption -> confirmSubmission($data)
-
-</explain-block>
-
-<explain-block title="fluentform/step_form_entry_vars">
-
-You can modify step form submission variables by using this filter.
-
-**Parameters**
-
-- `$entryVars` (array) Step Form Submission Variables
-- `$form` (object) Form Object
-
-**Usage**
-
-```php
-add_filter('fluentform/step_form_entry_vars', function ($entryVars, $form) {
-    // Do your stuff here
-    
-    return $entryVars;
-}, 10, 2);
-
-```
-```php
-$entryVars = [
-    'form_id' => $form->id,
-    'current_form_title' => $form->title,
-    'has_pro' => defined('FLUENTFORMPRO'),
-    'all_forms_url' => admin_url('admin.php?page=fluent_forms'),
-    'printStyles' => [fluentformMix('css/settings_global.css')],
-    'entries_url_base' => admin_url('admin.php?page=fluent_forms&route=msformentries&form_id='),
-    'available_countries' => getFluentFormCountryList(),
-    'no_found_text' => __('Sorry! No entries found. All your entries will be shown here once you start getting form submissions', 'fluentformpro')
-];
-```
-
-**Reference**
-
-`apply_filters('fluentform/step_form_entry_vars', $entryVars, $form);`
-
-This filter is located in FluentFormPro\src\classes\StepFormEntries -> renderEntries($form_id)
-
-</explain-block>
-
-<explain-block title="fluentform/all_entries">
-
-You can modify all submissions using the filter.
-
-**Parameters**
-
-- `$submission` (array) Form Submission
-
-**Usage**
-
-```php
-add_filter('fluentform/all_entries', function ($submission) {
-    // Do your stuff here
-    
-    return $submission;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/all_entries', $entries['submissions']);`
-
-This filter is located in FluentFormPro\src\classes\StepFormEntries -> getEntries()
 
 </explain-block>
 
@@ -1099,6 +876,150 @@ This filter is located in FluentFormPro\src\classes\StepFormEntries -> getstepFo
 
 </explain-block>
 
+<explain-block title="fluentform/step_form_entry_vars">
+
+You can modify step form submission variables by using this filter.
+
+**Parameters**
+
+- `$entryVars` (array) Step Form Submission Variables
+- `$form` (object) Form Object
+
+**Usage**
+
+```php
+add_filter('fluentform/step_form_entry_vars', function ($entryVars, $form) {
+    // Do your stuff here
+    
+    return $entryVars;
+}, 10, 2);
+
+```
+```php
+$entryVars = [
+    'form_id' => $form->id,
+    'current_form_title' => $form->title,
+    'has_pro' => defined('FLUENTFORMPRO'),
+    'all_forms_url' => admin_url('admin.php?page=fluent_forms'),
+    'printStyles' => [fluentformMix('css/settings_global.css')],
+    'entries_url_base' => admin_url('admin.php?page=fluent_forms&route=msformentries&form_id='),
+    'available_countries' => getFluentFormCountryList(),
+    'no_found_text' => __('Sorry! No entries found. All your entries will be shown here once you start getting form submissions', 'fluentformpro')
+];
+```
+
+**Reference**
+
+`apply_filters('fluentform/step_form_entry_vars', $entryVars, $form);`
+
+This filter is located in FluentFormPro\src\classes\StepFormEntries -> renderEntries($form_id)
+
+</explain-block>
+
+<explain-block title="fluentform/step_string">
+
+This filter returns the input labels for the Submission on the submission page.
+
+**Parameters**
+
+- `$stepText` (string) Active Step Text
+
+**Usage**
+
+```php
+add_filter('fluentform/step_string', function ($stepText) {
+   // Do your stuff here
+
+   return $stepText;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/step_string', $stepText);`
+
+This filter is located in FluentForm\App\Modules\Component\Component -> getEditorShortcodes()
+
+</explain-block>
+
+<explain-block title="fluentform/subfield_reportable_inputs">
+
+You can modify or add more inputs as subfield for making Submission Report by using this filter.
+
+**Parameters**
+
+- `$subFieldReportableInputs` (array) Reportable Inputs as Subfield
+
+**Usage**
+
+```php
+add_filter('fluentform/subfield_reportable_inputs', function ($subFieldReportableInputs) {
+    // Do your stuff here
+
+    return $subFieldReportableInputs;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/subfield_reportable_inputs', ['tabular_grid']);`
+
+This filter is located in FluentForm\App\Helpers\Helper -> getSubFieldReportableInputs()
+
+</explain-block>
+
+<explain-block title="fluentform/submission_api_logs">
+
+You can modify submission API logs or integration logs of a submission using this Filter.
+
+**Parameters**
+
+- `$submissionLogs` (array) Submission Logs
+- `$submissionId` (int) Submission ID
+
+**Usage**
+
+```php
+add_filter('fluentform/submission_api_logs', function($submissionLogs, $submissionId) {
+   // Do your stuff here
+
+   return $submissionLogs;
+}, 10, 2);
+
+```
+**Reference**
+
+`apply_filters('fluentform/submission_api_logs', $logs, $submissionId);`
+
+This filter is located in FluentForm\App\Services\Logger\Logger -> getSubmissionLogs($submissionId, $attributes = [])
+
+</explain-block>
+
+<explain-block title="fluentform/submission_before_parse">
+
+**Parameters**
+
+- `$submission` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/submission_before_parse', function ($submission, $form) {
+    return $submission;
+}, 10, 2);
+```
+
+**Reference**
+
+`$submission = apply_filters('fluentform/submission_before_parse', $submission, $form);`
+
+This filter is located in `app/Services/Submission/SubmissionService.php` (line 86).
+
+</explain-block>
+
 <explain-block title="fluentform/submission_cards">
 
 You can use this filter to modify submission page cards.
@@ -1125,6 +1046,86 @@ add_filter('fluentform/submission_cards', function ($cards, $resources, $submiss
 `apply_filters('fluentform/submission_cards', $cards, $resources, $submission);`
 
 This filter is located in Fluentform\app\services\Submission\SubmissionService -> resources($attributes)
+
+</explain-block>
+
+<explain-block title="fluentform/submission_form_data">
+
+**Parameters**
+
+- `$formData` — see source
+- `$insertId` — see source
+- `$form` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/submission_form_data', function ($formData, $insertId, $form) {
+    return $formData;
+}, 10, 3);
+```
+
+**Reference**
+
+`$formData = apply_filters('fluentform/submission_form_data', $formData, $insertId, $form);`
+
+This filter is located in `app/Services/Form/SubmissionHandlerService.php` (line 221).
+
+</explain-block>
+
+<explain-block title="fluentform/submission_labels">
+
+You can use this filter to modify Submission labels.
+
+**Parameters**
+
+- `$labels` (array) Label Names
+- `$submission` (array) Current Form Submission
+- `$form` (object) Form Object
+
+**Usage**
+
+```php
+add_filter('fluentform/submission_labels', function ($labels, $submission, $form) {
+    // Do your stuff here
+    
+    return $labels;
+}, 10, 3);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/submission_labels', $resources['labels'], $submission, $submission->form);`
+
+This filter is located in FluentForm\app\Services\Form\FormServices -> getDisabledComponents()
+
+</explain-block>
+
+<explain-block title="fluentform/submission_logs">
+
+You can modify submission logs of a submission using this Filter.
+
+**Parameters**
+
+- `$submissionLogs` (array) Submission Logs
+- `$submissionId` (int) Submission ID
+
+**Usage**
+
+```php
+add_filter('fluentform/submission_logs', function($submissionLogs, $submissionId) {
+   // Do your stuff here
+
+   return $submissionLogs;
+}, 10, 2);
+
+```
+**Reference**
+
+`apply_filters('fluentform/submission_logs', $logs, $submissionId);`
+
+This filter is located in FluentForm\App\Services\Logger\Logger -> getSubmissionLogs($submissionId, $attributes = [])
 
 </explain-block>
 
@@ -1157,59 +1158,94 @@ This filter is located in Fluentform\app\services\Submission\SubmissionService -
 
 </explain-block>
 
-<explain-block title="fluentform/auto_read_submission">
+<explain-block title="fluentform/submission_resources">
 
-You can use this filter to toggle submission status to read automatically.
+You can use this filter to modify all submission resources.
 
 **Parameters**
 
-- `$autoRead` (boolean) Whether change submission status to read
-- `$form` (object) Form Object
+- `$resources` (array) Submission Resources
 
 **Usage**
 
 ```php
-add_filter('fluentform/auto_read_submission', function ($autoRead, $form) {
+add_filter('fluentform/submission_resources', function ($resources) {
     // Do your stuff here
     
-    return $autoRead;
-}, 10, 2);
+    return $resources;
+}, 10, 1);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/auto_read', $autoRead, $form);`
+`apply_filters('fluentform/submission_resources', $resources);`
 
-This filter is located in Fluentform\app\Modules\Entries\Entries -> _getEntry()
+This filter is located in Fluentform\app\Services\Submission\SubmissionService -> resources($attributes)
 
 </explain-block>
 
-<explain-block title="fluentform/auto_read_submission">
-
-You can use this filter to toggle submission status to read automatically.
+<explain-block title="fluentform/submission_shortcodes">
 
 **Parameters**
 
-- `$autoRead` (boolean) Whether change submission status to read
-- `$form` (object) Form Object
+- `$submissionShortcodes` — see source
+- `$form` — see source
 
 **Usage**
 
 ```php
-add_filter('fluentform/auto_read_submission', function ($autoRead, $form) {
-    // Do your stuff here
-    
-    return $autoRead;
+add_filter('fluentform/submission_shortcodes', function ($submissionShortcodes, $form) {
+    return $submissionShortcodes;
 }, 10, 2);
-
 ```
 
 **Reference**
 
-`apply_filters('fluentform/auto_read_submission', $autoRead, $form);`
+`return apply_filters('fluentform/submission_shortcodes', $submissionShortcodes, $form);`
 
-This filter is located in Fluentform\app\Services\Submission\SubmissionService -> find($submissionId)
+This filter is located in `app/Services/FormBuilder/EditorShortCode.php` (line 108).
+
+</explain-block>
+
+<explain-block title="fluentform/submission_vars">
+
+You can modify submission variables on double optin confirmation by using this filter.
+
+**Parameters**
+
+- `$submissionVars` (array) Submission Variable
+- `$formId` (int) Form ID
+
+**Usage**
+
+```php
+add_filter('fluentform/submission_vars', function ($submissionVars, $formId) {
+    // Do your stuff here
+    
+    return $submissionVars;
+}, 10, 2);
+
+```
+```php
+$submissionVars = [
+    'settings'        => $settings,
+    'title'           => 'Submission Confirmed - ' . $form->title,
+    'form_id'         => $formId,
+    'entry'           => $entry,
+    'form'            => $form,
+    'bg_color'        => $settings['custom_color'],
+    'landing_content' => $message,
+    'has_header'      => false,
+    'isEmbeded'       => !!ArrayHelper::get($_GET, 'embedded')
+];
+```
+
+**Reference**
+
+`apply_filters('fluentform/submission_vars', $submissionVars, $formId);`
+
+This filter is located in FluentFormPro\src\classes\DoubleOption -> confirmSubmission($data)
 
 </explain-block>
 
@@ -1242,63 +1278,83 @@ This filter is located in Fluentform\app\Services\Submission\SubmissionService -
 
 </explain-block>
 
-<explain-block title="fluentform/submission_resources">
+<explain-block title="fluentform/supported_conditional_fields">
 
-You can use this filter to modify all submission resources.
+You can add or modify form fields as to support as conditional using this filter.
 
 **Parameters**
 
-- `$resources` (array) Submission Resources
+- `$supportedConditionalFields` (array) Form Field Names
 
 **Usage**
 
 ```php
-add_filter('fluentform/submission_resources', function ($resources) {
-    // Do your stuff here
-    
-    return $resources;
+add_filter('fluentform/supported_conditional_fields', function ($supportedConditionalFields) {
+   // Do your stuff here
+
+   return $supportedConditionalFields;
 }, 10, 1);
 
 ```
-
 **Reference**
 
-`apply_filters('fluentform/submission_resources', $resources);`
+`apply_filters('fluentform/supported_conditional_fields', $supportedConditionalFields);`
 
-This filter is located in Fluentform\app\Services\Submission\SubmissionService -> resources($attributes)
+This filter is located in FluentForm\App\Modules\Form\Inputs -> supportedConditionalFields()
 
 </explain-block>
 
-<explain-block title="fluentform/format_{$element}_response_as_html">
+<explain-block title="fluentform/too_many_requests">
 
-This filter allows you to determine whether a specific form element's response should be formatted as HTML. The `{$element}` in the filter name is dynamically replaced with the actual element type (supported elements: `select`, `input_checkbox`, `input_radio`, `address`, `select_country`, `gdpr_agreement`, `terms_and_condition`, `dynamic_field` and `multi_payment_component`).
+You can modify validation message for malicious attack prevention, maximum submission count and minimum submission interval using this filter.
 
 **Parameters**
 
-- `$isHtml` (boolean) Whether to format the response as HTML
-- `$response` (mixed) The form field response value
-- `$field` (array) The form field configuration
+- `$message` (string) Validation Message
+- `$formId` (int) Form ID
 
 **Usage**
 
 ```php
-// Example for select element
-add_filter('fluentform/format_select_response_as_html', function($isHtml, $response, $field) {
-    // Always format select fields as HTML
-    return true;
-}, 10, 3);
+add_filter('fluentform/too_many_requests', function($message, $formId) {
+   // Do your stuff here
 
-// Example for checkbox element
-add_filter('fluentform/format_input_checkbox_response_as_html', function($isHtml, $response, $field) {
-    // Custom logic to determine HTML formatting
-    return $isHtml;
-}, 10, 3);
+   return $message;
+}, 10, 2);
+
+```
+**Reference**
+
+`apply_filters('fluentform/too_many_requests', 'Too Many Requests.', $this->form->id), 'fluentform');`
+
+This filter is located in FluentForm\App\Services\Form\FormValidationService -> preventMaliciousAttacks()
+
+</explain-block>
+
+<explain-block title="fluentform/truncate_password_values">
+
+You can toggle password truncation before rendering on Submission by using this filter.
+
+**Parameters**
+
+- `$isTurncate` (boolean) Whether Password is truncated
+- `$formId` (int) Form ID
+
+**Usage**
+
+```php
+add_filter('fluentform/truncate_password_values', function ($isTruncate, $formId) {
+   // Do your stuff here
+   
+   return $isTruncate;
+}, 10, 2);
+
 ```
 
 **Reference**
 
-`apply_filters("fluentform/format_{$element}_response_as_html", $isHtml, $response, $field);`
+`apply_filters('fluentform/truncate_password_values', true, $formId)`
 
-This filter is located in `FluentForm\app\Hooks\filters.php` within the response rendering filter for various elements.
+This filter is located in FluentForm\App\Helpers\Helper -> shouldHidePassword($formId)
 
 </explain-block>

--- a/src/hooks/filters/user-registration.md
+++ b/src/hooks/filters/user-registration.md
@@ -4,87 +4,27 @@
 
 These filters let you modify user registration fields, roles, and data mapping.
 
-<explain-block title="fluentform/user_registration_field_defaults">
+<explain-block title="fluentform/user_registration_bypass_login">
 
-You can modify User Registration integration default fields using the filter.
+<Badge type="tip" vertical="top" text="Pro" />
 
 **Parameters**
 
-- `$fields` (array) Default Integration Fields
-- `$formId` (int) Form ID
+- `$value` — see source
 
 **Usage**
 
 ```php
-add_filter('fluentform/user_registration_field_defaults', function ($fields, $formId) {
-    // Do your stuff here
-    
-    return $fields;
-}, 10, 2);
-
+add_filter('fluentform/user_registration_bypass_login', function ($value) {
+    return $value;
+}, 10, 1);
 ```
 
 **Reference**
 
-`apply_filters('fluentform/user_registration_field_defaults', $fields, $formId);`
+`$isBypassLogin = apply_filters('fluentform/user_registration_bypass_login', false);`
 
-This filter is located in FluentFormPro\src\Integrations\UserRegistration\Bootstrap -> getIntegrationDefaults($settings, $formId = null)
-
-</explain-block>
-
-<explain-block title="fluentform/user_registration_feed_fields">
-
-You can modify User Registration feed fields using the filter.
-
-**Parameters**
-
-- `$fields` (array) Form Fields
-- `$formId` (int) Form ID
-
-**Usage**
-
-```php
-add_filter('fluentform/user_registration_feed_fields', function ($fields, $formId) {
-    // Do your stuff here
-    
-    return $fields;
-}, 10, 2);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/user_registration_feed_fields', $fieldSettings['fields'], $formId);`
-
-This filter is located in FluentFormPro\src\Integrations\UserRegistration\Bootstrap -> getSettingsFields($settings, $formId = null)
-
-</explain-block>
-
-<explain-block title="fluentform/user_update_feed_fields">
-
-You can modify User Update feed fields using the filter.
-
-**Parameters**
-
-- `$fields` (array) Form Fields
-- `$formId` (int) Form ID
-
-**Usage**
-
-```php
-add_filter('fluentform/user_update_feed_fields', function ($fields, $formId) {
-    // Do your stuff here
-    
-    return $fields;
-}, 10, 2);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/user_update_feed_fields', $fieldSettings['fields'], $formId);`
-
-This filter is located in FluentFormPro\src\Integrations\UserRegistration\Bootstrap -> getSettingsFields($settings, $formId = null)
+This filter is located in `src/Integrations/UserRegistration/UserRegistrationApi.php` (line 105).
 
 </explain-block>
 
@@ -144,60 +84,6 @@ This filter is located in FluentFormPro\src\Integrations\UserRegistration\UserRe
 
 </explain-block>
 
-<explain-block title="fluentform/user_registration_map_fields">
-
-You can modify User Registration field mapper using the filter.
-
-**Parameters**
-
-- `$fields` (array) Map Fields
-
-**Usage**
-
-```php
-add_filter('fluentform/user_registration_map_fields', function ($fields) {
-    // Do your stuff here
-    
-    return $fields;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/user_registration_map_fields', $fields);`
-
-This filter is located in FluentFormPro\src\Integrations\UserRegistration\UserRegistrationApi -> userRegistrationMapFields()
-
-</explain-block>
-
-<explain-block title="fluentform/user_update_map_fields">
-
-You can modify User Update field mapper using the filter.
-
-**Parameters**
-
-- `$fields` (array) Map Fields
-
-**Usage**
-
-```php
-add_filter('fluentform/user_update_map_fields', function ($fields) {
-    // Do your stuff here
-    
-    return $fields;
-}, 10, 1);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/user_update_map_fields', $fields);`
-
-This filter is located in FluentFormPro\src\Integrations\UserRegistration\UserUpdateFormHandler -> userUpdateMapFields()
-
-</explain-block>
-
 <explain-block title="fluentform/user_registration_feed_fields">
 
 You can modify user registration feed fields using the filter.
@@ -223,6 +109,61 @@ add_filter('fluentform/user_registration_feed_fields', function ($fields, $formI
 `apply_filters('fluentform/user_registration_feed_fields', $fieldSettings['fields'], $formId);`
 
 This filter is located in FluentFormPro\src\Integrations\UserRegistration\Bootstrap -> getSettingsFields($settings, $formId = null)
+
+</explain-block>
+
+<explain-block title="fluentform/user_registration_field_defaults">
+
+You can modify user registration default fields using the filter.
+
+**Parameters**
+
+- `$fields` (array) User Update Feed Fields
+- `$formId` (int) Form ID
+
+**Usage**
+
+```php
+add_filter('fluentform/user_registration_field_defaults', function ($fields, $formId) {
+    // Do your stuff here
+    
+    return $fields;
+}, 10, 2);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/user_registration_field_defaults', $fieldSettings['fields'], $formId);`
+
+This filter is located in FluentFormPro\src\Integrations\UserRegistration\Bootstrap -> getIntegrationDefaults($settings, $formId = null)
+
+</explain-block>
+
+<explain-block title="fluentform/user_registration_map_fields">
+
+You can modify User Registration field mapper using the filter.
+
+**Parameters**
+
+- `$fields` (array) Map Fields
+
+**Usage**
+
+```php
+add_filter('fluentform/user_registration_map_fields', function ($fields) {
+    // Do your stuff here
+    
+    return $fields;
+}, 10, 1);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/user_registration_map_fields', $fields);`
+
+This filter is located in FluentFormPro\src\Integrations\UserRegistration\UserRegistrationApi -> userRegistrationMapFields()
 
 </explain-block>
 
@@ -254,30 +195,29 @@ This filter is located in FluentFormPro\src\Integrations\UserRegistration\Bootst
 
 </explain-block>
 
-<explain-block title="fluentform/user_registration_field_defaults">
+<explain-block title="fluentform/user_update_map_fields">
 
-You can modify user registration default fields using the filter.
+You can modify User Update field mapper using the filter.
 
 **Parameters**
 
-- `$fields` (array) User Update Feed Fields
-- `$formId` (int) Form ID
+- `$fields` (array) Map Fields
 
 **Usage**
 
 ```php
-add_filter('fluentform/user_registration_field_defaults', function ($fields, $formId) {
+add_filter('fluentform/user_update_map_fields', function ($fields) {
     // Do your stuff here
     
     return $fields;
-}, 10, 2);
+}, 10, 1);
 
 ```
 
 **Reference**
 
-`apply_filters('fluentform/user_registration_field_defaults', $fieldSettings['fields'], $formId);`
+`apply_filters('fluentform/user_update_map_fields', $fields);`
 
-This filter is located in FluentFormPro\src\Integrations\UserRegistration\Bootstrap -> getIntegrationDefaults($settings, $formId = null)
+This filter is located in FluentFormPro\src\Integrations\UserRegistration\UserUpdateFormHandler -> userUpdateMapFields()
 
 </explain-block>

--- a/src/hooks/filters/webhook.md
+++ b/src/hooks/filters/webhook.md
@@ -4,6 +4,31 @@
 
 These filters let you modify webhook request arguments and data.
 
+<explain-block title="fluentform/webhook_notification_validation_errors">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$errors` — see source
+- `$notification` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/webhook_notification_validation_errors', function ($errors, $notification) {
+    return $errors;
+}, 10, 2);
+```
+
+**Reference**
+
+`$errors = apply_filters('fluentform/webhook_notification_validation_errors', $errors, $notification);`
+
+This filter is located in `src/Integrations/WebHook/Client.php` (line 143).
+
+</explain-block>
+
 <explain-block title="fluentform/webhook_request_args">
 
 You can modify webhook request arguments using the filter.
@@ -32,67 +57,6 @@ add_filter('fluentform/webhook_request_args', function ($payload, $settings, $fo
 `apply_filters('fluentform/webhook_request_args', $payload, $settings, $formData, $form, $entry->id);`
 
 This filter is located in FluentFormPro\src\Integrations\WebHook\NotifyTrait -> notify($feed, $formData, $entry, $form)
-
-</explain-block>
-
-<explain-block title="fluentform/webhook_request_method">
-
-You can modify webhook request method using the filter.
-
-**Parameters**
-
-- `$method` (array) Webhook Request Method
-- `$settings` (array) Webhook Feed
-- `$data` (array) Form Data
-- `$form` (object) Form Object
-- `$entryId` (int) Submission ID
-
-**Usage**
-
-```php
-add_filter('fluentform/webhook_request_method', function ($method, $settings, $data, $form, $entryId) {
-    // Do your stuff here
-    
-    return $method;
-}, 10, 5);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/webhook_request_method', $method, $settings, $data, $form, $entryId);`
-
-This filter is located in FluentFormPro\src\Integrations\WebHook\NotifyTrait -> getWebHookRequestMethod($settings, $data, $form, $entryId)
-
-</explain-block>
-
-<explain-block title="fluentform/webhook_request_headers">
-
-You can modify webhook request header data using the filter.
-
-**Parameters**
-
-- `$requestHeaders` (array) Webhook Request Header
-- `$settings` (array) Webhook Feed
-- `$data` (array) Form Data
-- `$entryId` (int) Submission ID
-
-**Usage**
-
-```php
-add_filter('fluentform/webhook_request_headers', function ($requestHeaders, $settings, $data, $form, $entryId) {
-    // Do your stuff here
-    
-    return $requestHeaders;
-}, 10, 4);
-
-```
-
-**Reference**
-
-`apply_filters('fluentform/webhook_request_headers', $requestHeaders, $settings, $data, $form, $entryId);`
-
-This filter is located in FluentFormPro\src\Integrations\WebHook\NotifyTrait -> getWebHookRequestMethod($settings, $data, $form, $entryId)
 
 </explain-block>
 
@@ -127,6 +91,67 @@ This filter is located in FluentFormPro\src\Integrations\WebHook\NotifyTrait -> 
 
 </explain-block>
 
+<explain-block title="fluentform/webhook_request_headers">
+
+You can modify webhook request header data using the filter.
+
+**Parameters**
+
+- `$requestHeaders` (array) Webhook Request Header
+- `$settings` (array) Webhook Feed
+- `$data` (array) Form Data
+- `$entryId` (int) Submission ID
+
+**Usage**
+
+```php
+add_filter('fluentform/webhook_request_headers', function ($requestHeaders, $settings, $data, $form, $entryId) {
+    // Do your stuff here
+    
+    return $requestHeaders;
+}, 10, 4);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/webhook_request_headers', $requestHeaders, $settings, $data, $form, $entryId);`
+
+This filter is located in FluentFormPro\src\Integrations\WebHook\NotifyTrait -> getWebHookRequestMethod($settings, $data, $form, $entryId)
+
+</explain-block>
+
+<explain-block title="fluentform/webhook_request_method">
+
+You can modify webhook request method using the filter.
+
+**Parameters**
+
+- `$method` (array) Webhook Request Method
+- `$settings` (array) Webhook Feed
+- `$data` (array) Form Data
+- `$form` (object) Form Object
+- `$entryId` (int) Submission ID
+
+**Usage**
+
+```php
+add_filter('fluentform/webhook_request_method', function ($method, $settings, $data, $form, $entryId) {
+    // Do your stuff here
+    
+    return $method;
+}, 10, 5);
+
+```
+
+**Reference**
+
+`apply_filters('fluentform/webhook_request_method', $method, $settings, $data, $form, $entryId);`
+
+This filter is located in FluentFormPro\src\Integrations\WebHook\NotifyTrait -> getWebHookRequestMethod($settings, $data, $form, $entryId)
+
+</explain-block>
+
 <explain-block title="fluentform/webhook_request_url">
 
 You can modify webhook request URL using the filter.
@@ -155,5 +180,29 @@ add_filter('fluentform/webhook_request_url', function ($url, $settings, $data, $
 `apply_filters('fluentform/webhook_request_url', $re$url, $settings, $data, $form, $entryId);`
 
 This filter is located in FluentFormPro\src\Integrations\WebHook\NotifyTrait -> getWebHookRequestUrl($settings, $data, $form, $entryId, $requestMethod, $requestData)
+
+</explain-block>
+
+<explain-block title="fluentform/webhook_ssl_verify">
+
+<Badge type="tip" vertical="top" text="Pro" />
+
+**Parameters**
+
+- `$sslVerify` — see source
+
+**Usage**
+
+```php
+add_filter('fluentform/webhook_ssl_verify', function ($sslVerify) {
+    return $sslVerify;
+}, 10, 1);
+```
+
+**Reference**
+
+`'sslverify' => apply_filters('fluentform/webhook_ssl_verify', $sslVerify),`
+
+This filter is located in `src/Integrations/WebHook/NotifyTrait.php` (line 52).
 
 </explain-block>


### PR DESCRIPTION
## What does this PR do and why?

Catches the developer docs up to current source and adds a dark mode theme.

The original task was a v6.2.1–6.2.3 catch-up. While auditing for that, a much
larger coverage gap surfaced (only 68% of free hooks and 59% of pro hooks were
documented; REST routes and per-model pages were entirely missing). This PR
closes the gap and lays down a dark theme on top.

**Related issue:** N/A

## Scope

- [x] Developer docs (this repo only)
- [ ] No source-plugin code changes

## Changes

- Hooks — added missing coverage so 450 free + 273 pro hooks are now in
  src/hooks/{actions,filters}/. New category pages: reports, messages,
  conversational, post-creation, dynamic-fields, entries-export,
  spam-protection, pdf (add-on). All files alphabetized and deduped.
- REST API — new src/api/endpoints/ section. One page per route group
  (14 pages covering 84 endpoints) auto-extracted from
  app/Http/Routes/api.php in the free plugin.
- Models — new src/database/models/ section with one page per Eloquent
  model (14 pages: Form, FormMeta, FormAnalytics, Submission, SubmissionMeta,
  Entry, EntryDetails, EntryMeta, Transaction, Subscription, OrderItem, Log,
  Scheduler, User) plus an index.
- Database schema — src/database/index.md: Pro badges added to coupons,
  draft_submissions, order_items, subscriptions, transactions. Fixed
  ff_scheduled_actions heading to fluentform_scheduled_actions.
- Helpers + class references — appended every public method in Arr, Str,
  Helper, Protector, IntegrationManagerHelper, BaseFieldManager,
  IntegrationManagerController, BaseProcessor, BasePaymentMethod,
  PDF TemplateManager. Each file is one alphabetized list with the
  hand-written entries preserved.
- Architecture — src/getting-started/index.md rewritten with the current
  directory structure, frontend stack table, REST base URL, custom
  capabilities, hook prefix convention.
- Changelog — new src/changelog/index.md covering 6.2.1 / 6.2.2 / 6.2.3
  across free and pro, linked from the navbar.
- Sidebars + navbar — src/.vuepress/sidebars/{hooks,apiSidebar,db-schema,helpers}.js
  and src/.vuepress/config.js updated to register every new page.
- Dark mode — new src/.vuepress/components/ThemeToggle.vue (floating
  bottom-right toggle, sun/moon icons), updated enhanceApp.js (mounts
  the toggle, applies stored or prefers-color-scheme theme before paint),
  .ff-dark overrides in src/.vuepress/styles/index.styl covering
  navbar, sidebar, content, code blocks, schema tables, ExplainBlock
  variants, info/warning callouts, Algolia DocSearch dropdown.
- Styling — new .info paragraph style (soft mint, emerald accent),
  refreshed .warning (soft amber, amber accent).

## How to test

1. npm install && npm run dev from the docs repo
2. Browse each new section and confirm pages render:
   - /hooks/filters/spam-protection/, /hooks/filters/reports/,
     /hooks/filters/messages/, /hooks/filters/conversational/,
     /hooks/filters/post-creation/, /hooks/filters/dynamic-fields/,
     /hooks/filters/entries-export/, /hooks/filters/pdf/,
     /hooks/actions/post-creation/, /hooks/actions/miscellaneous/
   - /api/endpoints/ (14 group pages)
   - /database/models/ (14 model pages)
   - /global-functions/, /cli/, /helpers/integration-manager-helper/
   - /changelog/
3. Confirm sidebar lists every new page.
4. Click the floating button (bottom-right) to toggle dark mode. Refresh
   to confirm the theme persists in localStorage.
5. Search via the navbar Algolia box — confirm the dropdown is themed in
   both light and dark.

## Anything the reviewer should know?

- All entries in the new auto-extracted sections carry concrete
  **Source:** path (line N) references so reviewers can trace each
  entry back to the actual apply_filters / do_action / route /
  method definition in the source.
- The auto-extraction was a script run on the current state of the
  fluentform, fluentformpro, and fluentforms-pdf repos. Each generated
  entry has a real signature and source pointer — descriptions are
  generic where the source had no docblock. Future hand-polish is
  expected and easy (the alphabetical merge keeps everything in one
  reviewable list per file).
- Dark mode uses CSS class .ff-dark on html. Algolia DocSearch
  override rules use !important to defeat VuePress' default theme
  specificity — this is scoped to .ff-dark .algolia-search-wrapper ...
  so light theme is untouched.
- VuePress 1 build still passes cleanly; the only pre-existing warning
  is vuepress-plugin-sitemap1 which is unrelated to this change.