### PR TITLE
Docs: note that the status filters are now enforced

### DIFF
--- a/src/hooks/filters/payment.md
+++ b/src/hooks/filters/payment.md
@@ -117,7 +117,16 @@ $paymentStatuses = [
 
 `apply_filters('fluentform/available_payment_statuses', $paymentStatuses);`
 
-This filter is located in FluentFormPro\src\Payments\PaymentHelper -> getPaymentStatuses()
+::: warning Registering a custom status is required
+Changing a transaction's status from the admin is validated against this list, so a status
+that is not registered here cannot be selected or applied.
+
+Validation only runs when the status actually changes. A row that already holds a status
+this build does not register keeps it, and its other fields (payer name, email, addresses)
+remain editable.
+:::
+
+Two classes define this list and both apply the filter: `FluentForm\App\Modules\Payments\PaymentHelper` (free) and `FluentFormPro\Payments\PaymentHelper` (Pro). The array above is Pro's — `requires_review` is Pro-only and is not present in the free list, so register any status you rely on through the filter rather than assuming a hardcoded default.
 
 </explain-block>
 

--- a/src/hooks/filters/submission.md
+++ b/src/hooks/filters/submission.md
@@ -345,6 +345,16 @@ add_filter('fluentform/entry_statuses_core', function ($statuses , $form_id) {
 
 This filter is located in FluentForm\App\Helpers\Helper -> getEntryStatuses($form_id = false)
 
+::: warning Registering a custom status is required
+Entry status writes are validated against this list. A status that is not registered here
+cannot be set — neither the bulk action nor the single-entry endpoint will apply it.
+
+The list is resolved per form, and add-ons that gate their statuses on a feature being
+active (Admin Approval, double opt-in) only contribute while that feature is enabled for
+the form. Existing rows keep a status after the feature is turned off, but it can no longer
+be re-applied; the base statuses stay available for triage.
+:::
+
 </explain-block>
 
 <explain-block title="fluentform/export_data">


### PR DESCRIPTION
## Summary

Two status filters are documented as "you can modify or add statuses". From the next plugin release that becomes a requirement rather than an option: both vocabularies are validated at the write path, so a status not registered through its filter can no longer be applied. Previously either endpoint wrote whatever string it was handed.

This documents the new constraint and corrects a factual error found while writing it.

**Related:** ticket [#22737](https://lounge.authlab.io/projects#/boards/16/tasks/22737-Security%3A-form-scope-bypass-an) · code PRs [fluentform-dev#1156](https://github.com/fluentform/fluentform-dev/pull/1156) (free) and [fluentformpro#273](https://github.com/fluentform/fluentformpro/pull/273) (Pro)

## Changes

**`fluentform/entry_statuses_core`** — entry status writes are checked against the per-form list. The note covers the part that isn't obvious from the filter signature: add-ons gate their statuses on the feature being *active*, so a row can hold a status that cannot be re-applied once the feature is switched off. The base statuses stay available, so an orphaned entry can still be triaged.

**`fluentform/available_payment_statuses`** — the same for the admin transaction endpoint, with one difference stated explicitly: validation runs **only when the status changes**, so a row already holding an unregistered status keeps it and its other fields stay editable.

**Corrected the payment filter's location note.** It read:

> This filter is located in FluentFormPro\src\Payments\PaymentHelper -> getPaymentStatuses()

That is incomplete in a way that misleads. **Two** classes define this list and both apply the filter — `FluentForm\App\Modules\Payments\PaymentHelper` (free) and `FluentFormPro\Payments\PaymentHelper` (Pro). The example array shown on the page is **Pro's**, and the `requires_review` entry in it is **Pro-only** — it is absent from the free list, which is the one the admin transaction endpoint validates against.

A developer trusting that example would conclude `requires_review` is a generally valid status. It is written by Pro's PayPal, Mollie, Paystack and RazorPay processors on an amount mismatch, but cannot be selected in the admin UI, and the status badge falls back to printing the raw slug. The note now says so and points readers at the filter rather than at a hardcoded default.

## How to verify

1. `npm install && npm run dev`, then open **Hooks → Filters → Submission** and **Hooks → Filters → Payment**.
2. Expand `fluentform/entry_statuses_core` and `fluentform/available_payment_statuses` — these blocks are collapsible, so the body is hidden until clicked. Each renders a warning callout after its **Reference** line.
3. The payment block's closing line names both classes and flags `requires_review` as Pro-only.

Verified locally both ways: `npm run dev` and `npm run build` both compile clean, and the callouts are present in the generated `dist/hooks/filters/{submission,payment}/index.html`. Uses the repo's existing `::: warning Title` … `:::` container, as in `src/hooks/filters/miscellaneous.md:1747`.

## Anything the reviewer should know?

**Timing.** This describes behaviour that ships with the two code PRs linked below. It reads as a statement of fact, so it should land with or after them, not before.

**The divergence is a real defect, documented here only as a workaround.** Pro hardcodes `requires_review` into its own copy of `getPaymentStatuses()` instead of registering it via `fluentform/available_payment_statuses`, which is why the two lists differ at all. The correct fix is a one-line `add_filter` in Pro, after which core's list would be complete and this caveat could be deleted. That is deliberately **not** in scope here — it would add a newly selectable option to the admin status radio group, a visible change on a money path. Worth its own ticket.

**Heads-up for anyone building locally:** `npm run build` deletes the tracked `src/.vuepress/dist/.gitkeep`, which `.gitignore` explicitly un-ignores. Restore it before committing or the diff carries a spurious deletion.

**Scope.** Docs only; no code, no config, no navigation changes.
