### PR TITLE
DOCS: Note the differing nonce_verify default on draft endpoints

### DIFF
--- a/src/hooks/filters/miscellaneous.md
+++ b/src/hooks/filters/miscellaneous.md
@@ -1481,6 +1481,25 @@ add_filter('fluentform/nonce_verify', function ($status, $formId) {
 
 This filter is located in FluentForm\app\Services\Form\FormValidationService -> validateNonce()
 
+**Defaults differ by endpoint**
+
+| Endpoint group | Default | Applied in |
+| --- | --- | --- |
+| Form submission | `false` (off) | `FormValidationService::validateNonce()`, `FormHandler::validateNonce()` |
+| Save & Continue / partial entries | `true` (on) | `DraftSubmissionsManager::shouldVerifyNonce()` (Pro) |
+
+The draft endpoints default to **on** because they are `nopriv` and carry
+additional hardening (draft privacy, and an open-mail-relay throttle on the
+resume-link email). Returning `false` disables the nonce on all five of them at
+once — `fluentform_step_form_get_data`, `fluentform_step_form_save_data`,
+`fluentform_save_form_progress_with_link`, `fluentform_get_form_state` and
+`fluentform_email_progress_link` — so the per-IP rate limit becomes the only
+remaining control on the mail-sending one.
+
+This is the supported way to keep Save & Continue working behind a full-page
+cache, where the nonce is frozen in the cached HTML and goes stale once the
+WordPress nonce tick rolls (~12 hours), causing HTTP 422 responses.
+
 </explain-block>
 
 <explain-block title="fluentform/number_input_mode">


### PR DESCRIPTION
## Summary

`fluentform/nonce_verify` defaults to **off** for form submission but **on** for the Save & Continue (draft/partial entry) endpoints. The page documented only the submission default and scoped the filter to `FormValidationService->validateNonce()`, so a site owner working around full-page caching had no way to learn the draft endpoints behave differently — or that opting out there also disables the nonce on the resume-link email endpoint.

**Related issue:** Refs: https://lounge.authlab.io/projects#/boards/16/tasks/22244-DraftSubmissionsManager%3A%3Averif

**Cross-repo PRs:** fix: https://github.com/fluentform/fluentformpro/pull/256 (pro) · tests: https://github.com/fluentform/fluentform-dev/pull/1123

## Changes

Adds a "Defaults differ by endpoint" section to the `fluentform/nonce_verify` block in `src/hooks/filters/miscellaneous.md`:

- a table of the two defaults and where each is applied
- all five draft endpoints named, so the blast radius of returning `false` is explicit
- a note that the per-IP rate limit becomes the only remaining control on the resume-link email endpoint
- the full-page-cache rationale (frozen nonce, ~12h tick, HTTP 422)

## How to verify

1. `npm run dev` (or the project's usual preview command).
2. Open **Hooks → Filters → Miscellaneous** and find `fluentform/nonce_verify`.
3. The new section renders below the existing Reference line, with the table intact.

## Anything the reviewer should know?

This documents behaviour introduced by the matching Pro PR — **it should not land before that one**, or it will describe a default the code does not yet have.

Depends on Pro's decision that the draft default stays `true`. If that PR ends up flipping to `false` for parity with submission, this page needs a corresponding edit.
